### PR TITLE
feat: shorter purls

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,10 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Changed
+  * PackageUrl(PURL) in JSON and XML results are as short as possible, but still precise. (via [#285])
+* Misc
+  * Raised dependency `@cyclonedx/cyclonedx-library@^1.4.0`, was `@^1.0.0`. (via [#285])
 * Build
   * Use _TypeScript_ `v4.8.2` now, was `v4.7.4`. (via [#284])
 
 [#284]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/284
+[#285]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/285
 
 ## 3.0.1 - 2022-06-25
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cyclonedx/cyclonedx-library": "^1.0.0",
+        "@cyclonedx/cyclonedx-library": "^1.4.0",
         "read-pkg-up": "^7.0.0",
         "xmlbuilder2": "^3.0.2"
       },
@@ -616,9 +616,9 @@
       "dev": true
     },
     "node_modules/@cyclonedx/cyclonedx-library": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-1.3.4.tgz",
-      "integrity": "sha512-xY0KAQM16ILqg7USghTtagB+ZhuM+kK79VaDS4zsHY73UD0Jfk8hDWRG+RSzdmpMlLfGfB6ys+rjM6n6cYea4g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-1.4.0.tgz",
+      "integrity": "sha512-/x+5al8mYKB7OjAG/o7eazgsq4bkiwP0Oe6D7kjH+Pp+tM4q+YbpqQhZq/DWSJ8nuHmn+0vW02B/+p6DrNYNJA==",
       "dependencies": {
         "packageurl-js": ">=0.0.6 <0.0.8"
       },
@@ -6961,9 +6961,9 @@
       "dev": true
     },
     "@cyclonedx/cyclonedx-library": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-1.3.4.tgz",
-      "integrity": "sha512-xY0KAQM16ILqg7USghTtagB+ZhuM+kK79VaDS4zsHY73UD0Jfk8hDWRG+RSzdmpMlLfGfB6ys+rjM6n6cYea4g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-1.4.0.tgz",
+      "integrity": "sha512-/x+5al8mYKB7OjAG/o7eazgsq4bkiwP0Oe6D7kjH+Pp+tM4q+YbpqQhZq/DWSJ8nuHmn+0vW02B/+p6DrNYNJA==",
       "requires": {
         "packageurl-js": ">=0.0.6 <0.0.8",
         "xmlbuilder2": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@cyclonedx/cyclonedx-library": "^1.0.0",
+    "@cyclonedx/cyclonedx-library": "^1.4.0",
     "read-pkg-up": "^7.0.0",
     "xmlbuilder2": "^3.0.2"
   },

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -25,13 +25,13 @@ type WebpackLogger = Compilation['logger']
 
 export class Extractor {
   readonly #compilation: Compilation
-  readonly #componentBuilder: CDX.Builders.FromPackageJson.ComponentBuilder
-  readonly #purlFactory: CDX.Factories.PackageUrlFactory
+  readonly #componentBuilder: CDX.Builders.FromNodePackageJson.ComponentBuilder
+  readonly #purlFactory: CDX.Factories.FromNodePackageJson.PackageUrlFactory
 
   constructor (
     compilation: Compilation,
-    componentBuilder: CDX.Builders.FromPackageJson.ComponentBuilder,
-    purlFactory: CDX.Factories.PackageUrlFactory
+    componentBuilder: CDX.Builders.FromNodePackageJson.ComponentBuilder,
+    purlFactory: CDX.Factories.FromNodePackageJson.PackageUrlFactory
   ) {
     this.#compilation = compilation
     this.#componentBuilder = componentBuilder

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -146,11 +146,11 @@ export class CycloneDxWebpackPlugin {
     }
 
     const logger = compilation.getLogger(pluginName)
-    const cdxExternalReferenceFactory = new CDX.Factories.FromPackageJson.ExternalReferenceFactory()
+    const cdxExternalReferenceFactory = new CDX.Factories.FromNodePackageJson.ExternalReferenceFactory()
     const cdxLicenseFactory = new CDX.Factories.LicenseFactory()
-    const cdxPurlFactory = new CDX.Factories.PackageUrlFactory('npm')
-    const cdxToolBuilder = new CDX.Builders.FromPackageJson.ToolBuilder(cdxExternalReferenceFactory)
-    const cdxComponentBuilder = new CDX.Builders.FromPackageJson.ComponentBuilder(cdxExternalReferenceFactory, cdxLicenseFactory)
+    const cdxPurlFactory = new CDX.Factories.FromNodePackageJson.PackageUrlFactory('npm')
+    const cdxToolBuilder = new CDX.Builders.FromNodePackageJson.ToolBuilder(cdxExternalReferenceFactory)
+    const cdxComponentBuilder = new CDX.Builders.FromNodePackageJson.ComponentBuilder(cdxExternalReferenceFactory, cdxLicenseFactory)
 
     const bom = new CDX.Models.Bom()
     bom.metadata.component = this.#makeRootComponent(compilation.compiler.context, cdxComponentBuilder)
@@ -231,7 +231,7 @@ export class CycloneDxWebpackPlugin {
     )
   }
 
-  #makeRootComponent (cwd: string, builder: CDX.Builders.FromPackageJson.ComponentBuilder): CDX.Models.Component | undefined {
+  #makeRootComponent (cwd: string, builder: CDX.Builders.FromNodePackageJson.ComponentBuilder): CDX.Models.Component | undefined {
     const thisPackage = this.rootComponentAutodetect
       ? readPackageUpSync({ cwd, normalize: false })
       : { packageJson: { name: this.rootComponentName, version: this.rootComponentVersion } }
@@ -242,8 +242,8 @@ export class CycloneDxWebpackPlugin {
 
   #finalizeBom (
     bom: CDX.Models.Bom,
-    cdxToolBuilder: CDX.Builders.FromPackageJson.ToolBuilder,
-    cdxPurlFactory: CDX.Factories.PackageUrlFactory
+    cdxToolBuilder: CDX.Builders.FromNodePackageJson.ToolBuilder,
+    cdxPurlFactory: CDX.Factories.FromNodePackageJson.PackageUrlFactory
   ): void {
     bom.metadata.timestamp = this.reproducibleResults
       ? undefined

--- a/tests/integration/__snapshots__/index.test.js.snap
+++ b/tests/integration/__snapshots__/index.test.js.snap
@@ -35,9 +35,9 @@ exports[`integration webpack5 with angular13 generated json file: dist/.bom/bom.
       \\"type\\": \\"application\\",
       \\"name\\": \\"example-webpack5-angular13\\",
       \\"group\\": \\"@cyclonedx-weboack-plugin-tests\\",
-      \\"bom-ref\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?\\",
+      \\"bom-ref\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13\\",
       \\"description\\": \\"example setup witch Angular13 in WebPack5\\",
-      \\"purl\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?\\"
+      \\"purl\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13\\"
     }
   },
   \\"components\\": [
@@ -262,7 +262,7 @@ exports[`integration webpack5 with angular13 generated json file: dist/.bom/bom.
       ]
     },
     {
-      \\"ref\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?\\",
+      \\"ref\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13\\",
       \\"dependsOn\\": [
         \\"pkg:npm/%40angular/common@13.3.11?vcs_url=https://github.com/angular/angular.git#packages/common\\",
         \\"pkg:npm/%40angular/core@13.3.11?vcs_url=https://github.com/angular/angular.git#packages/core\\",
@@ -325,9 +325,9 @@ exports[`integration webpack5 with angular13 generated json file: dist/.well-kno
       \\"type\\": \\"application\\",
       \\"name\\": \\"example-webpack5-angular13\\",
       \\"group\\": \\"@cyclonedx-weboack-plugin-tests\\",
-      \\"bom-ref\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?\\",
+      \\"bom-ref\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13\\",
       \\"description\\": \\"example setup witch Angular13 in WebPack5\\",
-      \\"purl\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?\\"
+      \\"purl\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13\\"
     }
   },
   \\"components\\": [
@@ -552,7 +552,7 @@ exports[`integration webpack5 with angular13 generated json file: dist/.well-kno
       ]
     },
     {
-      \\"ref\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?\\",
+      \\"ref\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13\\",
       \\"dependsOn\\": [
         \\"pkg:npm/%40angular/common@13.3.11?vcs_url=https://github.com/angular/angular.git#packages/common\\",
         \\"pkg:npm/%40angular/core@13.3.11?vcs_url=https://github.com/angular/angular.git#packages/core\\",
@@ -605,11 +605,11 @@ exports[`integration webpack5 with angular13 generated xml file: dist/.bom/bom.x
         </externalReferences>
       </tool>
     </tools>
-    <component type=\\"application\\" bom-ref=\\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?\\">
+    <component type=\\"application\\" bom-ref=\\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13\\">
       <group>@cyclonedx-weboack-plugin-tests</group>
       <name>example-webpack5-angular13</name>
       <description>example setup witch Angular13 in WebPack5</description>
-      <purl>pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?</purl>
+      <purl>pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13</purl>
     </component>
   </metadata>
   <components>
@@ -782,7 +782,7 @@ exports[`integration webpack5 with angular13 generated xml file: dist/.bom/bom.x
       <dependency ref=\\"pkg:npm/%40angular/common@13.3.11?vcs_url=https://github.com/angular/angular.git#packages/common\\"/>
       <dependency ref=\\"pkg:npm/%40angular/core@13.3.11?vcs_url=https://github.com/angular/angular.git#packages/core\\"/>
     </dependency>
-    <dependency ref=\\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?\\">
+    <dependency ref=\\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13\\">
       <dependency ref=\\"pkg:npm/%40angular/common@13.3.11?vcs_url=https://github.com/angular/angular.git#packages/common\\"/>
       <dependency ref=\\"pkg:npm/%40angular/core@13.3.11?vcs_url=https://github.com/angular/angular.git#packages/core\\"/>
       <dependency ref=\\"pkg:npm/%40angular/platform-browser@13.3.11?vcs_url=https://github.com/angular/angular.git#packages/platform-browser\\"/>
@@ -835,9 +835,9 @@ exports[`integration webpack5 with react18 generated json file: dist/.bom/bom.js
       \\"name\\": \\"example-webpack5-react18\\",
       \\"group\\": \\"@cyclonedx-webpack-plugin-tests\\",
       \\"version\\": \\"0.0.1\\",
-      \\"bom-ref\\": \\"pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?\\",
+      \\"bom-ref\\": \\"pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1\\",
       \\"description\\": \\"example setup with react and webpack5\\",
-      \\"purl\\": \\"pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?\\"
+      \\"purl\\": \\"pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1\\"
     }
   },
   \\"components\\": [
@@ -1001,7 +1001,7 @@ exports[`integration webpack5 with react18 generated json file: dist/.bom/bom.js
   ],
   \\"dependencies\\": [
     {
-      \\"ref\\": \\"pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?\\",
+      \\"ref\\": \\"pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1\\",
       \\"dependsOn\\": [
         \\"pkg:npm/css-loader@6.7.1?vcs_url=webpack-contrib/css-loader\\",
         \\"pkg:npm/react-dom@18.2.0?vcs_url=https://github.com/facebook/react.git#packages/react-dom\\",
@@ -1067,9 +1067,9 @@ exports[`integration webpack5 with react18 generated json file: dist/.well-known
       \\"name\\": \\"example-webpack5-react18\\",
       \\"group\\": \\"@cyclonedx-webpack-plugin-tests\\",
       \\"version\\": \\"0.0.1\\",
-      \\"bom-ref\\": \\"pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?\\",
+      \\"bom-ref\\": \\"pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1\\",
       \\"description\\": \\"example setup with react and webpack5\\",
-      \\"purl\\": \\"pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?\\"
+      \\"purl\\": \\"pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1\\"
     }
   },
   \\"components\\": [
@@ -1233,7 +1233,7 @@ exports[`integration webpack5 with react18 generated json file: dist/.well-known
   ],
   \\"dependencies\\": [
     {
-      \\"ref\\": \\"pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?\\",
+      \\"ref\\": \\"pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1\\",
       \\"dependsOn\\": [
         \\"pkg:npm/css-loader@6.7.1?vcs_url=webpack-contrib/css-loader\\",
         \\"pkg:npm/react-dom@18.2.0?vcs_url=https://github.com/facebook/react.git#packages/react-dom\\",
@@ -1288,12 +1288,12 @@ exports[`integration webpack5 with react18 generated xml file: dist/.bom/bom.xml
         </externalReferences>
       </tool>
     </tools>
-    <component type=\\"application\\" bom-ref=\\"pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?\\">
+    <component type=\\"application\\" bom-ref=\\"pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1\\">
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>example-webpack5-react18</name>
       <version>0.0.1</version>
       <description>example setup with react and webpack5</description>
-      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?</purl>
+      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1</purl>
     </component>
   </metadata>
   <components>
@@ -1422,7 +1422,7 @@ exports[`integration webpack5 with react18 generated xml file: dist/.bom/bom.xml
     </component>
   </components>
   <dependencies>
-    <dependency ref=\\"pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?\\">
+    <dependency ref=\\"pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1\\">
       <dependency ref=\\"pkg:npm/css-loader@6.7.1?vcs_url=webpack-contrib/css-loader\\"/>
       <dependency ref=\\"pkg:npm/react-dom@18.2.0?vcs_url=https://github.com/facebook/react.git#packages/react-dom\\"/>
       <dependency ref=\\"pkg:npm/react@18.2.0?vcs_url=https://github.com/facebook/react.git#packages/react\\"/>
@@ -1474,9 +1474,9 @@ exports[`integration webpack5 with vue2 generated json file: dist/.bom/bom.json 
       \\"type\\": \\"application\\",
       \\"name\\": \\"example-webpack5-vue2\\",
       \\"group\\": \\"@cyclonedx-weboack-plugin-tests\\",
-      \\"bom-ref\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?\\",
+      \\"bom-ref\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2\\",
       \\"description\\": \\"example setup witch Vue2 in WebPack5\\",
-      \\"purl\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?\\"
+      \\"purl\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2\\"
     }
   },
   \\"components\\": [
@@ -1516,7 +1516,7 @@ exports[`integration webpack5 with vue2 generated json file: dist/.bom/bom.json 
   ],
   \\"dependencies\\": [
     {
-      \\"ref\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?\\",
+      \\"ref\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2\\",
       \\"dependsOn\\": [
         \\"pkg:npm/vue@2.6.14?vcs_url=git+https://github.com/vuejs/vue.git\\"
       ]
@@ -1563,9 +1563,9 @@ exports[`integration webpack5 with vue2 generated json file: dist/.well-known/sb
       \\"type\\": \\"application\\",
       \\"name\\": \\"example-webpack5-vue2\\",
       \\"group\\": \\"@cyclonedx-weboack-plugin-tests\\",
-      \\"bom-ref\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?\\",
+      \\"bom-ref\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2\\",
       \\"description\\": \\"example setup witch Vue2 in WebPack5\\",
-      \\"purl\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?\\"
+      \\"purl\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2\\"
     }
   },
   \\"components\\": [
@@ -1605,7 +1605,7 @@ exports[`integration webpack5 with vue2 generated json file: dist/.well-known/sb
   ],
   \\"dependencies\\": [
     {
-      \\"ref\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?\\",
+      \\"ref\\": \\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2\\",
       \\"dependsOn\\": [
         \\"pkg:npm/vue@2.6.14?vcs_url=git+https://github.com/vuejs/vue.git\\"
       ]
@@ -1642,11 +1642,11 @@ exports[`integration webpack5 with vue2 generated xml file: dist/.bom/bom.xml 1`
         </externalReferences>
       </tool>
     </tools>
-    <component type=\\"application\\" bom-ref=\\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?\\">
+    <component type=\\"application\\" bom-ref=\\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2\\">
       <group>@cyclonedx-weboack-plugin-tests</group>
       <name>example-webpack5-vue2</name>
       <description>example setup witch Vue2 in WebPack5</description>
-      <purl>pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?</purl>
+      <purl>pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2</purl>
     </component>
   </metadata>
   <components>
@@ -1678,7 +1678,7 @@ exports[`integration webpack5 with vue2 generated xml file: dist/.bom/bom.xml 1`
     </component>
   </components>
   <dependencies>
-    <dependency ref=\\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?\\">
+    <dependency ref=\\"pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2\\">
       <dependency ref=\\"pkg:npm/vue@2.6.14?vcs_url=git+https://github.com/vuejs/vue.git\\"/>
     </dependency>
     <dependency ref=\\"pkg:npm/vue@2.6.14?vcs_url=git+https://github.com/vuejs/vue.git\\"/>


### PR DESCRIPTION
* Changed
  * PackageUrl(PURL) in JSON and XML results are as short as possible, but still precise.
* Misc
  * Raised dependency `@cyclonedx/cyclonedx-library@^1.4.0`, was `@^1.0.0`.
