### PR TITLE
fix: issue #745

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 * Fixed:
   * If packages' metadata [normalization](https://www.npmjs.com/package/normalize-package-data)
-    fails, then this results no longer in a crash but in a warning message. ([#745] via [#754])
+    fails, then this results no longer in an unhandled crash but causes a warning message ([#745] via [#754])
 
 [#745]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues/745
 [#754]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/754

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,10 +6,10 @@ All notable changes to this project will be documented in this file.
 
 * Fixed:
   * If packages' metadata [normalization](https://www.npmjs.com/package/normalize-package-data)
-    fails, then this results no longer in a crash but in a warning message. ([#745] via [#])
+    fails, then this results no longer in a crash but in a warning message. ([#745] via [#754])
 
 [#745]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues/745
-[#]: 
+[#754]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/754
 
 ## 3.4.0 - 2023-03-28
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Fixed:
+  * If packages' metadata [normalization](https://www.npmjs.com/package/normalize-package-data)
+    fails, then this results no longer in a crash but in a warning message. ([#745] via [#])
+
+[#745]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues/745
+[#]: 
+
 ## 3.4.0 - 2023-03-28
 
 * Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cyclonedx/webpack-plugin",
-  "version": "3.4.0",
+  "version": "3.4.1-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cyclonedx/webpack-plugin",
-      "version": "3.4.0",
+      "version": "3.4.1-rc.1",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@cyclonedx/cyclonedx-library": "^1.13.0",
+        "@cyclonedx/cyclonedx-library": "^1.13.2",
         "normalize-package-data": "^3||^4||^5",
         "xmlbuilder2": "^3.0.2"
       },
@@ -672,9 +672,9 @@
       "dev": true
     },
     "node_modules/@cyclonedx/cyclonedx-library": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-1.13.0.tgz",
-      "integrity": "sha512-1DGU18dP6g/t5J1u7TWrAho8sCFVtdWSJHs4Xxjh2/qMINNWkFnBTvgdHFB3G6mcPvEMqk77946SWzyWUT+6/Q==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-1.13.2.tgz",
+      "integrity": "sha512-acpRn9vNXVfuV1ngSfo+S0aCU97f2nEcMKAIwjFDHWb+izg5OQ02qj/+OC7+7XDrpSagmPDgz1OFo5zGCof3qw==",
       "funding": [
         {
           "type": "github",
@@ -7372,9 +7372,9 @@
       "dev": true
     },
     "@cyclonedx/cyclonedx-library": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-1.13.0.tgz",
-      "integrity": "sha512-1DGU18dP6g/t5J1u7TWrAho8sCFVtdWSJHs4Xxjh2/qMINNWkFnBTvgdHFB3G6mcPvEMqk77946SWzyWUT+6/Q==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-1.13.2.tgz",
+      "integrity": "sha512-acpRn9vNXVfuV1ngSfo+S0aCU97f2nEcMKAIwjFDHWb+izg5OQ02qj/+OC7+7XDrpSagmPDgz1OFo5zGCof3qw==",
       "requires": {
         "packageurl-js": ">=0.0.6 <0.0.8 || ^1",
         "xmlbuilder2": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyclonedx/webpack-plugin",
-  "version": "3.4.0",
+  "version": "3.4.1-rc.1",
   "description": "Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects",
   "license": "Apache-2.0",
   "copyright": "Copyright OWASP Foundation",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@cyclonedx/cyclonedx-library": "^1.13.0",
+    "@cyclonedx/cyclonedx-library": "^1.13.2",
     "normalize-package-data": "^3||^4||^5",
     "xmlbuilder2": "^3.0.2"
   },

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -65,6 +65,8 @@ export class Extractor {
           )
         } catch (e) {
           logger?.warn('normalizePackageJson from PkgPath', pkg.path, 'caused:', e)
+          // reset data, and try to run with it...
+          pkg.packageJson = require(pkg.path)
         }
         component = pkgs[pkg.path] = this.#componentBuilder.makeComponent(pkg.packageJson)
         logger?.debug('built', component, 'based on', pkg, 'for module', module)

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -58,7 +58,14 @@ export class Extractor {
       let component = pkgs[pkg.path]
       if (component === undefined) {
         logger?.log('try to build new Component from PkgPath', pkg.path)
-        normalizePackageJson(pkg.packageJson, w => logger?.debug('normalizePackageJson from PkgPath', pkg.path, 'caused:', w))
+        try {
+          normalizePackageJson(
+            pkg.packageJson,
+            w => logger?.debug('normalizePackageJson from PkgPath', pkg.path, 'caused:', w)
+          )
+        } catch (e) {
+          logger?.warn('normalizePackageJson from PkgPath', pkg.path, 'caused:', e)
+        }
         component = pkgs[pkg.path] = this.#componentBuilder.makeComponent(pkg.packageJson)
         logger?.debug('built', component, 'based on', pkg, 'for module', module)
       }

--- a/tests/integration/__snapshots__/index.test.js.snap
+++ b/tests/integration/__snapshots__/index.test.js.snap
@@ -56,8 +56,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
     "component": {
       "type": "application",
       "name": "example-webpack5-angular13",
-      "group": "@cyclonedx-weboack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13",
+      "group": "@cyclonedx-webpack-plugin-tests",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13",
       "author": "Jan Kowalleck",
       "description": "example setup witch Angular13 in WebPack5",
       "licenses": [
@@ -67,7 +67,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -344,7 +344,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       ]
     },
     {
-      "ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13",
       "dependsOn": [
         "pkg:npm/%40angular/common@13.3.11?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
         "pkg:npm/%40angular/core@13.3.11?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
@@ -428,8 +428,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
     "component": {
       "type": "application",
       "name": "example-webpack5-angular13",
-      "group": "@cyclonedx-weboack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13",
+      "group": "@cyclonedx-webpack-plugin-tests",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13",
       "author": "Jan Kowalleck",
       "description": "example setup witch Angular13 in WebPack5",
       "licenses": [
@@ -439,7 +439,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -716,7 +716,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       ]
     },
     {
-      "ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13",
       "dependsOn": [
         "pkg:npm/%40angular/common@13.3.11?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
         "pkg:npm/%40angular/core@13.3.11?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
@@ -788,9 +788,9 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
         </externalReferences>
       </tool>
     </tools>
-    <component type="application" bom-ref="pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13">
+    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13">
       <author>Jan Kowalleck</author>
-      <group>@cyclonedx-weboack-plugin-tests</group>
+      <group>@cyclonedx-webpack-plugin-tests</group>
       <name>example-webpack5-angular13</name>
       <description>example setup witch Angular13 in WebPack5</description>
       <licenses>
@@ -798,7 +798,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
           <id>Apache-2.0</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13</purl>
+      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
@@ -1013,7 +1013,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
       <dependency ref="pkg:npm/%40angular/common@13.3.11?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common"/>
       <dependency ref="pkg:npm/%40angular/core@13.3.11?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"/>
     </dependency>
-    <dependency ref="pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13">
+    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-angular13">
       <dependency ref="pkg:npm/%40angular/common@13.3.11?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common"/>
       <dependency ref="pkg:npm/%40angular/core@13.3.11?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"/>
       <dependency ref="pkg:npm/%40angular/platform-browser@13.3.11?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser"/>
@@ -1873,8 +1873,8 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.b
     "component": {
       "type": "application",
       "name": "example-webpack5-vue2",
-      "group": "@cyclonedx-weboack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
+      "group": "@cyclonedx-webpack-plugin-tests",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
       "author": "Jan Kowalleck",
       "description": "example setup witch Vue2 in WebPack5",
       "licenses": [
@@ -1884,7 +1884,7 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.b
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -1941,7 +1941,7 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.b
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
       "dependsOn": [
         "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"
       ]
@@ -2009,8 +2009,8 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.w
     "component": {
       "type": "application",
       "name": "example-webpack5-vue2",
-      "group": "@cyclonedx-weboack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
+      "group": "@cyclonedx-webpack-plugin-tests",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
       "author": "Jan Kowalleck",
       "description": "example setup witch Vue2 in WebPack5",
       "licenses": [
@@ -2020,7 +2020,7 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.w
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -2077,7 +2077,7 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.w
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
       "dependsOn": [
         "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"
       ]
@@ -2133,9 +2133,9 @@ exports[`integration functional: webpack5 with vue2 generated xml file: dist/.bo
         </externalReferences>
       </tool>
     </tools>
-    <component type="application" bom-ref="pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2">
+    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2">
       <author>Jan Kowalleck</author>
-      <group>@cyclonedx-weboack-plugin-tests</group>
+      <group>@cyclonedx-webpack-plugin-tests</group>
       <name>example-webpack5-vue2</name>
       <description>example setup witch Vue2 in WebPack5</description>
       <licenses>
@@ -2143,7 +2143,7 @@ exports[`integration functional: webpack5 with vue2 generated xml file: dist/.bo
           <id>Apache-2.0</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2</purl>
+      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
@@ -2189,7 +2189,7 @@ exports[`integration functional: webpack5 with vue2 generated xml file: dist/.bo
     </component>
   </components>
   <dependencies>
-    <dependency ref="pkg:npm/%40cyclonedx-weboack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2">
+    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2">
       <dependency ref="pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"/>
     </dependency>
     <dependency ref="pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"/>
@@ -2253,8 +2253,8 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
     "component": {
       "type": "application",
       "name": "regression-issue745",
-      "group": "@cyclonedx-weboack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "group": "@cyclonedx-webpack-plugin-tests",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
       "author": "Jan Kowalleck",
       "description": "example setup for issue#745",
       "licenses": [
@@ -2264,7 +2264,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -2289,77 +2289,77 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.36940ldpu6.f6ncunh9bio",
+      "bom-ref": "BomRef.1v6i7c2p2d.o6oj54aujq",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.4buj11o6t5.ssv71vuetgg",
+      "bom-ref": "BomRef.2uuhgjkqm4.44rbt5qa92",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.5deb55m03co.kkl8vrthmqg",
+      "bom-ref": "BomRef.574bgaaihho.ra6niip10oo",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.5lj43v71ke8.aet8potatb8",
+      "bom-ref": "BomRef.9nfeuv9mls8.fknbfl7qqio",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.626mu8poa.3h80f6ebc7",
+      "bom-ref": "BomRef.a4pdmbhdu4o.gr9hlr64lk",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.84kqf7lvnfg.s0sb023nqj8",
+      "bom-ref": "BomRef.bsjllu46o3g.6n1jcl11nt8",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.9tr0efifegg.6gjdn1e8r68",
+      "bom-ref": "BomRef.cujqv1hiht.k61uu3mgbjo",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.d7ihsbjjr28.n6qcm1umh7o",
+      "bom-ref": "BomRef.deq9qishqr.aranrud11po",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.q59kca90p48.ersa509b3qg",
+      "bom-ref": "BomRef.estn8etubf8.d3tbol05nqo",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.rgfl1tr9psg.1s4qiius3jo",
+      "bom-ref": "BomRef.snpcft3603.8567r648g4",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.vhjem3jc2gg.psk4k3mg7ko",
+      "bom-ref": "BomRef.vkrv75rojg.kp7bht4v6u8",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
@@ -2774,24 +2774,122 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
   ],
   "dependencies": [
     {
-      "ref": "BomRef.36940ldpu6.f6ncunh9bio",
+      "ref": "BomRef.1v6i7c2p2d.o6oj54aujq",
       "dependsOn": [
-        "BomRef.5lj43v71ke8.aet8potatb8",
-        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
+        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
+        "BomRef.cujqv1hiht.k61uu3mgbjo",
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
+      ]
+    },
+    {
+      "ref": "BomRef.2uuhgjkqm4.44rbt5qa92",
+      "dependsOn": [
+        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
+        "BomRef.cujqv1hiht.k61uu3mgbjo",
         "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
         "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
       ]
     },
     {
-      "ref": "BomRef.4buj11o6t5.ssv71vuetgg",
+      "ref": "BomRef.574bgaaihho.ra6niip10oo",
       "dependsOn": [
-        "BomRef.36940ldpu6.f6ncunh9bio",
-        "BomRef.5lj43v71ke8.aet8potatb8",
-        "BomRef.9tr0efifegg.6gjdn1e8r68",
-        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
-        "BomRef.q59kca90p48.ersa509b3qg",
-        "BomRef.rgfl1tr9psg.1s4qiius3jo",
-        "BomRef.vhjem3jc2gg.psk4k3mg7ko",
+        "BomRef.a4pdmbhdu4o.gr9hlr64lk"
+      ]
+    },
+    {
+      "ref": "BomRef.9nfeuv9mls8.fknbfl7qqio",
+      "dependsOn": [
+        "BomRef.2uuhgjkqm4.44rbt5qa92",
+        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
+        "BomRef.cujqv1hiht.k61uu3mgbjo",
+        "BomRef.vkrv75rojg.kp7bht4v6u8",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "BomRef.a4pdmbhdu4o.gr9hlr64lk",
+      "dependsOn": [
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+        "pkg:npm/ts-invariant%2Fprocess"
+      ]
+    },
+    {
+      "ref": "BomRef.bsjllu46o3g.6n1jcl11nt8",
+      "dependsOn": [
+        "BomRef.1v6i7c2p2d.o6oj54aujq",
+        "BomRef.574bgaaihho.ra6niip10oo",
+        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
+        "BomRef.deq9qishqr.aranrud11po"
+      ]
+    },
+    {
+      "ref": "BomRef.cujqv1hiht.k61uu3mgbjo",
+      "dependsOn": [
+        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "BomRef.deq9qishqr.aranrud11po",
+      "dependsOn": [
+        "BomRef.1v6i7c2p2d.o6oj54aujq",
+        "BomRef.574bgaaihho.ra6niip10oo",
+        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
+        "BomRef.cujqv1hiht.k61uu3mgbjo",
+        "BomRef.estn8etubf8.d3tbol05nqo",
+        "pkg:npm/%40apollo/client",
+        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "BomRef.estn8etubf8.d3tbol05nqo",
+      "dependsOn": [
+        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
+        "BomRef.cujqv1hiht.k61uu3mgbjo",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "BomRef.snpcft3603.8567r648g4",
+      "dependsOn": [
+        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
+        "BomRef.cujqv1hiht.k61uu3mgbjo",
+        "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "BomRef.vkrv75rojg.kp7bht4v6u8",
+      "dependsOn": [
+        "BomRef.2uuhgjkqm4.44rbt5qa92",
+        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
+        "BomRef.cujqv1hiht.k61uu3mgbjo",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client",
+      "dependsOn": [
+        "BomRef.2uuhgjkqm4.44rbt5qa92",
+        "BomRef.9nfeuv9mls8.fknbfl7qqio",
+        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
+        "BomRef.cujqv1hiht.k61uu3mgbjo",
+        "BomRef.estn8etubf8.d3tbol05nqo",
+        "BomRef.snpcft3603.8567r648g4",
+        "BomRef.vkrv75rojg.kp7bht4v6u8",
         "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
         "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
         "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
@@ -2802,112 +2900,14 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       ]
     },
     {
-      "ref": "BomRef.5deb55m03co.kkl8vrthmqg",
-      "dependsOn": [
-        "BomRef.5lj43v71ke8.aet8potatb8",
-        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
-        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
-      ]
-    },
-    {
-      "ref": "BomRef.5lj43v71ke8.aet8potatb8",
-      "dependsOn": [
-        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
-      ]
-    },
-    {
-      "ref": "BomRef.626mu8poa.3h80f6ebc7",
-      "dependsOn": [
-        "BomRef.d7ihsbjjr28.n6qcm1umh7o"
-      ]
-    },
-    {
-      "ref": "BomRef.84kqf7lvnfg.s0sb023nqj8",
-      "dependsOn": [
-        "BomRef.4buj11o6t5.ssv71vuetgg",
-        "BomRef.5deb55m03co.kkl8vrthmqg",
-        "BomRef.5lj43v71ke8.aet8potatb8",
-        "BomRef.626mu8poa.3h80f6ebc7",
-        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
-        "BomRef.q59kca90p48.ersa509b3qg",
-        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
-      ]
-    },
-    {
-      "ref": "BomRef.9tr0efifegg.6gjdn1e8r68",
-      "dependsOn": [
-        "BomRef.36940ldpu6.f6ncunh9bio",
-        "BomRef.5lj43v71ke8.aet8potatb8",
-        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
-      ]
-    },
-    {
-      "ref": "BomRef.d7ihsbjjr28.n6qcm1umh7o",
-      "dependsOn": [
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
-        "pkg:npm/ts-invariant%2Fprocess"
-      ]
-    },
-    {
-      "ref": "BomRef.q59kca90p48.ersa509b3qg",
-      "dependsOn": [
-        "BomRef.5lj43v71ke8.aet8potatb8",
-        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
-      ]
-    },
-    {
-      "ref": "BomRef.rgfl1tr9psg.1s4qiius3jo",
-      "dependsOn": [
-        "BomRef.5lj43v71ke8.aet8potatb8",
-        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
-        "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
-      ]
-    },
-    {
-      "ref": "BomRef.vhjem3jc2gg.psk4k3mg7ko",
-      "dependsOn": [
-        "BomRef.36940ldpu6.f6ncunh9bio",
-        "BomRef.5lj43v71ke8.aet8potatb8",
-        "BomRef.9tr0efifegg.6gjdn1e8r68",
-        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
-      ]
-    },
-    {
-      "ref": "pkg:npm/%40apollo/client",
-      "dependsOn": [
-        "BomRef.5deb55m03co.kkl8vrthmqg",
-        "BomRef.626mu8poa.3h80f6ebc7",
-        "BomRef.84kqf7lvnfg.s0sb023nqj8",
-        "BomRef.d7ihsbjjr28.n6qcm1umh7o"
-      ]
-    },
-    {
       "ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
       "dependsOn": [
-        "BomRef.4buj11o6t5.ssv71vuetgg",
+        "BomRef.bsjllu46o3g.6n1jcl11nt8",
         "pkg:npm/%40apollo/client"
       ]
     },
     {
-      "ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
       "dependsOn": [
         "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git"
       ]
@@ -3019,8 +3019,8 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
     "component": {
       "type": "application",
       "name": "regression-issue745",
-      "group": "@cyclonedx-weboack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "group": "@cyclonedx-webpack-plugin-tests",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
       "author": "Jan Kowalleck",
       "description": "example setup for issue#745",
       "licenses": [
@@ -3030,7 +3030,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -3055,77 +3055,77 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.4tr145qmr6.h37d6puhmrg",
+      "bom-ref": "BomRef.1qqa5gucsr8.m004ottvl2o",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.c49mpkd3av8.2b96ig8fht",
+      "bom-ref": "BomRef.303qa2m92h.9ugke721j48",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.clc590ats4g.1t3ctsrldoo",
+      "bom-ref": "BomRef.5jvbn6rdado.2leb9vrajdo",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.ddr00cbef2.8r5g0vmule",
+      "bom-ref": "BomRef.8jiivt537hg.r634smm6lto",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.g0udgt6fms8.bkfe7epe6ig",
+      "bom-ref": "BomRef.b47547ah6u8.8obnf9068qo",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.i8j9uhc2i98.lhc3kojg9a",
+      "bom-ref": "BomRef.hf4dtphovdo.4i4nr20p5dg",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.jmn9l08pju8.ll7otmvv5so",
+      "bom-ref": "BomRef.iecpj4e1vr.dd6kdf9kv8g",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.nbn3ubl6ad8.02qm3u9084g",
+      "bom-ref": "BomRef.in07cbh914g.tt3pobvo9pg",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.oc4prune9u8.sq9224s7c8g",
+      "bom-ref": "BomRef.kn8sqe77nk8.46sq28j9048",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.q2o6bg52qe.ul3d64bi1m",
+      "bom-ref": "BomRef.t8spi8bsjio.gllnu01au48",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.ra25hqjpjj.qd39m0goeco",
+      "bom-ref": "BomRef.tung50etti.dltr2j5rav8",
       "purl": "pkg:npm/%40apollo/client"
     },
     {
@@ -3540,15 +3540,122 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
   ],
   "dependencies": [
     {
-      "ref": "BomRef.4tr145qmr6.h37d6puhmrg",
+      "ref": "BomRef.1qqa5gucsr8.m004ottvl2o",
       "dependsOn": [
-        "BomRef.c49mpkd3av8.2b96ig8fht",
-        "BomRef.ddr00cbef2.8r5g0vmule",
-        "BomRef.g0udgt6fms8.bkfe7epe6ig",
-        "BomRef.jmn9l08pju8.ll7otmvv5so",
-        "BomRef.nbn3ubl6ad8.02qm3u9084g",
-        "BomRef.q2o6bg52qe.ul3d64bi1m",
-        "BomRef.ra25hqjpjj.qd39m0goeco",
+        "BomRef.in07cbh914g.tt3pobvo9pg",
+        "BomRef.t8spi8bsjio.gllnu01au48",
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
+      ]
+    },
+    {
+      "ref": "BomRef.303qa2m92h.9ugke721j48",
+      "dependsOn": [
+        "BomRef.t8spi8bsjio.gllnu01au48"
+      ]
+    },
+    {
+      "ref": "BomRef.5jvbn6rdado.2leb9vrajdo",
+      "dependsOn": [
+        "BomRef.in07cbh914g.tt3pobvo9pg",
+        "BomRef.t8spi8bsjio.gllnu01au48",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "BomRef.8jiivt537hg.r634smm6lto",
+      "dependsOn": [
+        "BomRef.1qqa5gucsr8.m004ottvl2o",
+        "BomRef.303qa2m92h.9ugke721j48",
+        "BomRef.hf4dtphovdo.4i4nr20p5dg",
+        "BomRef.in07cbh914g.tt3pobvo9pg",
+        "BomRef.t8spi8bsjio.gllnu01au48",
+        "pkg:npm/%40apollo/client",
+        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "BomRef.b47547ah6u8.8obnf9068qo",
+      "dependsOn": [
+        "BomRef.5jvbn6rdado.2leb9vrajdo",
+        "BomRef.in07cbh914g.tt3pobvo9pg",
+        "BomRef.kn8sqe77nk8.46sq28j9048",
+        "BomRef.t8spi8bsjio.gllnu01au48",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "BomRef.hf4dtphovdo.4i4nr20p5dg",
+      "dependsOn": [
+        "BomRef.in07cbh914g.tt3pobvo9pg",
+        "BomRef.t8spi8bsjio.gllnu01au48",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "BomRef.iecpj4e1vr.dd6kdf9kv8g",
+      "dependsOn": [
+        "BomRef.1qqa5gucsr8.m004ottvl2o",
+        "BomRef.303qa2m92h.9ugke721j48",
+        "BomRef.8jiivt537hg.r634smm6lto",
+        "BomRef.t8spi8bsjio.gllnu01au48"
+      ]
+    },
+    {
+      "ref": "BomRef.in07cbh914g.tt3pobvo9pg",
+      "dependsOn": [
+        "BomRef.t8spi8bsjio.gllnu01au48",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "BomRef.kn8sqe77nk8.46sq28j9048",
+      "dependsOn": [
+        "BomRef.5jvbn6rdado.2leb9vrajdo",
+        "BomRef.in07cbh914g.tt3pobvo9pg",
+        "BomRef.t8spi8bsjio.gllnu01au48",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "BomRef.t8spi8bsjio.gllnu01au48",
+      "dependsOn": [
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+        "pkg:npm/ts-invariant%2Fprocess"
+      ]
+    },
+    {
+      "ref": "BomRef.tung50etti.dltr2j5rav8",
+      "dependsOn": [
+        "BomRef.in07cbh914g.tt3pobvo9pg",
+        "BomRef.t8spi8bsjio.gllnu01au48",
+        "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client",
+      "dependsOn": [
+        "BomRef.5jvbn6rdado.2leb9vrajdo",
+        "BomRef.b47547ah6u8.8obnf9068qo",
+        "BomRef.hf4dtphovdo.4i4nr20p5dg",
+        "BomRef.in07cbh914g.tt3pobvo9pg",
+        "BomRef.kn8sqe77nk8.46sq28j9048",
+        "BomRef.t8spi8bsjio.gllnu01au48",
+        "BomRef.tung50etti.dltr2j5rav8",
         "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
         "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
         "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
@@ -3559,121 +3666,14 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       ]
     },
     {
-      "ref": "BomRef.c49mpkd3av8.2b96ig8fht",
-      "dependsOn": [
-        "BomRef.ddr00cbef2.8r5g0vmule",
-        "BomRef.nbn3ubl6ad8.02qm3u9084g",
-        "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
-      ]
-    },
-    {
-      "ref": "BomRef.clc590ats4g.1t3ctsrldoo",
-      "dependsOn": [
-        "BomRef.ddr00cbef2.8r5g0vmule",
-        "BomRef.nbn3ubl6ad8.02qm3u9084g",
-        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
-      ]
-    },
-    {
-      "ref": "BomRef.ddr00cbef2.8r5g0vmule",
-      "dependsOn": [
-        "BomRef.nbn3ubl6ad8.02qm3u9084g",
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
-      ]
-    },
-    {
-      "ref": "BomRef.g0udgt6fms8.bkfe7epe6ig",
-      "dependsOn": [
-        "BomRef.ddr00cbef2.8r5g0vmule",
-        "BomRef.nbn3ubl6ad8.02qm3u9084g",
-        "BomRef.q2o6bg52qe.ul3d64bi1m",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
-      ]
-    },
-    {
-      "ref": "BomRef.i8j9uhc2i98.lhc3kojg9a",
-      "dependsOn": [
-        "BomRef.4tr145qmr6.h37d6puhmrg",
-        "BomRef.clc590ats4g.1t3ctsrldoo",
-        "BomRef.ddr00cbef2.8r5g0vmule",
-        "BomRef.nbn3ubl6ad8.02qm3u9084g",
-        "BomRef.oc4prune9u8.sq9224s7c8g",
-        "BomRef.ra25hqjpjj.qd39m0goeco",
-        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
-      ]
-    },
-    {
-      "ref": "BomRef.jmn9l08pju8.ll7otmvv5so",
-      "dependsOn": [
-        "BomRef.ddr00cbef2.8r5g0vmule",
-        "BomRef.g0udgt6fms8.bkfe7epe6ig",
-        "BomRef.nbn3ubl6ad8.02qm3u9084g",
-        "BomRef.q2o6bg52qe.ul3d64bi1m",
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
-      ]
-    },
-    {
-      "ref": "BomRef.nbn3ubl6ad8.02qm3u9084g",
-      "dependsOn": [
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
-        "pkg:npm/ts-invariant%2Fprocess"
-      ]
-    },
-    {
-      "ref": "BomRef.oc4prune9u8.sq9224s7c8g",
-      "dependsOn": [
-        "BomRef.nbn3ubl6ad8.02qm3u9084g"
-      ]
-    },
-    {
-      "ref": "BomRef.q2o6bg52qe.ul3d64bi1m",
-      "dependsOn": [
-        "BomRef.ddr00cbef2.8r5g0vmule",
-        "BomRef.nbn3ubl6ad8.02qm3u9084g",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
-      ]
-    },
-    {
-      "ref": "BomRef.ra25hqjpjj.qd39m0goeco",
-      "dependsOn": [
-        "BomRef.ddr00cbef2.8r5g0vmule",
-        "BomRef.nbn3ubl6ad8.02qm3u9084g",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
-      ]
-    },
-    {
-      "ref": "pkg:npm/%40apollo/client",
-      "dependsOn": [
-        "BomRef.clc590ats4g.1t3ctsrldoo",
-        "BomRef.i8j9uhc2i98.lhc3kojg9a",
-        "BomRef.nbn3ubl6ad8.02qm3u9084g",
-        "BomRef.oc4prune9u8.sq9224s7c8g"
-      ]
-    },
-    {
       "ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
       "dependsOn": [
-        "BomRef.4tr145qmr6.h37d6puhmrg",
+        "BomRef.iecpj4e1vr.dd6kdf9kv8g",
         "pkg:npm/%40apollo/client"
       ]
     },
     {
-      "ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
       "dependsOn": [
         "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git"
       ]
@@ -3773,9 +3773,9 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </externalReferences>
       </tool>
     </tools>
-    <component type="application" bom-ref="pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745">
+    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745">
       <author>Jan Kowalleck</author>
-      <group>@cyclonedx-weboack-plugin-tests</group>
+      <group>@cyclonedx-webpack-plugin-tests</group>
       <name>regression-issue745</name>
       <description>example setup for issue#745</description>
       <licenses>
@@ -3783,7 +3783,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
           <id>Apache-2.0</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745</purl>
+      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
@@ -3801,57 +3801,57 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="BomRef.2coo4jadono.f3462oemnko">
+    <component type="library" bom-ref="BomRef.0bg0jc9bg0g.l8p1v5626p8">
       <group>@apollo</group>
       <name>client</name>
       <purl>pkg:npm/%40apollo/client</purl>
     </component>
-    <component type="library" bom-ref="BomRef.am4lm237ol.g4raeovugog">
+    <component type="library" bom-ref="BomRef.45hfu10oka.98iijunc7bg">
       <group>@apollo</group>
       <name>client</name>
       <purl>pkg:npm/%40apollo/client</purl>
     </component>
-    <component type="library" bom-ref="BomRef.joepd1q1eko.64qp3m29sd8">
+    <component type="library" bom-ref="BomRef.6lfmvv9rggo.ioop0bposb8">
       <group>@apollo</group>
       <name>client</name>
       <purl>pkg:npm/%40apollo/client</purl>
     </component>
-    <component type="library" bom-ref="BomRef.kskhg402i6g.44l26rjdoc">
+    <component type="library" bom-ref="BomRef.6pik6fbe0ao.4hro6s214fo">
       <group>@apollo</group>
       <name>client</name>
       <purl>pkg:npm/%40apollo/client</purl>
     </component>
-    <component type="library" bom-ref="BomRef.mjt7cod22s.cl0ae3fb5ug">
+    <component type="library" bom-ref="BomRef.ce89fl1bfq.83qbpvv2amg">
       <group>@apollo</group>
       <name>client</name>
       <purl>pkg:npm/%40apollo/client</purl>
     </component>
-    <component type="library" bom-ref="BomRef.qdi0hames6o.at7jeig2pco">
+    <component type="library" bom-ref="BomRef.fcdblkggsso.gi923dvudto">
       <group>@apollo</group>
       <name>client</name>
       <purl>pkg:npm/%40apollo/client</purl>
     </component>
-    <component type="library" bom-ref="BomRef.rdd0ted4bc8.n8i7k3j6nvg">
+    <component type="library" bom-ref="BomRef.fi6v6n7lqgg.nf11dk5f7dg">
       <group>@apollo</group>
       <name>client</name>
       <purl>pkg:npm/%40apollo/client</purl>
     </component>
-    <component type="library" bom-ref="BomRef.s72ha53pguo.cp6nbvk0j9g">
+    <component type="library" bom-ref="BomRef.fnnm3t4qakg.lsc13rq842o">
       <group>@apollo</group>
       <name>client</name>
       <purl>pkg:npm/%40apollo/client</purl>
     </component>
-    <component type="library" bom-ref="BomRef.tq2q7rrh9r.rc9dj91ocp">
+    <component type="library" bom-ref="BomRef.kbok9enj81o.4l9ko1j0egg">
       <group>@apollo</group>
       <name>client</name>
       <purl>pkg:npm/%40apollo/client</purl>
     </component>
-    <component type="library" bom-ref="BomRef.u29qci2oc2o.u6g8u00bdm">
+    <component type="library" bom-ref="BomRef.n339j9o2un8.capjq851t1">
       <group>@apollo</group>
       <name>client</name>
       <purl>pkg:npm/%40apollo/client</purl>
     </component>
-    <component type="library" bom-ref="BomRef.vqr4bvoar0g.su5krk9r04o">
+    <component type="library" bom-ref="BomRef.qk87495vt1.biahsp4eje8">
       <group>@apollo</group>
       <name>client</name>
       <purl>pkg:npm/%40apollo/client</purl>
@@ -4179,24 +4179,88 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
     </component>
   </components>
   <dependencies>
-    <dependency ref="BomRef.2coo4jadono.f3462oemnko">
-      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
-      <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug"/>
-      <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"/>
+    <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8">
+      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
+      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
+      <dependency ref="pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
     </dependency>
-    <dependency ref="BomRef.am4lm237ol.g4raeovugog">
+    <dependency ref="BomRef.45hfu10oka.98iijunc7bg">
+      <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8"/>
+      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+    </dependency>
+    <dependency ref="BomRef.6lfmvv9rggo.ioop0bposb8">
+      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
+      <dependency ref="BomRef.fcdblkggsso.gi923dvudto"/>
+      <dependency ref="BomRef.fnnm3t4qakg.lsc13rq842o"/>
+      <dependency ref="BomRef.kbok9enj81o.4l9ko1j0egg"/>
+    </dependency>
+    <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo">
       <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
       <dependency ref="pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git"/>
       <dependency ref="pkg:npm/ts-invariant%2Fprocess"/>
     </dependency>
-    <dependency ref="BomRef.joepd1q1eko.64qp3m29sd8">
-      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
-      <dependency ref="BomRef.kskhg402i6g.44l26rjdoc"/>
-      <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug"/>
-      <dependency ref="BomRef.qdi0hames6o.at7jeig2pco"/>
-      <dependency ref="BomRef.tq2q7rrh9r.rc9dj91ocp"/>
-      <dependency ref="BomRef.u29qci2oc2o.u6g8u00bdm"/>
-      <dependency ref="BomRef.vqr4bvoar0g.su5krk9r04o"/>
+    <dependency ref="BomRef.ce89fl1bfq.83qbpvv2amg">
+      <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8"/>
+      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
+      <dependency ref="BomRef.qk87495vt1.biahsp4eje8"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
+    </dependency>
+    <dependency ref="BomRef.fcdblkggsso.gi923dvudto">
+      <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8"/>
+      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
+      <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"/>
+    </dependency>
+    <dependency ref="BomRef.fi6v6n7lqgg.nf11dk5f7dg">
+      <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8"/>
+      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
+      <dependency ref="BomRef.ce89fl1bfq.83qbpvv2amg"/>
+      <dependency ref="BomRef.qk87495vt1.biahsp4eje8"/>
+      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
+    </dependency>
+    <dependency ref="BomRef.fnnm3t4qakg.lsc13rq842o">
+      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
+    </dependency>
+    <dependency ref="BomRef.kbok9enj81o.4l9ko1j0egg">
+      <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8"/>
+      <dependency ref="BomRef.45hfu10oka.98iijunc7bg"/>
+      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
+      <dependency ref="BomRef.fcdblkggsso.gi923dvudto"/>
+      <dependency ref="BomRef.fnnm3t4qakg.lsc13rq842o"/>
+      <dependency ref="pkg:npm/%40apollo/client"/>
+      <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
+      <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+    </dependency>
+    <dependency ref="BomRef.n339j9o2un8.capjq851t1">
+      <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8"/>
+      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
+      <dependency ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
+      <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
+      <dependency ref="pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
+      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
+      <dependency ref="pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+    </dependency>
+    <dependency ref="BomRef.qk87495vt1.biahsp4eje8">
+      <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8"/>
+      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
+    </dependency>
+    <dependency ref="pkg:npm/%40apollo/client">
+      <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8"/>
+      <dependency ref="BomRef.45hfu10oka.98iijunc7bg"/>
+      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
+      <dependency ref="BomRef.ce89fl1bfq.83qbpvv2amg"/>
+      <dependency ref="BomRef.fi6v6n7lqgg.nf11dk5f7dg"/>
+      <dependency ref="BomRef.n339j9o2un8.capjq851t1"/>
+      <dependency ref="BomRef.qk87495vt1.biahsp4eje8"/>
       <dependency ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git"/>
       <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
       <dependency ref="pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git"/>
@@ -4205,75 +4269,11 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
       <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
       <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
     </dependency>
-    <dependency ref="BomRef.kskhg402i6g.44l26rjdoc">
-      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
-      <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug"/>
-      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-    </dependency>
-    <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug">
-      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
-      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
-      <dependency ref="pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git"/>
-      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
-    </dependency>
-    <dependency ref="BomRef.qdi0hames6o.at7jeig2pco">
-      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
-      <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug"/>
-      <dependency ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
-      <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
-      <dependency ref="pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
-      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
-      <dependency ref="pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git"/>
-      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-    </dependency>
-    <dependency ref="BomRef.rdd0ted4bc8.n8i7k3j6nvg">
-      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
-    </dependency>
-    <dependency ref="BomRef.s72ha53pguo.cp6nbvk0j9g">
-      <dependency ref="BomRef.2coo4jadono.f3462oemnko"/>
-      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
-      <dependency ref="BomRef.joepd1q1eko.64qp3m29sd8"/>
-      <dependency ref="BomRef.kskhg402i6g.44l26rjdoc"/>
-      <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug"/>
-      <dependency ref="BomRef.rdd0ted4bc8.n8i7k3j6nvg"/>
-      <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
-      <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"/>
-      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-    </dependency>
-    <dependency ref="BomRef.tq2q7rrh9r.rc9dj91ocp">
-      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
-      <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug"/>
-      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
-    </dependency>
-    <dependency ref="BomRef.u29qci2oc2o.u6g8u00bdm">
-      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
-      <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug"/>
-      <dependency ref="BomRef.tq2q7rrh9r.rc9dj91ocp"/>
-      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
-    </dependency>
-    <dependency ref="BomRef.vqr4bvoar0g.su5krk9r04o">
-      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
-      <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug"/>
-      <dependency ref="BomRef.tq2q7rrh9r.rc9dj91ocp"/>
-      <dependency ref="BomRef.u29qci2oc2o.u6g8u00bdm"/>
-      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
-      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
-    </dependency>
-    <dependency ref="pkg:npm/%40apollo/client">
-      <dependency ref="BomRef.2coo4jadono.f3462oemnko"/>
-      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
-      <dependency ref="BomRef.rdd0ted4bc8.n8i7k3j6nvg"/>
-      <dependency ref="BomRef.s72ha53pguo.cp6nbvk0j9g"/>
-    </dependency>
     <dependency ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git">
-      <dependency ref="BomRef.joepd1q1eko.64qp3m29sd8"/>
+      <dependency ref="BomRef.6lfmvv9rggo.ioop0bposb8"/>
       <dependency ref="pkg:npm/%40apollo/client"/>
     </dependency>
-    <dependency ref="pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745">
+    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745">
       <dependency ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git"/>
     </dependency>
     <dependency ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>

--- a/tests/integration/__snapshots__/index.test.js.snap
+++ b/tests/integration/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`integration webpack5 with angular13 generated json file: dist/.bom/bom.json 1`] = `
+exports[`integration functional: webpack5 with angular13 generated json file: dist/.bom/bom.json 1`] = `
 "{
   "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
   "bomFormat": "CycloneDX",
@@ -372,7 +372,7 @@ exports[`integration webpack5 with angular13 generated json file: dist/.bom/bom.
 }"
 `;
 
-exports[`integration webpack5 with angular13 generated json file: dist/.well-known/sbom 1`] = `
+exports[`integration functional: webpack5 with angular13 generated json file: dist/.well-known/sbom 1`] = `
 "{
   "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
   "bomFormat": "CycloneDX",
@@ -744,7 +744,7 @@ exports[`integration webpack5 with angular13 generated json file: dist/.well-kno
 }"
 `;
 
-exports[`integration webpack5 with angular13 generated xml file: dist/.bom/bom.xml 1`] = `
+exports[`integration functional: webpack5 with angular13 generated xml file: dist/.bom/bom.xml 1`] = `
 "<?xml version="1.0" encoding="UTF-8"?>
 <bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1">
   <metadata>
@@ -1030,7 +1030,7 @@ exports[`integration webpack5 with angular13 generated xml file: dist/.bom/bom.x
 </bom>"
 `;
 
-exports[`integration webpack5 with react18 generated json file: dist/.bom/bom.json 1`] = `
+exports[`integration functional: webpack5 with react18 generated json file: dist/.bom/bom.json 1`] = `
 "{
   "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
   "bomFormat": "CycloneDX",
@@ -1314,7 +1314,7 @@ exports[`integration webpack5 with react18 generated json file: dist/.bom/bom.js
 }"
 `;
 
-exports[`integration webpack5 with react18 generated json file: dist/.well-known/sbom 1`] = `
+exports[`integration functional: webpack5 with react18 generated json file: dist/.well-known/sbom 1`] = `
 "{
   "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
   "bomFormat": "CycloneDX",
@@ -1598,7 +1598,7 @@ exports[`integration webpack5 with react18 generated json file: dist/.well-known
 }"
 `;
 
-exports[`integration webpack5 with react18 generated xml file: dist/.bom/bom.xml 1`] = `
+exports[`integration functional: webpack5 with react18 generated xml file: dist/.bom/bom.xml 1`] = `
 "<?xml version="1.0" encoding="UTF-8"?>
 <bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1">
   <metadata>
@@ -1817,7 +1817,7 @@ exports[`integration webpack5 with react18 generated xml file: dist/.bom/bom.xml
 </bom>"
 `;
 
-exports[`integration webpack5 with vue2 generated json file: dist/.bom/bom.json 1`] = `
+exports[`integration functional: webpack5 with vue2 generated json file: dist/.bom/bom.json 1`] = `
 "{
   "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
   "bomFormat": "CycloneDX",
@@ -1953,7 +1953,7 @@ exports[`integration webpack5 with vue2 generated json file: dist/.bom/bom.json 
 }"
 `;
 
-exports[`integration webpack5 with vue2 generated json file: dist/.well-known/sbom 1`] = `
+exports[`integration functional: webpack5 with vue2 generated json file: dist/.well-known/sbom 1`] = `
 "{
   "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
   "bomFormat": "CycloneDX",
@@ -2089,7 +2089,7 @@ exports[`integration webpack5 with vue2 generated json file: dist/.well-known/sb
 }"
 `;
 
-exports[`integration webpack5 with vue2 generated xml file: dist/.bom/bom.xml 1`] = `
+exports[`integration functional: webpack5 with vue2 generated xml file: dist/.bom/bom.xml 1`] = `
 "<?xml version="1.0" encoding="UTF-8"?>
 <bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1">
   <metadata>
@@ -2193,6 +2193,2109 @@ exports[`integration webpack5 with vue2 generated xml file: dist/.bom/bom.xml 1`
       <dependency ref="pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"/>
     </dependency>
     <dependency ref="pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"/>
+  </dependencies>
+</bom>"
+`;
+
+exports[`integration regression: issue#745 generated json file: dist/.bom/bom.json 1`] = `
+"{
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1,
+  "metadata": {
+    "tools": [
+      {
+        "vendor": "@cyclonedx",
+        "name": "cyclonedx-library",
+        "version": "libVersion-testing",
+        "externalReferences": [
+          {
+            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+            "type": "issue-tracker",
+            "comment": "as detected from PackageJson property \\"bugs.url\\""
+          },
+          {
+            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+            "type": "vcs",
+            "comment": "as detected from PackageJson property \\"repository.url\\""
+          },
+          {
+            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+            "type": "website",
+            "comment": "as detected from PackageJson property \\"homepage\\""
+          }
+        ]
+      },
+      {
+        "vendor": "@cyclonedx",
+        "name": "webpack-plugin",
+        "version": "thisVersion-testing",
+        "externalReferences": [
+          {
+            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+            "type": "issue-tracker",
+            "comment": "as detected from PackageJson property \\"bugs.url\\""
+          },
+          {
+            "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+            "type": "vcs",
+            "comment": "as detected from PackageJson property \\"repository.url\\""
+          },
+          {
+            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
+            "type": "website",
+            "comment": "as detected from PackageJson property \\"homepage\\""
+          }
+        ]
+      }
+    ],
+    "component": {
+      "type": "application",
+      "name": "regression-issue745",
+      "group": "@cyclonedx-weboack-plugin-tests",
+      "bom-ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "author": "Jan Kowalleck",
+      "description": "example setup for issue#745",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "externalReferences": [
+        {
+          "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/tree/master/tests/integration/regression-issue745#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.36940ldpu6.f6ncunh9bio",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.4buj11o6t5.ssv71vuetgg",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.5deb55m03co.kkl8vrthmqg",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.5lj43v71ke8.aet8potatb8",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.626mu8poa.3h80f6ebc7",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.84kqf7lvnfg.s0sb023nqj8",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.9tr0efifegg.6gjdn1e8r68",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.d7ihsbjjr28.n6qcm1umh7o",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.q59kca90p48.ersa509b3qg",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.rgfl1tr9psg.1s4qiius3jo",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.vhjem3jc2gg.psk4k3mg7ko",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "version": "3.7.10",
+      "bom-ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+      "author": "packages@apollographql.com",
+      "description": "A fully-featured caching GraphQL client.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/apollographql/apollo-client/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/apollographql/apollo-client.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://www.apollographql.com/docs/react/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "context",
+      "group": "@wry",
+      "version": "0.7.0",
+      "bom-ref": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "author": "Ben Newman",
+      "description": "Manage contextual information needed by (a)synchronous tasks without explicitly passing objects around",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/benjamn/wryware/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/benjamn/wryware.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/benjamn/wryware",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "equality",
+      "group": "@wry",
+      "version": "0.5.3",
+      "bom-ref": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "author": "Ben Newman",
+      "description": "Structural equality checking for JavaScript values",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/benjamn/wryware/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/benjamn/wryware.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/benjamn/wryware",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "trie",
+      "group": "@wry",
+      "version": "0.3.2",
+      "bom-ref": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "author": "Ben Newman",
+      "description": "https://en.wikipedia.org/wiki/Trie",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/benjamn/wryware/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/benjamn/wryware.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/benjamn/wryware",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "graphql-tag",
+      "version": "2.12.6",
+      "bom-ref": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
+      "description": "A JavaScript template literal tag that parses GraphQL queries",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/apollographql/graphql-tag/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/apollographql/graphql-tag.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/apollographql/graphql-tag#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "graphql",
+      "version": "16.6.0",
+      "bom-ref": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+      "description": "A Query Language and Runtime which can target any service.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/graphql/graphql-js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/graphql/graphql-js.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/graphql/graphql-js",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "optimism",
+      "version": "0.16.2",
+      "bom-ref": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
+      "author": "Ben Newman",
+      "description": "Composable reactive caching with efficient invalidation.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/benjamn/optimism/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/benjamn/optimism.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/benjamn/optimism#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "react",
+      "version": "18.2.0",
+      "bom-ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+      "description": "React is a JavaScript library for building user interfaces.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+      "externalReferences": [
+        {
+          "url": "https://github.com/facebook/react/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/facebook/react.git#packages/react",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://reactjs.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "symbol-observable",
+      "version": "4.0.0",
+      "bom-ref": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
+      "author": "Ben Lesh",
+      "description": "Symbol.observable ponyfill",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/blesh/symbol-observable/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/blesh/symbol-observable.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/blesh/symbol-observable#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "ts-invariant",
+      "version": "0.10.3",
+      "bom-ref": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+      "author": "Ben Newman",
+      "description": "TypeScript implementation of invariant(condition, message)",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/apollographql/invariant-packages/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/apollographql/invariant-packages.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/apollographql/invariant-packages",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "ts-invariant/process",
+      "bom-ref": "pkg:npm/ts-invariant%2Fprocess",
+      "purl": "pkg:npm/ts-invariant%2Fprocess"
+    },
+    {
+      "type": "library",
+      "name": "tslib",
+      "version": "2.5.0",
+      "bom-ref": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "author": "Microsoft Corp.",
+      "description": "Runtime library for TypeScript helper functions",
+      "licenses": [
+        {
+          "license": {
+            "id": "0BSD"
+          }
+        }
+      ],
+      "purl": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/Microsoft/TypeScript/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/Microsoft/tslib.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://www.typescriptlang.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "zen-observable-ts",
+      "version": "1.2.5",
+      "bom-ref": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git",
+      "description": "Thin wrapper around zen-observable and @types/zen-observable, to support ESM exports as well as CommonJS exports",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/apollographql/zen-observable-ts/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/apollographql/zen-observable-ts.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/apollographql/zen-observable-ts#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "BomRef.36940ldpu6.f6ncunh9bio",
+      "dependsOn": [
+        "BomRef.5lj43v71ke8.aet8potatb8",
+        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "BomRef.4buj11o6t5.ssv71vuetgg",
+      "dependsOn": [
+        "BomRef.36940ldpu6.f6ncunh9bio",
+        "BomRef.5lj43v71ke8.aet8potatb8",
+        "BomRef.9tr0efifegg.6gjdn1e8r68",
+        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
+        "BomRef.q59kca90p48.ersa509b3qg",
+        "BomRef.rgfl1tr9psg.1s4qiius3jo",
+        "BomRef.vhjem3jc2gg.psk4k3mg7ko",
+        "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "BomRef.5deb55m03co.kkl8vrthmqg",
+      "dependsOn": [
+        "BomRef.5lj43v71ke8.aet8potatb8",
+        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
+      ]
+    },
+    {
+      "ref": "BomRef.5lj43v71ke8.aet8potatb8",
+      "dependsOn": [
+        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "BomRef.626mu8poa.3h80f6ebc7",
+      "dependsOn": [
+        "BomRef.d7ihsbjjr28.n6qcm1umh7o"
+      ]
+    },
+    {
+      "ref": "BomRef.84kqf7lvnfg.s0sb023nqj8",
+      "dependsOn": [
+        "BomRef.4buj11o6t5.ssv71vuetgg",
+        "BomRef.5deb55m03co.kkl8vrthmqg",
+        "BomRef.5lj43v71ke8.aet8potatb8",
+        "BomRef.626mu8poa.3h80f6ebc7",
+        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
+        "BomRef.q59kca90p48.ersa509b3qg",
+        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "BomRef.9tr0efifegg.6gjdn1e8r68",
+      "dependsOn": [
+        "BomRef.36940ldpu6.f6ncunh9bio",
+        "BomRef.5lj43v71ke8.aet8potatb8",
+        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "BomRef.d7ihsbjjr28.n6qcm1umh7o",
+      "dependsOn": [
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+        "pkg:npm/ts-invariant%2Fprocess"
+      ]
+    },
+    {
+      "ref": "BomRef.q59kca90p48.ersa509b3qg",
+      "dependsOn": [
+        "BomRef.5lj43v71ke8.aet8potatb8",
+        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "BomRef.rgfl1tr9psg.1s4qiius3jo",
+      "dependsOn": [
+        "BomRef.5lj43v71ke8.aet8potatb8",
+        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
+        "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "BomRef.vhjem3jc2gg.psk4k3mg7ko",
+      "dependsOn": [
+        "BomRef.36940ldpu6.f6ncunh9bio",
+        "BomRef.5lj43v71ke8.aet8potatb8",
+        "BomRef.9tr0efifegg.6gjdn1e8r68",
+        "BomRef.d7ihsbjjr28.n6qcm1umh7o",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client",
+      "dependsOn": [
+        "BomRef.5deb55m03co.kkl8vrthmqg",
+        "BomRef.626mu8poa.3h80f6ebc7",
+        "BomRef.84kqf7lvnfg.s0sb023nqj8",
+        "BomRef.d7ihsbjjr28.n6qcm1umh7o"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+      "dependsOn": [
+        "BomRef.4buj11o6t5.ssv71vuetgg",
+        "pkg:npm/%40apollo/client"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"
+    },
+    {
+      "ref": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"
+    },
+    {
+      "ref": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"
+    },
+    {
+      "ref": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
+      "dependsOn": [
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"
+    },
+    {
+      "ref": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
+      "dependsOn": [
+        "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
+    },
+    {
+      "ref": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git"
+    },
+    {
+      "ref": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+      "dependsOn": [
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/ts-invariant%2Fprocess"
+    },
+    {
+      "ref": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+    },
+    {
+      "ref": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+    }
+  ]
+}"
+`;
+
+exports[`integration regression: issue#745 generated json file: dist/.well-known/sbom 1`] = `
+"{
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1,
+  "metadata": {
+    "tools": [
+      {
+        "vendor": "@cyclonedx",
+        "name": "cyclonedx-library",
+        "version": "libVersion-testing",
+        "externalReferences": [
+          {
+            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+            "type": "issue-tracker",
+            "comment": "as detected from PackageJson property \\"bugs.url\\""
+          },
+          {
+            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+            "type": "vcs",
+            "comment": "as detected from PackageJson property \\"repository.url\\""
+          },
+          {
+            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+            "type": "website",
+            "comment": "as detected from PackageJson property \\"homepage\\""
+          }
+        ]
+      },
+      {
+        "vendor": "@cyclonedx",
+        "name": "webpack-plugin",
+        "version": "thisVersion-testing",
+        "externalReferences": [
+          {
+            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+            "type": "issue-tracker",
+            "comment": "as detected from PackageJson property \\"bugs.url\\""
+          },
+          {
+            "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+            "type": "vcs",
+            "comment": "as detected from PackageJson property \\"repository.url\\""
+          },
+          {
+            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
+            "type": "website",
+            "comment": "as detected from PackageJson property \\"homepage\\""
+          }
+        ]
+      }
+    ],
+    "component": {
+      "type": "application",
+      "name": "regression-issue745",
+      "group": "@cyclonedx-weboack-plugin-tests",
+      "bom-ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "author": "Jan Kowalleck",
+      "description": "example setup for issue#745",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "externalReferences": [
+        {
+          "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/tree/master/tests/integration/regression-issue745#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.4tr145qmr6.h37d6puhmrg",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.c49mpkd3av8.2b96ig8fht",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.clc590ats4g.1t3ctsrldoo",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.ddr00cbef2.8r5g0vmule",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.g0udgt6fms8.bkfe7epe6ig",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.i8j9uhc2i98.lhc3kojg9a",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.jmn9l08pju8.ll7otmvv5so",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.nbn3ubl6ad8.02qm3u9084g",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.oc4prune9u8.sq9224s7c8g",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.q2o6bg52qe.ul3d64bi1m",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "BomRef.ra25hqjpjj.qd39m0goeco",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client",
+      "purl": "pkg:npm/%40apollo/client"
+    },
+    {
+      "type": "library",
+      "name": "client",
+      "group": "@apollo",
+      "version": "3.7.10",
+      "bom-ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+      "author": "packages@apollographql.com",
+      "description": "A fully-featured caching GraphQL client.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/apollographql/apollo-client/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/apollographql/apollo-client.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://www.apollographql.com/docs/react/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "context",
+      "group": "@wry",
+      "version": "0.7.0",
+      "bom-ref": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "author": "Ben Newman",
+      "description": "Manage contextual information needed by (a)synchronous tasks without explicitly passing objects around",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/benjamn/wryware/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/benjamn/wryware.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/benjamn/wryware",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "equality",
+      "group": "@wry",
+      "version": "0.5.3",
+      "bom-ref": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "author": "Ben Newman",
+      "description": "Structural equality checking for JavaScript values",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/benjamn/wryware/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/benjamn/wryware.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/benjamn/wryware",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "trie",
+      "group": "@wry",
+      "version": "0.3.2",
+      "bom-ref": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "author": "Ben Newman",
+      "description": "https://en.wikipedia.org/wiki/Trie",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/benjamn/wryware/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/benjamn/wryware.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/benjamn/wryware",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "graphql-tag",
+      "version": "2.12.6",
+      "bom-ref": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
+      "description": "A JavaScript template literal tag that parses GraphQL queries",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/apollographql/graphql-tag/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/apollographql/graphql-tag.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/apollographql/graphql-tag#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "graphql",
+      "version": "16.6.0",
+      "bom-ref": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+      "description": "A Query Language and Runtime which can target any service.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/graphql/graphql-js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/graphql/graphql-js.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/graphql/graphql-js",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "optimism",
+      "version": "0.16.2",
+      "bom-ref": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
+      "author": "Ben Newman",
+      "description": "Composable reactive caching with efficient invalidation.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/benjamn/optimism/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/benjamn/optimism.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/benjamn/optimism#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "react",
+      "version": "18.2.0",
+      "bom-ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+      "description": "React is a JavaScript library for building user interfaces.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+      "externalReferences": [
+        {
+          "url": "https://github.com/facebook/react/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/facebook/react.git#packages/react",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://reactjs.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "symbol-observable",
+      "version": "4.0.0",
+      "bom-ref": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
+      "author": "Ben Lesh",
+      "description": "Symbol.observable ponyfill",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/blesh/symbol-observable/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/blesh/symbol-observable.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/blesh/symbol-observable#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "ts-invariant",
+      "version": "0.10.3",
+      "bom-ref": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+      "author": "Ben Newman",
+      "description": "TypeScript implementation of invariant(condition, message)",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/apollographql/invariant-packages/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/apollographql/invariant-packages.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/apollographql/invariant-packages",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "ts-invariant/process",
+      "bom-ref": "pkg:npm/ts-invariant%2Fprocess",
+      "purl": "pkg:npm/ts-invariant%2Fprocess"
+    },
+    {
+      "type": "library",
+      "name": "tslib",
+      "version": "2.5.0",
+      "bom-ref": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "author": "Microsoft Corp.",
+      "description": "Runtime library for TypeScript helper functions",
+      "licenses": [
+        {
+          "license": {
+            "id": "0BSD"
+          }
+        }
+      ],
+      "purl": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/Microsoft/TypeScript/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/Microsoft/tslib.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://www.typescriptlang.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "zen-observable-ts",
+      "version": "1.2.5",
+      "bom-ref": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git",
+      "description": "Thin wrapper around zen-observable and @types/zen-observable, to support ESM exports as well as CommonJS exports",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/apollographql/zen-observable-ts/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/apollographql/zen-observable-ts.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/apollographql/zen-observable-ts#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "BomRef.4tr145qmr6.h37d6puhmrg",
+      "dependsOn": [
+        "BomRef.c49mpkd3av8.2b96ig8fht",
+        "BomRef.ddr00cbef2.8r5g0vmule",
+        "BomRef.g0udgt6fms8.bkfe7epe6ig",
+        "BomRef.jmn9l08pju8.ll7otmvv5so",
+        "BomRef.nbn3ubl6ad8.02qm3u9084g",
+        "BomRef.q2o6bg52qe.ul3d64bi1m",
+        "BomRef.ra25hqjpjj.qd39m0goeco",
+        "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "BomRef.c49mpkd3av8.2b96ig8fht",
+      "dependsOn": [
+        "BomRef.ddr00cbef2.8r5g0vmule",
+        "BomRef.nbn3ubl6ad8.02qm3u9084g",
+        "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "BomRef.clc590ats4g.1t3ctsrldoo",
+      "dependsOn": [
+        "BomRef.ddr00cbef2.8r5g0vmule",
+        "BomRef.nbn3ubl6ad8.02qm3u9084g",
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
+      ]
+    },
+    {
+      "ref": "BomRef.ddr00cbef2.8r5g0vmule",
+      "dependsOn": [
+        "BomRef.nbn3ubl6ad8.02qm3u9084g",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "BomRef.g0udgt6fms8.bkfe7epe6ig",
+      "dependsOn": [
+        "BomRef.ddr00cbef2.8r5g0vmule",
+        "BomRef.nbn3ubl6ad8.02qm3u9084g",
+        "BomRef.q2o6bg52qe.ul3d64bi1m",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "BomRef.i8j9uhc2i98.lhc3kojg9a",
+      "dependsOn": [
+        "BomRef.4tr145qmr6.h37d6puhmrg",
+        "BomRef.clc590ats4g.1t3ctsrldoo",
+        "BomRef.ddr00cbef2.8r5g0vmule",
+        "BomRef.nbn3ubl6ad8.02qm3u9084g",
+        "BomRef.oc4prune9u8.sq9224s7c8g",
+        "BomRef.ra25hqjpjj.qd39m0goeco",
+        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "BomRef.jmn9l08pju8.ll7otmvv5so",
+      "dependsOn": [
+        "BomRef.ddr00cbef2.8r5g0vmule",
+        "BomRef.g0udgt6fms8.bkfe7epe6ig",
+        "BomRef.nbn3ubl6ad8.02qm3u9084g",
+        "BomRef.q2o6bg52qe.ul3d64bi1m",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "BomRef.nbn3ubl6ad8.02qm3u9084g",
+      "dependsOn": [
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+        "pkg:npm/ts-invariant%2Fprocess"
+      ]
+    },
+    {
+      "ref": "BomRef.oc4prune9u8.sq9224s7c8g",
+      "dependsOn": [
+        "BomRef.nbn3ubl6ad8.02qm3u9084g"
+      ]
+    },
+    {
+      "ref": "BomRef.q2o6bg52qe.ul3d64bi1m",
+      "dependsOn": [
+        "BomRef.ddr00cbef2.8r5g0vmule",
+        "BomRef.nbn3ubl6ad8.02qm3u9084g",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "BomRef.ra25hqjpjj.qd39m0goeco",
+      "dependsOn": [
+        "BomRef.ddr00cbef2.8r5g0vmule",
+        "BomRef.nbn3ubl6ad8.02qm3u9084g",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client",
+      "dependsOn": [
+        "BomRef.clc590ats4g.1t3ctsrldoo",
+        "BomRef.i8j9uhc2i98.lhc3kojg9a",
+        "BomRef.nbn3ubl6ad8.02qm3u9084g",
+        "BomRef.oc4prune9u8.sq9224s7c8g"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+      "dependsOn": [
+        "BomRef.4tr145qmr6.h37d6puhmrg",
+        "pkg:npm/%40apollo/client"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"
+    },
+    {
+      "ref": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"
+    },
+    {
+      "ref": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"
+    },
+    {
+      "ref": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
+      "dependsOn": [
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"
+    },
+    {
+      "ref": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
+      "dependsOn": [
+        "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
+    },
+    {
+      "ref": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git"
+    },
+    {
+      "ref": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+      "dependsOn": [
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/ts-invariant%2Fprocess"
+    },
+    {
+      "ref": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+    },
+    {
+      "ref": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+    }
+  ]
+}"
+`;
+
+exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1">
+  <metadata>
+    <tools>
+      <tool>
+        <vendor>@cyclonedx</vendor>
+        <name>cyclonedx-library</name>
+        <version>libVersion-testing</version>
+        <externalReferences>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-javascript-library/issues</url>
+            <comment>as detected from PackageJson property "bugs.url"</comment>
+          </reference>
+          <reference type="vcs">
+            <url>git+https://github.com/CycloneDX/cyclonedx-javascript-library.git</url>
+            <comment>as detected from PackageJson property "repository.url"</comment>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-javascript-library#readme</url>
+            <comment>as detected from PackageJson property "homepage"</comment>
+          </reference>
+        </externalReferences>
+      </tool>
+      <tool>
+        <vendor>@cyclonedx</vendor>
+        <name>webpack-plugin</name>
+        <version>thisVersion-testing</version>
+        <externalReferences>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
+            <comment>as detected from PackageJson property "bugs.url"</comment>
+          </reference>
+          <reference type="vcs">
+            <url>git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git</url>
+            <comment>as detected from PackageJson property "repository.url"</comment>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme</url>
+            <comment>as detected from PackageJson property "homepage"</comment>
+          </reference>
+        </externalReferences>
+      </tool>
+    </tools>
+    <component type="application" bom-ref="pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745">
+      <author>Jan Kowalleck</author>
+      <group>@cyclonedx-weboack-plugin-tests</group>
+      <name>regression-issue745</name>
+      <description>example setup for issue#745</description>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745</url>
+          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/tree/master/tests/integration/regression-issue745#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="BomRef.2coo4jadono.f3462oemnko">
+      <group>@apollo</group>
+      <name>client</name>
+      <purl>pkg:npm/%40apollo/client</purl>
+    </component>
+    <component type="library" bom-ref="BomRef.am4lm237ol.g4raeovugog">
+      <group>@apollo</group>
+      <name>client</name>
+      <purl>pkg:npm/%40apollo/client</purl>
+    </component>
+    <component type="library" bom-ref="BomRef.joepd1q1eko.64qp3m29sd8">
+      <group>@apollo</group>
+      <name>client</name>
+      <purl>pkg:npm/%40apollo/client</purl>
+    </component>
+    <component type="library" bom-ref="BomRef.kskhg402i6g.44l26rjdoc">
+      <group>@apollo</group>
+      <name>client</name>
+      <purl>pkg:npm/%40apollo/client</purl>
+    </component>
+    <component type="library" bom-ref="BomRef.mjt7cod22s.cl0ae3fb5ug">
+      <group>@apollo</group>
+      <name>client</name>
+      <purl>pkg:npm/%40apollo/client</purl>
+    </component>
+    <component type="library" bom-ref="BomRef.qdi0hames6o.at7jeig2pco">
+      <group>@apollo</group>
+      <name>client</name>
+      <purl>pkg:npm/%40apollo/client</purl>
+    </component>
+    <component type="library" bom-ref="BomRef.rdd0ted4bc8.n8i7k3j6nvg">
+      <group>@apollo</group>
+      <name>client</name>
+      <purl>pkg:npm/%40apollo/client</purl>
+    </component>
+    <component type="library" bom-ref="BomRef.s72ha53pguo.cp6nbvk0j9g">
+      <group>@apollo</group>
+      <name>client</name>
+      <purl>pkg:npm/%40apollo/client</purl>
+    </component>
+    <component type="library" bom-ref="BomRef.tq2q7rrh9r.rc9dj91ocp">
+      <group>@apollo</group>
+      <name>client</name>
+      <purl>pkg:npm/%40apollo/client</purl>
+    </component>
+    <component type="library" bom-ref="BomRef.u29qci2oc2o.u6g8u00bdm">
+      <group>@apollo</group>
+      <name>client</name>
+      <purl>pkg:npm/%40apollo/client</purl>
+    </component>
+    <component type="library" bom-ref="BomRef.vqr4bvoar0g.su5krk9r04o">
+      <group>@apollo</group>
+      <name>client</name>
+      <purl>pkg:npm/%40apollo/client</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40apollo/client">
+      <group>@apollo</group>
+      <name>client</name>
+      <purl>pkg:npm/%40apollo/client</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git">
+      <author>packages@apollographql.com</author>
+      <group>@apollo</group>
+      <name>client</name>
+      <version>3.7.10</version>
+      <description>A fully-featured caching GraphQL client.</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/apollographql/apollo-client/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/apollographql/apollo-client.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://www.apollographql.com/docs/react/</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git">
+      <author>Ben Newman</author>
+      <group>@wry</group>
+      <name>context</name>
+      <version>0.7.0</version>
+      <description>Manage contextual information needed by (a)synchronous tasks without explicitly passing objects around</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/benjamn/wryware/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/benjamn/wryware.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/benjamn/wryware</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git">
+      <author>Ben Newman</author>
+      <group>@wry</group>
+      <name>equality</name>
+      <version>0.5.3</version>
+      <description>Structural equality checking for JavaScript values</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/benjamn/wryware/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/benjamn/wryware.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/benjamn/wryware</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git">
+      <author>Ben Newman</author>
+      <group>@wry</group>
+      <name>trie</name>
+      <version>0.3.2</version>
+      <description>https://en.wikipedia.org/wiki/Trie</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/benjamn/wryware/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/benjamn/wryware.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/benjamn/wryware</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git">
+      <name>graphql-tag</name>
+      <version>2.12.6</version>
+      <description>A JavaScript template literal tag that parses GraphQL queries</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/apollographql/graphql-tag/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/apollographql/graphql-tag.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/apollographql/graphql-tag#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git">
+      <name>graphql</name>
+      <version>16.6.0</version>
+      <description>A Query Language and Runtime which can target any service.</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/graphql/graphql-js/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/graphql/graphql-js.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/graphql/graphql-js</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git">
+      <author>Ben Newman</author>
+      <name>optimism</name>
+      <version>0.16.2</version>
+      <description>Composable reactive caching with efficient invalidation.</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/benjamn/optimism/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/benjamn/optimism.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/benjamn/optimism#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react">
+      <name>react</name>
+      <version>18.2.0</version>
+      <description>React is a JavaScript library for building user interfaces.</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/facebook/react/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/facebook/react.git#packages/react</url>
+          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://reactjs.org/</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git">
+      <author>Ben Lesh</author>
+      <name>symbol-observable</name>
+      <version>4.0.0</version>
+      <description>Symbol.observable ponyfill</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/blesh/symbol-observable/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/blesh/symbol-observable.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/blesh/symbol-observable#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git">
+      <author>Ben Newman</author>
+      <name>ts-invariant</name>
+      <version>0.10.3</version>
+      <description>TypeScript implementation of invariant(condition, message)</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/apollographql/invariant-packages/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/apollographql/invariant-packages.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/apollographql/invariant-packages</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:npm/ts-invariant%2Fprocess">
+      <name>ts-invariant/process</name>
+      <purl>pkg:npm/ts-invariant%2Fprocess</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git">
+      <author>Microsoft Corp.</author>
+      <name>tslib</name>
+      <version>2.5.0</version>
+      <description>Runtime library for TypeScript helper functions</description>
+      <licenses>
+        <license>
+          <id>0BSD</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/Microsoft/TypeScript/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/Microsoft/tslib.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://www.typescriptlang.org/</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git">
+      <name>zen-observable-ts</name>
+      <version>1.2.5</version>
+      <description>Thin wrapper around zen-observable and @types/zen-observable, to support ESM exports as well as CommonJS exports</description>
+      <licenses>
+        <license>
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/apollographql/zen-observable-ts/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/apollographql/zen-observable-ts.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/apollographql/zen-observable-ts#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="BomRef.2coo4jadono.f3462oemnko">
+      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
+      <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug"/>
+      <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"/>
+    </dependency>
+    <dependency ref="BomRef.am4lm237ol.g4raeovugog">
+      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
+      <dependency ref="pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git"/>
+      <dependency ref="pkg:npm/ts-invariant%2Fprocess"/>
+    </dependency>
+    <dependency ref="BomRef.joepd1q1eko.64qp3m29sd8">
+      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
+      <dependency ref="BomRef.kskhg402i6g.44l26rjdoc"/>
+      <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug"/>
+      <dependency ref="BomRef.qdi0hames6o.at7jeig2pco"/>
+      <dependency ref="BomRef.tq2q7rrh9r.rc9dj91ocp"/>
+      <dependency ref="BomRef.u29qci2oc2o.u6g8u00bdm"/>
+      <dependency ref="BomRef.vqr4bvoar0g.su5krk9r04o"/>
+      <dependency ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git"/>
+      <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
+      <dependency ref="pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git"/>
+      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
+      <dependency ref="pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
+    </dependency>
+    <dependency ref="BomRef.kskhg402i6g.44l26rjdoc">
+      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
+      <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+    </dependency>
+    <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug">
+      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
+      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
+      <dependency ref="pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
+    </dependency>
+    <dependency ref="BomRef.qdi0hames6o.at7jeig2pco">
+      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
+      <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug"/>
+      <dependency ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
+      <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
+      <dependency ref="pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
+      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
+      <dependency ref="pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+    </dependency>
+    <dependency ref="BomRef.rdd0ted4bc8.n8i7k3j6nvg">
+      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
+    </dependency>
+    <dependency ref="BomRef.s72ha53pguo.cp6nbvk0j9g">
+      <dependency ref="BomRef.2coo4jadono.f3462oemnko"/>
+      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
+      <dependency ref="BomRef.joepd1q1eko.64qp3m29sd8"/>
+      <dependency ref="BomRef.kskhg402i6g.44l26rjdoc"/>
+      <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug"/>
+      <dependency ref="BomRef.rdd0ted4bc8.n8i7k3j6nvg"/>
+      <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
+      <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+    </dependency>
+    <dependency ref="BomRef.tq2q7rrh9r.rc9dj91ocp">
+      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
+      <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
+    </dependency>
+    <dependency ref="BomRef.u29qci2oc2o.u6g8u00bdm">
+      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
+      <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug"/>
+      <dependency ref="BomRef.tq2q7rrh9r.rc9dj91ocp"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
+    </dependency>
+    <dependency ref="BomRef.vqr4bvoar0g.su5krk9r04o">
+      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
+      <dependency ref="BomRef.mjt7cod22s.cl0ae3fb5ug"/>
+      <dependency ref="BomRef.tq2q7rrh9r.rc9dj91ocp"/>
+      <dependency ref="BomRef.u29qci2oc2o.u6g8u00bdm"/>
+      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
+    </dependency>
+    <dependency ref="pkg:npm/%40apollo/client">
+      <dependency ref="BomRef.2coo4jadono.f3462oemnko"/>
+      <dependency ref="BomRef.am4lm237ol.g4raeovugog"/>
+      <dependency ref="BomRef.rdd0ted4bc8.n8i7k3j6nvg"/>
+      <dependency ref="BomRef.s72ha53pguo.cp6nbvk0j9g"/>
+    </dependency>
+    <dependency ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git">
+      <dependency ref="BomRef.joepd1q1eko.64qp3m29sd8"/>
+      <dependency ref="pkg:npm/%40apollo/client"/>
+    </dependency>
+    <dependency ref="pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745">
+      <dependency ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git"/>
+    </dependency>
+    <dependency ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
+    <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
+    <dependency ref="pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
+    <dependency ref="pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git">
+      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+    </dependency>
+    <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
+    <dependency ref="pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git">
+      <dependency ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
+      <dependency ref="pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
+    </dependency>
+    <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"/>
+    <dependency ref="pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git"/>
+    <dependency ref="pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git">
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+    </dependency>
+    <dependency ref="pkg:npm/ts-invariant%2Fprocess"/>
+    <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+    <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
   </dependencies>
 </bom>"
 `;

--- a/tests/integration/__snapshots__/index.test.js.snap
+++ b/tests/integration/__snapshots__/index.test.js.snap
@@ -2289,90 +2289,6 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.1v6i7c2p2d.o6oj54aujq",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.2uuhgjkqm4.44rbt5qa92",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.574bgaaihho.ra6niip10oo",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.9nfeuv9mls8.fknbfl7qqio",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.a4pdmbhdu4o.gr9hlr64lk",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.bsjllu46o3g.6n1jcl11nt8",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.cujqv1hiht.k61uu3mgbjo",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.deq9qishqr.aranrud11po",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.estn8etubf8.d3tbol05nqo",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.snpcft3603.8567r648g4",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.vkrv75rojg.kp7bht4v6u8",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "pkg:npm/%40apollo/client",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
       "version": "3.7.10",
       "bom-ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
       "author": "packages@apollographql.com",
@@ -2402,6 +2318,90 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
       ]
+    },
+    {
+      "type": "library",
+      "name": "client/cache",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Fcache",
+      "purl": "pkg:npm/%40apollo/client%2Fcache"
+    },
+    {
+      "type": "library",
+      "name": "client/core",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Fcore",
+      "purl": "pkg:npm/%40apollo/client%2Fcore"
+    },
+    {
+      "type": "library",
+      "name": "client/errors",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Ferrors",
+      "purl": "pkg:npm/%40apollo/client%2Ferrors"
+    },
+    {
+      "type": "library",
+      "name": "client/link/core",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Flink%2Fcore",
+      "purl": "pkg:npm/%40apollo/client%2Flink%2Fcore"
+    },
+    {
+      "type": "library",
+      "name": "client/link/http",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Flink%2Fhttp",
+      "purl": "pkg:npm/%40apollo/client%2Flink%2Fhttp"
+    },
+    {
+      "type": "library",
+      "name": "client/link/utils",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Flink%2Futils",
+      "purl": "pkg:npm/%40apollo/client%2Flink%2Futils"
+    },
+    {
+      "type": "library",
+      "name": "client/react",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Freact",
+      "purl": "pkg:npm/%40apollo/client%2Freact"
+    },
+    {
+      "type": "library",
+      "name": "client/react/context",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Freact%2Fcontext",
+      "purl": "pkg:npm/%40apollo/client%2Freact%2Fcontext"
+    },
+    {
+      "type": "library",
+      "name": "client/react/hooks",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Freact%2Fhooks",
+      "purl": "pkg:npm/%40apollo/client%2Freact%2Fhooks"
+    },
+    {
+      "type": "library",
+      "name": "client/react/parser",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Freact%2Fparser",
+      "purl": "pkg:npm/%40apollo/client%2Freact%2Fparser"
+    },
+    {
+      "type": "library",
+      "name": "client/utilities",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Futilities",
+      "purl": "pkg:npm/%40apollo/client%2Futilities"
+    },
+    {
+      "type": "library",
+      "name": "client/utilities/globals",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+      "purl": "pkg:npm/%40apollo/client%2Futilities%2Fglobals"
     },
     {
       "type": "library",
@@ -2774,94 +2774,17 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
   ],
   "dependencies": [
     {
-      "ref": "BomRef.1v6i7c2p2d.o6oj54aujq",
+      "ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
       "dependsOn": [
-        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
-        "BomRef.cujqv1hiht.k61uu3mgbjo",
-        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
+        "pkg:npm/%40apollo/client%2Fcore",
+        "pkg:npm/%40apollo/client%2Freact"
       ]
     },
     {
-      "ref": "BomRef.2uuhgjkqm4.44rbt5qa92",
+      "ref": "pkg:npm/%40apollo/client%2Fcache",
       "dependsOn": [
-        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
-        "BomRef.cujqv1hiht.k61uu3mgbjo",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
-      ]
-    },
-    {
-      "ref": "BomRef.574bgaaihho.ra6niip10oo",
-      "dependsOn": [
-        "BomRef.a4pdmbhdu4o.gr9hlr64lk"
-      ]
-    },
-    {
-      "ref": "BomRef.9nfeuv9mls8.fknbfl7qqio",
-      "dependsOn": [
-        "BomRef.2uuhgjkqm4.44rbt5qa92",
-        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
-        "BomRef.cujqv1hiht.k61uu3mgbjo",
-        "BomRef.vkrv75rojg.kp7bht4v6u8",
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
-      ]
-    },
-    {
-      "ref": "BomRef.a4pdmbhdu4o.gr9hlr64lk",
-      "dependsOn": [
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
-        "pkg:npm/ts-invariant%2Fprocess"
-      ]
-    },
-    {
-      "ref": "BomRef.bsjllu46o3g.6n1jcl11nt8",
-      "dependsOn": [
-        "BomRef.1v6i7c2p2d.o6oj54aujq",
-        "BomRef.574bgaaihho.ra6niip10oo",
-        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
-        "BomRef.deq9qishqr.aranrud11po"
-      ]
-    },
-    {
-      "ref": "BomRef.cujqv1hiht.k61uu3mgbjo",
-      "dependsOn": [
-        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
-      ]
-    },
-    {
-      "ref": "BomRef.deq9qishqr.aranrud11po",
-      "dependsOn": [
-        "BomRef.1v6i7c2p2d.o6oj54aujq",
-        "BomRef.574bgaaihho.ra6niip10oo",
-        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
-        "BomRef.cujqv1hiht.k61uu3mgbjo",
-        "BomRef.estn8etubf8.d3tbol05nqo",
-        "pkg:npm/%40apollo/client",
-        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
-      ]
-    },
-    {
-      "ref": "BomRef.estn8etubf8.d3tbol05nqo",
-      "dependsOn": [
-        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
-        "BomRef.cujqv1hiht.k61uu3mgbjo",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
-      ]
-    },
-    {
-      "ref": "BomRef.snpcft3603.8567r648g4",
-      "dependsOn": [
-        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
-        "BomRef.cujqv1hiht.k61uu3mgbjo",
+        "pkg:npm/%40apollo/client%2Futilities",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
         "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
         "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
         "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
@@ -2871,26 +2794,16 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       ]
     },
     {
-      "ref": "BomRef.vkrv75rojg.kp7bht4v6u8",
+      "ref": "pkg:npm/%40apollo/client%2Fcore",
       "dependsOn": [
-        "BomRef.2uuhgjkqm4.44rbt5qa92",
-        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
-        "BomRef.cujqv1hiht.k61uu3mgbjo",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
-      ]
-    },
-    {
-      "ref": "pkg:npm/%40apollo/client",
-      "dependsOn": [
-        "BomRef.2uuhgjkqm4.44rbt5qa92",
-        "BomRef.9nfeuv9mls8.fknbfl7qqio",
-        "BomRef.a4pdmbhdu4o.gr9hlr64lk",
-        "BomRef.cujqv1hiht.k61uu3mgbjo",
-        "BomRef.estn8etubf8.d3tbol05nqo",
-        "BomRef.snpcft3603.8567r648g4",
-        "BomRef.vkrv75rojg.kp7bht4v6u8",
         "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+        "pkg:npm/%40apollo/client%2Fcache",
+        "pkg:npm/%40apollo/client%2Ferrors",
+        "pkg:npm/%40apollo/client%2Flink%2Fcore",
+        "pkg:npm/%40apollo/client%2Flink%2Fhttp",
+        "pkg:npm/%40apollo/client%2Flink%2Futils",
+        "pkg:npm/%40apollo/client%2Futilities",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
         "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
         "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
         "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
@@ -2900,10 +2813,97 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       ]
     },
     {
-      "ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+      "ref": "pkg:npm/%40apollo/client%2Ferrors",
       "dependsOn": [
-        "BomRef.bsjllu46o3g.6n1jcl11nt8",
-        "pkg:npm/%40apollo/client"
+        "pkg:npm/%40apollo/client%2Futilities",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Flink%2Fcore",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client%2Flink%2Futils",
+        "pkg:npm/%40apollo/client%2Futilities",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Flink%2Fhttp",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client%2Flink%2Fcore",
+        "pkg:npm/%40apollo/client%2Flink%2Futils",
+        "pkg:npm/%40apollo/client%2Futilities",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Flink%2Futils",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client%2Futilities",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Freact",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client%2Freact%2Fcontext",
+        "pkg:npm/%40apollo/client%2Freact%2Fhooks",
+        "pkg:npm/%40apollo/client%2Freact%2Fparser",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Freact%2Fcontext",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client%2Futilities",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Freact%2Fhooks",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client%2Fcore",
+        "pkg:npm/%40apollo/client%2Ferrors",
+        "pkg:npm/%40apollo/client%2Freact%2Fcontext",
+        "pkg:npm/%40apollo/client%2Freact%2Fparser",
+        "pkg:npm/%40apollo/client%2Futilities",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Freact%2Fparser",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Futilities",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+      "dependsOn": [
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+        "pkg:npm/ts-invariant%2Fprocess"
       ]
     },
     {
@@ -3055,90 +3055,6 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       "type": "library",
       "name": "client",
       "group": "@apollo",
-      "bom-ref": "BomRef.1qqa5gucsr8.m004ottvl2o",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.303qa2m92h.9ugke721j48",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.5jvbn6rdado.2leb9vrajdo",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.8jiivt537hg.r634smm6lto",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.b47547ah6u8.8obnf9068qo",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.hf4dtphovdo.4i4nr20p5dg",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.iecpj4e1vr.dd6kdf9kv8g",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.in07cbh914g.tt3pobvo9pg",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.kn8sqe77nk8.46sq28j9048",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.t8spi8bsjio.gllnu01au48",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "BomRef.tung50etti.dltr2j5rav8",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
-      "bom-ref": "pkg:npm/%40apollo/client",
-      "purl": "pkg:npm/%40apollo/client"
-    },
-    {
-      "type": "library",
-      "name": "client",
-      "group": "@apollo",
       "version": "3.7.10",
       "bom-ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
       "author": "packages@apollographql.com",
@@ -3168,6 +3084,90 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
       ]
+    },
+    {
+      "type": "library",
+      "name": "client/cache",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Fcache",
+      "purl": "pkg:npm/%40apollo/client%2Fcache"
+    },
+    {
+      "type": "library",
+      "name": "client/core",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Fcore",
+      "purl": "pkg:npm/%40apollo/client%2Fcore"
+    },
+    {
+      "type": "library",
+      "name": "client/errors",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Ferrors",
+      "purl": "pkg:npm/%40apollo/client%2Ferrors"
+    },
+    {
+      "type": "library",
+      "name": "client/link/core",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Flink%2Fcore",
+      "purl": "pkg:npm/%40apollo/client%2Flink%2Fcore"
+    },
+    {
+      "type": "library",
+      "name": "client/link/http",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Flink%2Fhttp",
+      "purl": "pkg:npm/%40apollo/client%2Flink%2Fhttp"
+    },
+    {
+      "type": "library",
+      "name": "client/link/utils",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Flink%2Futils",
+      "purl": "pkg:npm/%40apollo/client%2Flink%2Futils"
+    },
+    {
+      "type": "library",
+      "name": "client/react",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Freact",
+      "purl": "pkg:npm/%40apollo/client%2Freact"
+    },
+    {
+      "type": "library",
+      "name": "client/react/context",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Freact%2Fcontext",
+      "purl": "pkg:npm/%40apollo/client%2Freact%2Fcontext"
+    },
+    {
+      "type": "library",
+      "name": "client/react/hooks",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Freact%2Fhooks",
+      "purl": "pkg:npm/%40apollo/client%2Freact%2Fhooks"
+    },
+    {
+      "type": "library",
+      "name": "client/react/parser",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Freact%2Fparser",
+      "purl": "pkg:npm/%40apollo/client%2Freact%2Fparser"
+    },
+    {
+      "type": "library",
+      "name": "client/utilities",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Futilities",
+      "purl": "pkg:npm/%40apollo/client%2Futilities"
+    },
+    {
+      "type": "library",
+      "name": "client/utilities/globals",
+      "group": "@apollo",
+      "bom-ref": "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+      "purl": "pkg:npm/%40apollo/client%2Futilities%2Fglobals"
     },
     {
       "type": "library",
@@ -3540,104 +3540,17 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
   ],
   "dependencies": [
     {
-      "ref": "BomRef.1qqa5gucsr8.m004ottvl2o",
+      "ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
       "dependsOn": [
-        "BomRef.in07cbh914g.tt3pobvo9pg",
-        "BomRef.t8spi8bsjio.gllnu01au48",
-        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
+        "pkg:npm/%40apollo/client%2Fcore",
+        "pkg:npm/%40apollo/client%2Freact"
       ]
     },
     {
-      "ref": "BomRef.303qa2m92h.9ugke721j48",
+      "ref": "pkg:npm/%40apollo/client%2Fcache",
       "dependsOn": [
-        "BomRef.t8spi8bsjio.gllnu01au48"
-      ]
-    },
-    {
-      "ref": "BomRef.5jvbn6rdado.2leb9vrajdo",
-      "dependsOn": [
-        "BomRef.in07cbh914g.tt3pobvo9pg",
-        "BomRef.t8spi8bsjio.gllnu01au48",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
-      ]
-    },
-    {
-      "ref": "BomRef.8jiivt537hg.r634smm6lto",
-      "dependsOn": [
-        "BomRef.1qqa5gucsr8.m004ottvl2o",
-        "BomRef.303qa2m92h.9ugke721j48",
-        "BomRef.hf4dtphovdo.4i4nr20p5dg",
-        "BomRef.in07cbh914g.tt3pobvo9pg",
-        "BomRef.t8spi8bsjio.gllnu01au48",
-        "pkg:npm/%40apollo/client",
-        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
-      ]
-    },
-    {
-      "ref": "BomRef.b47547ah6u8.8obnf9068qo",
-      "dependsOn": [
-        "BomRef.5jvbn6rdado.2leb9vrajdo",
-        "BomRef.in07cbh914g.tt3pobvo9pg",
-        "BomRef.kn8sqe77nk8.46sq28j9048",
-        "BomRef.t8spi8bsjio.gllnu01au48",
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
-      ]
-    },
-    {
-      "ref": "BomRef.hf4dtphovdo.4i4nr20p5dg",
-      "dependsOn": [
-        "BomRef.in07cbh914g.tt3pobvo9pg",
-        "BomRef.t8spi8bsjio.gllnu01au48",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
-      ]
-    },
-    {
-      "ref": "BomRef.iecpj4e1vr.dd6kdf9kv8g",
-      "dependsOn": [
-        "BomRef.1qqa5gucsr8.m004ottvl2o",
-        "BomRef.303qa2m92h.9ugke721j48",
-        "BomRef.8jiivt537hg.r634smm6lto",
-        "BomRef.t8spi8bsjio.gllnu01au48"
-      ]
-    },
-    {
-      "ref": "BomRef.in07cbh914g.tt3pobvo9pg",
-      "dependsOn": [
-        "BomRef.t8spi8bsjio.gllnu01au48",
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
-      ]
-    },
-    {
-      "ref": "BomRef.kn8sqe77nk8.46sq28j9048",
-      "dependsOn": [
-        "BomRef.5jvbn6rdado.2leb9vrajdo",
-        "BomRef.in07cbh914g.tt3pobvo9pg",
-        "BomRef.t8spi8bsjio.gllnu01au48",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
-      ]
-    },
-    {
-      "ref": "BomRef.t8spi8bsjio.gllnu01au48",
-      "dependsOn": [
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
-        "pkg:npm/ts-invariant%2Fprocess"
-      ]
-    },
-    {
-      "ref": "BomRef.tung50etti.dltr2j5rav8",
-      "dependsOn": [
-        "BomRef.in07cbh914g.tt3pobvo9pg",
-        "BomRef.t8spi8bsjio.gllnu01au48",
+        "pkg:npm/%40apollo/client%2Futilities",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
         "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
         "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
         "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
@@ -3647,16 +3560,16 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       ]
     },
     {
-      "ref": "pkg:npm/%40apollo/client",
+      "ref": "pkg:npm/%40apollo/client%2Fcore",
       "dependsOn": [
-        "BomRef.5jvbn6rdado.2leb9vrajdo",
-        "BomRef.b47547ah6u8.8obnf9068qo",
-        "BomRef.hf4dtphovdo.4i4nr20p5dg",
-        "BomRef.in07cbh914g.tt3pobvo9pg",
-        "BomRef.kn8sqe77nk8.46sq28j9048",
-        "BomRef.t8spi8bsjio.gllnu01au48",
-        "BomRef.tung50etti.dltr2j5rav8",
         "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+        "pkg:npm/%40apollo/client%2Fcache",
+        "pkg:npm/%40apollo/client%2Ferrors",
+        "pkg:npm/%40apollo/client%2Flink%2Fcore",
+        "pkg:npm/%40apollo/client%2Flink%2Fhttp",
+        "pkg:npm/%40apollo/client%2Flink%2Futils",
+        "pkg:npm/%40apollo/client%2Futilities",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
         "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
         "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
         "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
@@ -3666,10 +3579,97 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       ]
     },
     {
-      "ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+      "ref": "pkg:npm/%40apollo/client%2Ferrors",
       "dependsOn": [
-        "BomRef.iecpj4e1vr.dd6kdf9kv8g",
-        "pkg:npm/%40apollo/client"
+        "pkg:npm/%40apollo/client%2Futilities",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Flink%2Fcore",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client%2Flink%2Futils",
+        "pkg:npm/%40apollo/client%2Futilities",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Flink%2Fhttp",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client%2Flink%2Fcore",
+        "pkg:npm/%40apollo/client%2Flink%2Futils",
+        "pkg:npm/%40apollo/client%2Futilities",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Flink%2Futils",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client%2Futilities",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Freact",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client%2Freact%2Fcontext",
+        "pkg:npm/%40apollo/client%2Freact%2Fhooks",
+        "pkg:npm/%40apollo/client%2Freact%2Fparser",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Freact%2Fcontext",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client%2Futilities",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Freact%2Fhooks",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client%2Fcore",
+        "pkg:npm/%40apollo/client%2Ferrors",
+        "pkg:npm/%40apollo/client%2Freact%2Fcontext",
+        "pkg:npm/%40apollo/client%2Freact%2Fparser",
+        "pkg:npm/%40apollo/client%2Futilities",
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Freact%2Fparser",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Futilities",
+      "dependsOn": [
+        "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      ]
+    },
+    {
+      "ref": "pkg:npm/%40apollo/client%2Futilities%2Fglobals",
+      "dependsOn": [
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+        "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+        "pkg:npm/ts-invariant%2Fprocess"
       ]
     },
     {
@@ -3801,66 +3801,6 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="BomRef.0bg0jc9bg0g.l8p1v5626p8">
-      <group>@apollo</group>
-      <name>client</name>
-      <purl>pkg:npm/%40apollo/client</purl>
-    </component>
-    <component type="library" bom-ref="BomRef.45hfu10oka.98iijunc7bg">
-      <group>@apollo</group>
-      <name>client</name>
-      <purl>pkg:npm/%40apollo/client</purl>
-    </component>
-    <component type="library" bom-ref="BomRef.6lfmvv9rggo.ioop0bposb8">
-      <group>@apollo</group>
-      <name>client</name>
-      <purl>pkg:npm/%40apollo/client</purl>
-    </component>
-    <component type="library" bom-ref="BomRef.6pik6fbe0ao.4hro6s214fo">
-      <group>@apollo</group>
-      <name>client</name>
-      <purl>pkg:npm/%40apollo/client</purl>
-    </component>
-    <component type="library" bom-ref="BomRef.ce89fl1bfq.83qbpvv2amg">
-      <group>@apollo</group>
-      <name>client</name>
-      <purl>pkg:npm/%40apollo/client</purl>
-    </component>
-    <component type="library" bom-ref="BomRef.fcdblkggsso.gi923dvudto">
-      <group>@apollo</group>
-      <name>client</name>
-      <purl>pkg:npm/%40apollo/client</purl>
-    </component>
-    <component type="library" bom-ref="BomRef.fi6v6n7lqgg.nf11dk5f7dg">
-      <group>@apollo</group>
-      <name>client</name>
-      <purl>pkg:npm/%40apollo/client</purl>
-    </component>
-    <component type="library" bom-ref="BomRef.fnnm3t4qakg.lsc13rq842o">
-      <group>@apollo</group>
-      <name>client</name>
-      <purl>pkg:npm/%40apollo/client</purl>
-    </component>
-    <component type="library" bom-ref="BomRef.kbok9enj81o.4l9ko1j0egg">
-      <group>@apollo</group>
-      <name>client</name>
-      <purl>pkg:npm/%40apollo/client</purl>
-    </component>
-    <component type="library" bom-ref="BomRef.n339j9o2un8.capjq851t1">
-      <group>@apollo</group>
-      <name>client</name>
-      <purl>pkg:npm/%40apollo/client</purl>
-    </component>
-    <component type="library" bom-ref="BomRef.qk87495vt1.biahsp4eje8">
-      <group>@apollo</group>
-      <name>client</name>
-      <purl>pkg:npm/%40apollo/client</purl>
-    </component>
-    <component type="library" bom-ref="pkg:npm/%40apollo/client">
-      <group>@apollo</group>
-      <name>client</name>
-      <purl>pkg:npm/%40apollo/client</purl>
-    </component>
     <component type="library" bom-ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git">
       <author>packages@apollographql.com</author>
       <group>@apollo</group>
@@ -3887,6 +3827,66 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40apollo/client%2Fcache">
+      <group>@apollo</group>
+      <name>client/cache</name>
+      <purl>pkg:npm/%40apollo/client%2Fcache</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40apollo/client%2Fcore">
+      <group>@apollo</group>
+      <name>client/core</name>
+      <purl>pkg:npm/%40apollo/client%2Fcore</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40apollo/client%2Ferrors">
+      <group>@apollo</group>
+      <name>client/errors</name>
+      <purl>pkg:npm/%40apollo/client%2Ferrors</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40apollo/client%2Flink%2Fcore">
+      <group>@apollo</group>
+      <name>client/link/core</name>
+      <purl>pkg:npm/%40apollo/client%2Flink%2Fcore</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40apollo/client%2Flink%2Fhttp">
+      <group>@apollo</group>
+      <name>client/link/http</name>
+      <purl>pkg:npm/%40apollo/client%2Flink%2Fhttp</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40apollo/client%2Flink%2Futils">
+      <group>@apollo</group>
+      <name>client/link/utils</name>
+      <purl>pkg:npm/%40apollo/client%2Flink%2Futils</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40apollo/client%2Freact">
+      <group>@apollo</group>
+      <name>client/react</name>
+      <purl>pkg:npm/%40apollo/client%2Freact</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40apollo/client%2Freact%2Fcontext">
+      <group>@apollo</group>
+      <name>client/react/context</name>
+      <purl>pkg:npm/%40apollo/client%2Freact%2Fcontext</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40apollo/client%2Freact%2Fhooks">
+      <group>@apollo</group>
+      <name>client/react/hooks</name>
+      <purl>pkg:npm/%40apollo/client%2Freact%2Fhooks</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40apollo/client%2Freact%2Fparser">
+      <group>@apollo</group>
+      <name>client/react/parser</name>
+      <purl>pkg:npm/%40apollo/client%2Freact%2Fparser</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40apollo/client%2Futilities">
+      <group>@apollo</group>
+      <name>client/utilities</name>
+      <purl>pkg:npm/%40apollo/client%2Futilities</purl>
+    </component>
+    <component type="library" bom-ref="pkg:npm/%40apollo/client%2Futilities%2Fglobals">
+      <group>@apollo</group>
+      <name>client/utilities/globals</name>
+      <purl>pkg:npm/%40apollo/client%2Futilities%2Fglobals</purl>
     </component>
     <component type="library" bom-ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git">
       <author>Ben Newman</author>
@@ -4179,67 +4179,13 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
     </component>
   </components>
   <dependencies>
-    <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8">
-      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
-      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
-      <dependency ref="pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git"/>
-      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
+    <dependency ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git">
+      <dependency ref="pkg:npm/%40apollo/client%2Fcore"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Freact"/>
     </dependency>
-    <dependency ref="BomRef.45hfu10oka.98iijunc7bg">
-      <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8"/>
-      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
-      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-    </dependency>
-    <dependency ref="BomRef.6lfmvv9rggo.ioop0bposb8">
-      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
-      <dependency ref="BomRef.fcdblkggsso.gi923dvudto"/>
-      <dependency ref="BomRef.fnnm3t4qakg.lsc13rq842o"/>
-      <dependency ref="BomRef.kbok9enj81o.4l9ko1j0egg"/>
-    </dependency>
-    <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo">
-      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
-      <dependency ref="pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git"/>
-      <dependency ref="pkg:npm/ts-invariant%2Fprocess"/>
-    </dependency>
-    <dependency ref="BomRef.ce89fl1bfq.83qbpvv2amg">
-      <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8"/>
-      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
-      <dependency ref="BomRef.qk87495vt1.biahsp4eje8"/>
-      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
-    </dependency>
-    <dependency ref="BomRef.fcdblkggsso.gi923dvudto">
-      <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8"/>
-      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
-      <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"/>
-    </dependency>
-    <dependency ref="BomRef.fi6v6n7lqgg.nf11dk5f7dg">
-      <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8"/>
-      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
-      <dependency ref="BomRef.ce89fl1bfq.83qbpvv2amg"/>
-      <dependency ref="BomRef.qk87495vt1.biahsp4eje8"/>
-      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
-      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
-    </dependency>
-    <dependency ref="BomRef.fnnm3t4qakg.lsc13rq842o">
-      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
-    </dependency>
-    <dependency ref="BomRef.kbok9enj81o.4l9ko1j0egg">
-      <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8"/>
-      <dependency ref="BomRef.45hfu10oka.98iijunc7bg"/>
-      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
-      <dependency ref="BomRef.fcdblkggsso.gi923dvudto"/>
-      <dependency ref="BomRef.fnnm3t4qakg.lsc13rq842o"/>
-      <dependency ref="pkg:npm/%40apollo/client"/>
-      <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
-      <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"/>
-      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-    </dependency>
-    <dependency ref="BomRef.n339j9o2un8.capjq851t1">
-      <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8"/>
-      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
+    <dependency ref="pkg:npm/%40apollo/client%2Fcache">
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities%2Fglobals"/>
       <dependency ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
       <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
       <dependency ref="pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
@@ -4247,21 +4193,15 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
       <dependency ref="pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git"/>
       <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
     </dependency>
-    <dependency ref="BomRef.qk87495vt1.biahsp4eje8">
-      <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8"/>
-      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
-      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
-    </dependency>
-    <dependency ref="pkg:npm/%40apollo/client">
-      <dependency ref="BomRef.0bg0jc9bg0g.l8p1v5626p8"/>
-      <dependency ref="BomRef.45hfu10oka.98iijunc7bg"/>
-      <dependency ref="BomRef.6pik6fbe0ao.4hro6s214fo"/>
-      <dependency ref="BomRef.ce89fl1bfq.83qbpvv2amg"/>
-      <dependency ref="BomRef.fi6v6n7lqgg.nf11dk5f7dg"/>
-      <dependency ref="BomRef.n339j9o2un8.capjq851t1"/>
-      <dependency ref="BomRef.qk87495vt1.biahsp4eje8"/>
+    <dependency ref="pkg:npm/%40apollo/client%2Fcore">
       <dependency ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Fcache"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Ferrors"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Flink%2Fcore"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Flink%2Fhttp"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Flink%2Futils"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities%2Fglobals"/>
       <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
       <dependency ref="pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git"/>
       <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
@@ -4269,9 +4209,69 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
       <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
       <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
     </dependency>
-    <dependency ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git">
-      <dependency ref="BomRef.6lfmvv9rggo.ioop0bposb8"/>
-      <dependency ref="pkg:npm/%40apollo/client"/>
+    <dependency ref="pkg:npm/%40apollo/client%2Ferrors">
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities%2Fglobals"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+    </dependency>
+    <dependency ref="pkg:npm/%40apollo/client%2Flink%2Fcore">
+      <dependency ref="pkg:npm/%40apollo/client%2Flink%2Futils"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities%2Fglobals"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
+    </dependency>
+    <dependency ref="pkg:npm/%40apollo/client%2Flink%2Fhttp">
+      <dependency ref="pkg:npm/%40apollo/client%2Flink%2Fcore"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Flink%2Futils"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities%2Fglobals"/>
+      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
+    </dependency>
+    <dependency ref="pkg:npm/%40apollo/client%2Flink%2Futils">
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities%2Fglobals"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
+    </dependency>
+    <dependency ref="pkg:npm/%40apollo/client%2Freact">
+      <dependency ref="pkg:npm/%40apollo/client%2Freact%2Fcontext"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Freact%2Fhooks"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Freact%2Fparser"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities%2Fglobals"/>
+    </dependency>
+    <dependency ref="pkg:npm/%40apollo/client%2Freact%2Fcontext">
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities%2Fglobals"/>
+      <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"/>
+    </dependency>
+    <dependency ref="pkg:npm/%40apollo/client%2Freact%2Fhooks">
+      <dependency ref="pkg:npm/%40apollo/client%2Fcore"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Ferrors"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Freact%2Fcontext"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Freact%2Fparser"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities"/>
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities%2Fglobals"/>
+      <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
+      <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+    </dependency>
+    <dependency ref="pkg:npm/%40apollo/client%2Freact%2Fparser">
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities%2Fglobals"/>
+    </dependency>
+    <dependency ref="pkg:npm/%40apollo/client%2Futilities">
+      <dependency ref="pkg:npm/%40apollo/client%2Futilities%2Fglobals"/>
+      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
+      <dependency ref="pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
+    </dependency>
+    <dependency ref="pkg:npm/%40apollo/client%2Futilities%2Fglobals">
+      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
+      <dependency ref="pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git"/>
+      <dependency ref="pkg:npm/ts-invariant%2Fprocess"/>
     </dependency>
     <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745">
       <dependency ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git"/>

--- a/tests/integration/index.test.js
+++ b/tests/integration/index.test.js
@@ -28,9 +28,10 @@ const { version: thisVersion } = require('../../package.json')
 describe('integration', () => {
   describe.each(
     [
+      // region functional
       {
         dir: 'webpack5-vue2',
-        purpose: 'webpack5 with vue2',
+        purpose: 'functional: webpack5 with vue2',
         results: [ // paths relative to `dir`
           {
             format: 'xml',
@@ -48,7 +49,7 @@ describe('integration', () => {
       },
       {
         dir: 'webpack5-angular13',
-        purpose: 'webpack5 with angular13',
+        purpose: 'functional: webpack5 with angular13',
         results: [ // paths relative to `dir`
           {
             format: 'xml',
@@ -66,7 +67,27 @@ describe('integration', () => {
       },
       {
         dir: 'webpack5-react18',
-        purpose: 'webpack5 with react18',
+        purpose: 'functional: webpack5 with react18',
+        results: [ // paths relative to `dir`
+          {
+            format: 'xml',
+            file: 'dist/.bom/bom.xml'
+          },
+          {
+            format: 'json',
+            file: 'dist/.bom/bom.json'
+          },
+          {
+            format: 'json',
+            file: 'dist/.well-known/sbom'
+          }
+        ]
+      },
+      // endregion functional
+      // region regression
+      {
+        dir: 'regression-issue745',
+        purpose: 'regression: issue#745',
         results: [ // paths relative to `dir`
           {
             format: 'xml',
@@ -82,6 +103,7 @@ describe('integration', () => {
           }
         ]
       }
+      // endregion regression
     ]
   )('$purpose', ({ dir, results }) => {
     const built = spawnSync(

--- a/tests/integration/regression-issue745/.gitattributes
+++ b/tests/integration/regression-issue745/.gitattributes
@@ -1,0 +1,1 @@
+** linguist-vendored

--- a/tests/integration/regression-issue745/.gitignore
+++ b/tests/integration/regression-issue745/.gitignore
@@ -1,0 +1,9 @@
+*
+!/.gitignore
+!/.gitattributes
+!/README.md
+!/package.json
+!/package-lock.json
+!/webpack.config.js
+!/src
+!/src/*

--- a/tests/integration/regression-issue745/README.md
+++ b/tests/integration/regression-issue745/README.md
@@ -1,0 +1,10 @@
+# Test: regression [issue#745]
+
+This setup is intended to create reproducible results (SBoM).  
+It might install outdated, unmaintained or vulnerable components, for showcasing purposes.
+
+----
+
+this setup is a regression test for [issue#745].
+
+[issue#745]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues/745#issuecomment-1487012610

--- a/tests/integration/regression-issue745/package-lock.json
+++ b/tests/integration/regression-issue745/package-lock.json
@@ -7,7 +7,8 @@
       "name": "@cyclonedx-weboack-plugin-tests/regression-issue745",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apollo/client": "^3.7.10"
+        "@apollo/client": "3.7.10",
+        "react": "^18.2.0"
       },
       "devDependencies": {
         "@cyclonedx/webpack-plugin": "file:../../..",
@@ -20,6 +21,7 @@
       }
     },
     "../../..": {
+      "name": "@cyclonedx/webpack-plugin",
       "version": "3.4.0",
       "dev": true,
       "funding": [
@@ -1093,6 +1095,17 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {

--- a/tests/integration/regression-issue745/package-lock.json
+++ b/tests/integration/regression-issue745/package-lock.json
@@ -1,0 +1,1580 @@
+{
+  "name": "@cyclonedx-weboack-plugin-tests/regression-issue745",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@cyclonedx-weboack-plugin-tests/regression-issue745",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apollo/client": "^3.7.10"
+      },
+      "devDependencies": {
+        "@cyclonedx/webpack-plugin": "file:../../..",
+        "webpack": "^5.76.0",
+        "webpack-cli": "^4.9.2"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=8"
+      }
+    },
+    "../../..": {
+      "version": "3.4.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jkowalleck"
+        },
+        {
+          "type": "individual",
+          "url": "https://owasp.org/donate/?reponame=www-project-cyclonedx&title=OWASP+CycloneDX"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cyclonedx/cyclonedx-library": "^1.13.0",
+        "normalize-package-data": "^3||^4||^5",
+        "xmlbuilder2": "^3.0.2"
+      },
+      "devDependencies": {
+        "@types/node": ">=14",
+        "@types/normalize-package-data": "^2.4.1",
+        "eslint": "^8.23.0",
+        "eslint-config-standard-with-typescript": "^34.0.0",
+        "eslint-plugin-header": "^3.1.1",
+        "eslint-plugin-simple-import-sort": "^10.0.0",
+        "jest": "^29.5.0",
+        "jest-junit": "^15.0.0",
+        "npm-run-all": "^4.1.5",
+        "typescript": "4.9.5",
+        "webpack": "^5"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "webpack": "^5"
+      }
+    },
+    "node_modules/@apollo/client": {
+      "version": "3.7.10",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.7.10.tgz",
+      "integrity": "sha512-/k1MfrqPKYiPNdHcOzdxg9cEx96vhAGxAcSorzfBvV29XtFQcYW2cPNQOTjK/fpSMtqVo8UNmu5vwQAWD1gfCg==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/context": "^0.7.0",
+        "@wry/equality": "^0.5.0",
+        "@wry/trie": "^0.3.0",
+        "graphql-tag": "^2.12.6",
+        "hoist-non-react-statics": "^3.3.2",
+        "optimism": "^0.16.1",
+        "prop-types": "^15.7.2",
+        "response-iterator": "^0.2.6",
+        "symbol-observable": "^4.0.0",
+        "ts-invariant": "^0.10.3",
+        "tslib": "^2.3.0",
+        "zen-observable-ts": "^1.2.5"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "subscriptions-transport-ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cyclonedx/webpack-plugin": {
+      "resolved": "../../..",
+      "link": true
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@types/eslint": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.3.tgz",
+      "integrity": "sha512-fa7GkppZVEByMWGbTtE5MbmXWJTVbrjjaS8K6uQj+XtuuUv1fsuPAxhygfqLmsb/Ufb3CV8deFCpiMfAgi00Sw==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+      "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "dev": true
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "18.15.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+      "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+      "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+      "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+      "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+      "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+        "@webassemblyjs/helper-api-error": "1.11.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+      "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+      "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+      "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+      "dev": true,
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+      "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+      "dev": true,
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+      "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+      "dev": true
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+      "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/helper-wasm-section": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1",
+        "@webassemblyjs/wasm-opt": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1",
+        "@webassemblyjs/wast-printer": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+      "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/ieee754": "1.11.1",
+        "@webassemblyjs/leb128": "1.11.1",
+        "@webassemblyjs/utf8": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+      "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+      "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-api-error": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/ieee754": "1.11.1",
+        "@webassemblyjs/leb128": "1.11.1",
+        "@webassemblyjs/utf8": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+      "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webpack-cli/configtest": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+      "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
+      "dev": true,
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x",
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/info": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
+      "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
+      "dev": true,
+      "dependencies": {
+        "envinfo": "^7.7.3"
+      },
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/serve": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
+      "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
+      "dev": true,
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wry/context": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.0.tgz",
+      "integrity": "sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/equality": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.3.tgz",
+      "integrity": "sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@wry/trie": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.2.tgz",
+      "integrity": "sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "dev": true
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true
+    },
+    "node_modules/acorn": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-assertions": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001472",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz",
+      "integrity": "sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
+    },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+      "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
+      "dev": true
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.4.342",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.342.tgz",
+      "integrity": "sha512-dTei3VResi5bINDENswBxhL+N0Mw5YnfWyTqO75KGsVldurEkhC9+CelJVAse8jycWyP8pv3VSj4BSyP8wTWJA==",
+      "dev": true
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
+      "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/envinfo": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
+      "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
+      "dev": true,
+      "bin": {
+        "envinfo": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+      "dev": true
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
+    "node_modules/graphql": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
+      "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
+      "dev": true,
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/loader-runner": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
+      "dev": true
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/optimism": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.2.tgz",
+      "integrity": "sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==",
+      "dependencies": {
+        "@wry/context": "^0.7.0",
+        "@wry/trie": "^0.3.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/rechoir": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.9.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/response-iterator": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
+      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/schema-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/symbol-observable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.16.8",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.8.tgz",
+      "integrity": "sha512-QI5g1E/ef7d+PsDifb+a6nnVgC4F22Bg6T0xrBrz6iloVB4PUkkunp6V8nzoOOZJIzjWVdAGqCdlKlhLq/TbIA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz",
+      "integrity": "sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^3.1.1",
+        "serialize-javascript": "^6.0.1",
+        "terser": "^5.16.5"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-invariant": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist-lint": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "dev": true,
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack": {
+      "version": "5.76.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+      "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.3",
+        "@types/estree": "^0.0.51",
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/wasm-edit": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1",
+        "acorn": "^8.7.1",
+        "acorn-import-assertions": "^1.7.6",
+        "browserslist": "^4.14.5",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.10.0",
+        "es-module-lexer": "^0.9.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.9",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.1.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.1.3",
+        "watchpack": "^2.4.0",
+        "webpack-sources": "^3.2.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-cli": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
+      "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
+      "dev": true,
+      "dependencies": {
+        "@discoveryjs/json-ext": "^0.5.0",
+        "@webpack-cli/configtest": "^1.2.0",
+        "@webpack-cli/info": "^1.5.0",
+        "@webpack-cli/serve": "^1.7.0",
+        "colorette": "^2.0.14",
+        "commander": "^7.0.0",
+        "cross-spawn": "^7.0.3",
+        "fastest-levenshtein": "^1.0.12",
+        "import-local": "^3.0.2",
+        "interpret": "^2.2.0",
+        "rechoir": "^0.7.0",
+        "webpack-merge": "^5.7.3"
+      },
+      "bin": {
+        "webpack-cli": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@webpack-cli/generators": {
+          "optional": true
+        },
+        "@webpack-cli/migrate": {
+          "optional": true
+        },
+        "webpack-bundle-analyzer": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-cli/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-merge": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+      "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+      "dev": true,
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wildcard": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
+      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+      "dev": true
+    },
+    "node_modules/zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+    },
+    "node_modules/zen-observable-ts": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
+      "dependencies": {
+        "zen-observable": "0.8.15"
+      }
+    }
+  }
+}

--- a/tests/integration/regression-issue745/package-lock.json
+++ b/tests/integration/regression-issue745/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "@cyclonedx-weboack-plugin-tests/regression-issue745",
+  "name": "@cyclonedx-webpack-plugin-tests/regression-issue745",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@cyclonedx-weboack-plugin-tests/regression-issue745",
+      "name": "@cyclonedx-webpack-plugin-tests/regression-issue745",
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/client": "3.7.10",

--- a/tests/integration/regression-issue745/package.json
+++ b/tests/integration/regression-issue745/package.json
@@ -33,7 +33,8 @@
     "build": "webpack build"
   },
   "dependencies": {
-    "@apollo/client": "3.7.10"
+    "@apollo/client": "3.7.10",
+    "react": "^18.2.0"
   },
   "devDependencies": {
     "@cyclonedx/webpack-plugin": "file:../../..",

--- a/tests/integration/regression-issue745/package.json
+++ b/tests/integration/regression-issue745/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cyclonedx-weboack-plugin-tests/regression-issue745",
+  "name": "@cyclonedx-webpack-plugin-tests/regression-issue745",
   "description": "example setup for issue#745",
   "private": true,
   "type": "commonjs",

--- a/tests/integration/regression-issue745/package.json
+++ b/tests/integration/regression-issue745/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@cyclonedx-weboack-plugin-tests/regression-issue745",
+  "description": "example setup for issue#745",
+  "private": true,
+  "type": "commonjs",
+  "homepage": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/tree/master/tests/integration/regression-issue745#readme",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "Jan Kowalleck",
+    "email": "jan.kowalleck@gmail.com"
+  },
+  "contributors": [
+    {
+      "name": "Jan Kowalleck",
+      "email": "jan.kowalleck@gmail.com"
+    },
+    {
+      "name": "Stefan Resch",
+      "url": "https://github.com/sresch4b"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+    "directory": "tests/integration/regression-issue745"
+  },
+  "bugs": {
+    "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues"
+  },
+  "main": "index.html",
+  "scripts": {
+    "prebuild:node": "node -r fs -e 'fs.rmSync(\"dist\",{recursive:true,force:true})'",
+    "build": "webpack build"
+  },
+  "dependencies": {
+    "@apollo/client": "3.7.10"
+  },
+  "devDependencies": {
+    "@cyclonedx/webpack-plugin": "file:../../..",
+    "webpack": "^5.76.0",
+    "webpack-cli": "^4.9.2"
+  },
+  "engines": {
+    "node": ">=14.0.0",
+    "npm": ">=8"
+  }
+}

--- a/tests/integration/regression-issue745/src/index.js
+++ b/tests/integration/regression-issue745/src/index.js
@@ -1,0 +1,18 @@
+/**
+ * Taken from https://github.com/sresch4b/cyclonedx-issue/blob/961aed0b3a6577a4c76e3ab94420ed4e770497e7/src/index.js
+ * Originally published under MIT license by GIthubUser "sresch4b".
+ */
+
+const { ApolloClient, InMemoryCache } = require('@apollo/client')
+
+function component () {
+  const client = new ApolloClient({
+    uri: 'https://example.com/',
+    cache: new InMemoryCache(),
+  })
+  client.query({ query: '' }).then(() => console.log('test'))
+  const element = document.createElement('div')
+  return element
+}
+
+document.body.appendChild(component())

--- a/tests/integration/regression-issue745/webpack.config.js
+++ b/tests/integration/regression-issue745/webpack.config.js
@@ -1,0 +1,19 @@
+const path = require('path')
+
+const { CycloneDxWebpackPlugin } = require('@cyclonedx/webpack-plugin')
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js'
+  },
+  plugins: [
+    new CycloneDxWebpackPlugin(
+      {
+        outputLocation: '.bom',
+        reproducibleResults: true
+      }
+    )
+  ]
+}

--- a/tests/integration/setup.js
+++ b/tests/integration/setup.js
@@ -22,9 +22,14 @@ const path = require('path');
 
 (function () {
   const REQUIRES_NPM_INSTALL = [
-    'webpack5-vue2',
+    // region functional tests
     'webpack5-angular13',
-    'webpack5-react18'
+    'webpack5-react18',
+    'webpack5-vue2',
+    // endregion functional tests
+    // region regression tests
+    'regression-issue745'
+    // endregion regression tests
   ]
 
   console.warn(`

--- a/tests/integration/webpack5-angular13/package-lock.json
+++ b/tests/integration/webpack5-angular13/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "@cyclonedx-weboack-plugin-tests/example-webpack5-angular13",
+  "name": "@cyclonedx-webpack-plugin-tests/example-webpack5-angular13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@cyclonedx-weboack-plugin-tests/example-webpack5-angular13",
+      "name": "@cyclonedx-webpack-plugin-tests/example-webpack5-angular13",
       "license": "Apache-2.0",
       "dependencies": {
         "@angular/animations": "~13.3.0",

--- a/tests/integration/webpack5-angular13/package.json
+++ b/tests/integration/webpack5-angular13/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cyclonedx-weboack-plugin-tests/example-webpack5-angular13",
+  "name": "@cyclonedx-webpack-plugin-tests/example-webpack5-angular13",
   "description": "example setup witch Angular13 in WebPack5",
   "private": true,
   "homepage": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/tree/master/tests/integration/webpack5-angular13#readme",

--- a/tests/integration/webpack5-vue2/package-lock.json
+++ b/tests/integration/webpack5-vue2/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "@cyclonedx-weboack-plugin-tests/example-webpack5-vue2",
+  "name": "@cyclonedx-webpack-plugin-tests/example-webpack5-vue2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@cyclonedx-weboack-plugin-tests/example-webpack5-vue2",
+      "name": "@cyclonedx-webpack-plugin-tests/example-webpack5-vue2",
       "license": "Apache-2.0",
       "dependencies": {
         "vue": "^2.6.14"

--- a/tests/integration/webpack5-vue2/package.json
+++ b/tests/integration/webpack5-vue2/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cyclonedx-weboack-plugin-tests/example-webpack5-vue2",
+  "name": "@cyclonedx-webpack-plugin-tests/example-webpack5-vue2",
   "description": "example setup witch Vue2 in WebPack5",
   "private": true,
   "homepage": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/tree/master/tests/integration/webpack5-vue2#readme",


### PR DESCRIPTION
fixes #745

If normalizing packages' metadata fails, then this results no longer in an unhandled crash but in a warning message



requires: https://github.com/CycloneDX/cyclonedx-javascript-library/pull/600