### PR TITLE
feat: populate `metadata.lifecycles`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Added
+  * SBOM results ar marked to be produced in lifecycle phase "build" ([#1173] via [#]) 
+* Misc
+  * Raised dependency `@cyclonedx/cyclonedx-library@^5`, was `@^3||^4` (via [#])
+
+[#1173]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues/1173
+[#]:
+
 ## 3.7.0 - 2023-07-05
 
 Added support for [_CycloneDX_ Specification-1.5](https://github.com/CycloneDX/specification/releases/tag/1.5).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,12 +5,12 @@ All notable changes to this project will be documented in this file.
 ## unreleased
 
 * Added
-  * SBOM results ar marked to be produced in lifecycle phase "build" ([#1173] via [#]) 
+  * SBOM results are marked to be produced in lifecycle phase "build" ([#1173] via [#1188]) 
 * Misc
-  * Raised dependency `@cyclonedx/cyclonedx-library@^5`, was `@^3||^4` (via [#])
+  * Raised dependency `@cyclonedx/cyclonedx-library@^5`, was `@^3||^4` (via [#1188])
 
 [#1173]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues/1173
-[#]:
+[#1188]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1188
 
 ## 3.7.0 - 2023-07-05
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@cyclonedx/cyclonedx-library": "^3||^4",
+        "@cyclonedx/cyclonedx-library": "^5.0.0",
         "normalize-package-data": "^3||^4||^5",
         "xmlbuilder2": "^3.0.2"
       },
@@ -668,9 +668,9 @@
       "dev": true
     },
     "node_modules/@cyclonedx/cyclonedx-library": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-4.0.0.tgz",
-      "integrity": "sha512-A+LPqMEG+/9KIE4kPM3Q4LjRMh3c3fbLzA/12p1BtYxSNmwj4gnf+1eZV/JsoqgQJagV8RRttNt+Mkn2SjgVgA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-5.0.0.tgz",
+      "integrity": "sha512-6uBduEtMcAxJyLZ4VIZzVXP7mqqHhM5kvsQA1r+I6+9p3QRuyE1NLevWOzUbAyI77c6lK0PR8+CEEOWtW+rB/w==",
       "funding": [
         {
           "type": "github",
@@ -7889,9 +7889,9 @@
       "dev": true
     },
     "@cyclonedx/cyclonedx-library": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-4.0.0.tgz",
-      "integrity": "sha512-A+LPqMEG+/9KIE4kPM3Q4LjRMh3c3fbLzA/12p1BtYxSNmwj4gnf+1eZV/JsoqgQJagV8RRttNt+Mkn2SjgVgA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-5.0.0.tgz",
+      "integrity": "sha512-6uBduEtMcAxJyLZ4VIZzVXP7mqqHhM5kvsQA1r+I6+9p3QRuyE1NLevWOzUbAyI77c6lK0PR8+CEEOWtW+rB/w==",
       "requires": {
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@cyclonedx/cyclonedx-library": "^3||^4",
+    "@cyclonedx/cyclonedx-library": "^5.0.0",
     "normalize-package-data": "^3||^4||^5",
     "xmlbuilder2": "^3.0.2"
   },

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -178,6 +178,7 @@ export class CycloneDxWebpackPlugin {
     const cdxComponentBuilder = new CDX.Builders.FromNodePackageJson.ComponentBuilder(cdxExternalReferenceFactory, cdxLicenseFactory)
 
     const bom = new CDX.Models.Bom()
+    bom.metadata.lifecycles.add(CDX.Enums.LifecyclePhase.Build)
     bom.metadata.component = this.#makeRootComponent(compilation.compiler.context, cdxComponentBuilder, logger.getChildLogger('RootComponentBuilder'))
 
     const serializeOptions: CDX.Serialize.Types.SerializerOptions & CDX.Serialize.Types.NormalizerOptions = {

--- a/tests/integration/__snapshots__/index.test.js.snap
+++ b/tests/integration/__snapshots__/index.test.js.snap
@@ -2,11 +2,16 @@
 
 exports[`integration functional: webpack5 with angular13 generated json file: dist/.bom/bom.json 1`] = `
 "{
-  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
+  "specVersion": "1.5",
   "version": 1,
   "metadata": {
+    "lifecycles": [
+      {
+        "phase": "build"
+      }
+    ],
     "tools": [
       {
         "vendor": "@cyclonedx",
@@ -374,11 +379,16 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
 
 exports[`integration functional: webpack5 with angular13 generated json file: dist/.well-known/sbom 1`] = `
 "{
-  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
+  "specVersion": "1.5",
   "version": 1,
   "metadata": {
+    "lifecycles": [
+      {
+        "phase": "build"
+      }
+    ],
     "tools": [
       {
         "vendor": "@cyclonedx",
@@ -746,8 +756,13 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
 
 exports[`integration functional: webpack5 with angular13 generated xml file: dist/.bom/bom.xml 1`] = `
 "<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
   <metadata>
+    <lifecycles>
+      <lifecycle>
+        <phase>build</phase>
+      </lifecycle>
+    </lifecycles>
     <tools>
       <tool>
         <vendor>@cyclonedx</vendor>
@@ -1032,11 +1047,16 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
 
 exports[`integration functional: webpack5 with react18 generated json file: dist/.bom/bom.json 1`] = `
 "{
-  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
+  "specVersion": "1.5",
   "version": 1,
   "metadata": {
+    "lifecycles": [
+      {
+        "phase": "build"
+      }
+    ],
     "tools": [
       {
         "vendor": "@cyclonedx",
@@ -1316,11 +1336,16 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
 
 exports[`integration functional: webpack5 with react18 generated json file: dist/.well-known/sbom 1`] = `
 "{
-  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
+  "specVersion": "1.5",
   "version": 1,
   "metadata": {
+    "lifecycles": [
+      {
+        "phase": "build"
+      }
+    ],
     "tools": [
       {
         "vendor": "@cyclonedx",
@@ -1600,8 +1625,13 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
 
 exports[`integration functional: webpack5 with react18 generated xml file: dist/.bom/bom.xml 1`] = `
 "<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
   <metadata>
+    <lifecycles>
+      <lifecycle>
+        <phase>build</phase>
+      </lifecycle>
+    </lifecycles>
     <tools>
       <tool>
         <vendor>@cyclonedx</vendor>
@@ -1819,11 +1849,16 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
 
 exports[`integration functional: webpack5 with vue2 generated json file: dist/.bom/bom.json 1`] = `
 "{
-  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
+  "specVersion": "1.5",
   "version": 1,
   "metadata": {
+    "lifecycles": [
+      {
+        "phase": "build"
+      }
+    ],
     "tools": [
       {
         "vendor": "@cyclonedx",
@@ -1955,11 +1990,16 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.b
 
 exports[`integration functional: webpack5 with vue2 generated json file: dist/.well-known/sbom 1`] = `
 "{
-  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
+  "specVersion": "1.5",
   "version": 1,
   "metadata": {
+    "lifecycles": [
+      {
+        "phase": "build"
+      }
+    ],
     "tools": [
       {
         "vendor": "@cyclonedx",
@@ -2091,8 +2131,13 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.w
 
 exports[`integration functional: webpack5 with vue2 generated xml file: dist/.bom/bom.xml 1`] = `
 "<?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" version="1">
   <metadata>
+    <lifecycles>
+      <lifecycle>
+        <phase>build</phase>
+      </lifecycle>
+    </lifecycles>
     <tools>
       <tool>
         <vendor>@cyclonedx</vendor>

--- a/tests/integration/webpack5-angular13/webpack-build.config.js
+++ b/tests/integration/webpack5-angular13/webpack-build.config.js
@@ -3,6 +3,7 @@ const { CycloneDxWebpackPlugin } = require('@cyclonedx/webpack-plugin')
 module.exports = {
   plugins: [
     new CycloneDxWebpackPlugin({
+      specVersion: '1.5',
       outputLocation: '.bom',
       reproducibleResults: true,
       validateResults: true

--- a/tests/integration/webpack5-react18/config/webpack.config.js
+++ b/tests/integration/webpack5-react18/config/webpack.config.js
@@ -749,6 +749,7 @@ module.exports = function (webpackEnv) {
           }
         }),
       new CycloneDxWebpackPlugin({
+        specVersion: '1.5',
         outputLocation: '.bom',
         reproducibleResults: true,
         validateResults: true

--- a/tests/integration/webpack5-vue2/webpack.config.js
+++ b/tests/integration/webpack5-vue2/webpack.config.js
@@ -17,6 +17,7 @@ module.exports = {
     new HtmlInlineScriptPlugin(),
     new CycloneDxWebpackPlugin(
       {
+        specVersion: '1.5',
         outputLocation: '.bom',
         reproducibleResults: true,
         validateResults: true


### PR DESCRIPTION
fixes #1173

-----

* Added
  * SBOM results are marked to be produced in lifecycle phase "build" 
* Misc
  * Raised dependency `@cyclonedx/cyclonedx-library@^5`, was `@^3||^4` 