### PR TITLE
feat: license acknowledgement

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 <!-- unreleased changes go here -->
 
+* Added
+  * Licenses acknowledgement might be populated ([#1274] via [#])
+* Misc
+  * Raised dependency `@cyclonedx/cyclonedx-library@^6.6.0`, was `@^6.5.0` (via [#])
+
+[#1274]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues/1274
+
 ## 3.10.0 - 2024-04-23
 
 Added support for [_CycloneDX_ Specification-1.6](https://github.com/CycloneDX/specification/releases/tag/1.6).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,11 +7,12 @@ All notable changes to this project will be documented in this file.
 <!-- unreleased changes go here -->
 
 * Added
-  * Licenses acknowledgement might be populated ([#1274] via [#])
+  * Licenses acknowledgement might be populated ([#1274] via [#1281])
 * Misc
-  * Raised dependency `@cyclonedx/cyclonedx-library@^6.6.0`, was `@^6.5.0` (via [#])
+  * Raised dependency `@cyclonedx/cyclonedx-library@^6.6.0`, was `@^6.5.0` (via [#1281])
 
 [#1274]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues/1274
+[#1281]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1281
 
 ## 3.10.0 - 2024-04-23
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@cyclonedx/cyclonedx-library": "^6.5.0",
+    "@cyclonedx/cyclonedx-library": "^6.6.0",
     "normalize-package-data": "^3||^4||^5||^6",
     "xmlbuilder2": "^3.0.2"
   },

--- a/tests/integration/__snapshots__/index.test.js.snap
+++ b/tests/integration/__snapshots__/index.test.js.snap
@@ -68,7 +68,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -104,7 +105,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -138,7 +140,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -172,7 +175,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -205,7 +209,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -238,7 +243,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -271,7 +277,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "0BSD"
+            "id": "0BSD",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -304,7 +311,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -445,7 +453,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -481,7 +490,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -515,7 +525,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -549,7 +560,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -582,7 +594,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -615,7 +628,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -648,7 +662,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "0BSD"
+            "id": "0BSD",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -681,7 +696,8 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -809,7 +825,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
       <name>example-webpack5-angular13</name>
       <description>example setup witch Angular13 in WebPack5</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>Apache-2.0</id>
         </license>
       </licenses>
@@ -838,7 +854,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
       <version>13.3.12</version>
       <description>Angular - commonly needed directives and services</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
@@ -865,7 +881,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
       <version>13.3.12</version>
       <description>Angular - the core framework</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
@@ -892,7 +908,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
       <version>13.3.12</version>
       <description>Angular - library for using Angular in a web browser</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
@@ -918,7 +934,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
       <version>6.5.1</version>
       <description>css loader module for webpack</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
@@ -944,7 +960,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
       <version>7.5.7</version>
       <description>Reactive Extensions for modern JavaScript</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>Apache-2.0</id>
         </license>
       </licenses>
@@ -970,7 +986,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
       <version>2.3.1</version>
       <description>Runtime library for TypeScript helper functions</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>0BSD</id>
         </license>
       </licenses>
@@ -996,7 +1012,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
       <version>0.11.8</version>
       <description>Zones for JavaScript</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
@@ -1114,7 +1130,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1150,7 +1167,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1184,7 +1202,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1218,7 +1237,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1252,7 +1272,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1285,7 +1306,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1318,7 +1340,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1351,7 +1374,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "0BSD"
+            "id": "0BSD",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1384,7 +1408,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1535,7 +1560,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1571,7 +1597,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1605,7 +1632,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1639,7 +1667,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1673,7 +1702,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1706,7 +1736,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1739,7 +1770,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1772,7 +1804,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "0BSD"
+            "id": "0BSD",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1805,7 +1838,8 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -1943,7 +1977,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
       <version>0.0.0</version>
       <description>example setup witch Angular17 in WebPack5</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>Apache-2.0</id>
         </license>
       </licenses>
@@ -1972,7 +2006,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
       <version>17.3.0</version>
       <description>Angular - commonly needed directives and services</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
@@ -1999,7 +2033,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
       <version>17.3.0</version>
       <description>Angular - the core framework</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
@@ -2026,7 +2060,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
       <version>17.3.0</version>
       <description>Angular - library for using Angular in a web browser</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
@@ -2053,7 +2087,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
       <version>17.3.0</version>
       <description>Angular - the routing library</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
@@ -2079,7 +2113,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
       <version>6.10.0</version>
       <description>css loader module for webpack</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
@@ -2105,7 +2139,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
       <version>7.8.1</version>
       <description>Reactive Extensions for modern JavaScript</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>Apache-2.0</id>
         </license>
       </licenses>
@@ -2131,7 +2165,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
       <version>2.6.2</version>
       <description>Runtime library for TypeScript helper functions</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>0BSD</id>
         </license>
       </licenses>
@@ -2157,7 +2191,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
       <version>0.14.4</version>
       <description>Zones for JavaScript</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
@@ -2281,7 +2315,8 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -2316,7 +2351,8 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -2348,7 +2384,8 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -2380,7 +2417,8 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -2412,7 +2450,8 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -2445,7 +2484,8 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -2570,7 +2610,8 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -2605,7 +2646,8 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -2637,7 +2679,8 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -2669,7 +2712,8 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -2701,7 +2745,8 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -2734,7 +2779,8 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -2846,7 +2892,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
       <version>0.0.1</version>
       <description>example setup with react and webpack5</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>Apache-2.0</id>
         </license>
       </licenses>
@@ -2874,7 +2920,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
       <version>6.7.1</version>
       <description>css loader module for webpack</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
@@ -2899,7 +2945,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
       <version>18.2.0</version>
       <description>React package for working with the DOM.</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
@@ -2924,7 +2970,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
       <version>18.2.0</version>
       <description>React is a JavaScript library for building user interfaces.</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
@@ -2949,7 +2995,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
       <version>0.23.0</version>
       <description>Cooperative scheduler for the browser environment.</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
@@ -2975,7 +3021,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
       <version>2.1.4</version>
       <description>Easily measure performance metrics in JavaScript</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>Apache-2.0</id>
         </license>
       </licenses>
@@ -3082,7 +3128,8 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.b
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -3117,7 +3164,8 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.b
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -3223,7 +3271,8 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.w
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -3258,7 +3307,8 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.w
       "licenses": [
         {
           "license": {
-            "id": "MIT"
+            "id": "MIT",
+            "acknowledgement": "declared"
           }
         }
       ],
@@ -3351,7 +3401,7 @@ exports[`integration functional: webpack5 with vue2 generated xml file: dist/.bo
       <name>example-webpack5-vue2</name>
       <description>example setup witch Vue2 in WebPack5</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>Apache-2.0</id>
         </license>
       </licenses>
@@ -3379,7 +3429,7 @@ exports[`integration functional: webpack5 with vue2 generated xml file: dist/.bo
       <version>2.6.14</version>
       <description>Reactive, component-oriented view layer for modern web interfaces.</description>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>


### PR DESCRIPTION
fixes #1274

## Added
  * Licenses acknowledgement might be populated ([#1274] via [#1281])
## Misc
  * Raised dependency `@cyclonedx/cyclonedx-library@^6.6.0`, was `@^6.5.0` (via [#1281])

[#1274]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues/1274
[#1281]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1281

