### PR TITLE
chore: migrate to `npm-run-all2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "eslint-plugin-simple-import-sort": "12.1.0",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
-    "npm-run-all": "^4.1.5",
+    "npm-run-all2": "^6.2.3",
     "typescript": "5.6.2",
     "webpack": "^5"
   },
@@ -96,11 +96,11 @@
     "prepublish": "npm run build",
     "prepublishOnly": "run-s -lc build setup-tests test",
     "lint": "tsc --noEmit",
-    "build": "run-p --aggregate-output -l build:*",
+    "build": "run-p --aggregate-output -l 'build:*'",
     "prebuild:node": "node -r fs -e 'fs.rmSync(\"dist\",{recursive:true,force:true})'",
     "build:node": "tsc -b ./tsconfig.json",
     "setup-tests": "node tests/integration/setup.js",
-    "test": "run-p --aggregate-output -lc test:*",
+    "test": "run-p --aggregate-output -lc 'test:*'",
     "test:jest": "c8 jest",
     "test:standard": "eslint .",
     "cs-fix": "eslint --fix ."


### PR DESCRIPTION
fixes #1260