### PR TITLE
fix: use the non-deprecated version of metadata/tools for 1.5+

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@cyclonedx/cyclonedx-library": "^6.11.0",
+    "@cyclonedx/cyclonedx-library": "^7.0.0",
     "normalize-package-data": "^3||^4||^5||^6",
     "xmlbuilder2": "^3.0.2"
   },

--- a/tests/integration/__snapshots__/index.test.js.snap
+++ b/tests/integration/__snapshots__/index.test.js.snap
@@ -12,58 +12,80 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
         "phase": "build"
       }
     ],
-    "tools": [
-      {
-        "vendor": "@cyclonedx",
-        "name": "cyclonedx-library",
-        "version": "libVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      },
-      {
-        "vendor": "@cyclonedx",
-        "name": "webpack-plugin",
-        "version": "thisVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      }
-    ],
+    "tools": {
+      "components": [
+        {
+          "type": "library",
+          "name": "cyclonedx-library",
+          "group": "@cyclonedx",
+          "version": "7.0.0",
+          "author": "Jan Kowalleck",
+          "description": "Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "name": "webpack-plugin",
+          "group": "@cyclonedx",
+          "version": "3.15.1",
+          "author": "Jan Kowalleck",
+          "description": "Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
       "name": "feature-issue676",
       "group": "@cyclonedx-webpack-plugin-tests",
       "version": "0.0.0",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/feature-issue676",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Ffeature-issue676",
       "author": "Jan Kowalleck",
       "description": "example setup for testing evidence collection",
       "licenses": [
@@ -74,7 +96,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/feature-issue676",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Ffeature-issue676",
       "externalReferences": [
         {
           "url": "git+ssh://git@gitlab.example.com/demos/feature-issue676",
@@ -129,7 +151,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
       "name": "common",
       "group": "@angular",
       "version": "18.2.7",
-      "bom-ref": "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "bom-ref": "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "author": "angular",
       "description": "Angular - commonly needed directives and services",
       "licenses": [
@@ -140,7 +162,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "purl": "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -178,7 +200,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
       "name": "core",
       "group": "@angular",
       "version": "18.2.7",
-      "bom-ref": "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "bom-ref": "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "author": "angular",
       "description": "Angular - the core framework",
       "licenses": [
@@ -189,7 +211,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "purl": "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -227,7 +249,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
       "name": "platform-browser",
       "group": "@angular",
       "version": "18.2.7",
-      "bom-ref": "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "bom-ref": "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "author": "angular",
       "description": "Angular - library for using Angular in a web browser",
       "licenses": [
@@ -238,7 +260,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "purl": "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -276,7 +298,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
       "name": "router",
       "group": "@angular",
       "version": "18.2.7",
-      "bom-ref": "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router",
+      "bom-ref": "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router",
       "author": "angular",
       "description": "Angular - the routing library",
       "licenses": [
@@ -287,7 +309,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router",
+      "purl": "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -325,7 +347,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
       "name": "runtime",
       "group": "@babel",
       "version": "7.25.0",
-      "bom-ref": "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
+      "bom-ref": "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
       "author": "The Babel Team",
       "description": "babel's modular runtime helpers",
       "licenses": [
@@ -336,7 +358,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
           }
         }
       ],
-      "purl": "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
+      "purl": "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
       "externalReferences": [
         {
           "url": "https://github.com/babel/babel/issues",
@@ -373,7 +395,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
       "type": "library",
       "name": "css-loader",
       "version": "7.1.2",
-      "bom-ref": "pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
+      "bom-ref": "pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
       "author": "Tobias Koppers @sokra",
       "description": "css loader module for webpack",
       "licenses": [
@@ -384,7 +406,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
           }
         }
       ],
-      "purl": "pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
+      "purl": "pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
       "externalReferences": [
         {
           "url": "https://github.com/webpack-contrib/css-loader/issues",
@@ -421,7 +443,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
       "type": "library",
       "name": "rxjs",
       "version": "7.8.1",
-      "bom-ref": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "bom-ref": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "author": "Ben Lesh",
       "description": "Reactive Extensions for modern JavaScript",
       "licenses": [
@@ -432,7 +454,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
           }
         }
       ],
-      "purl": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "purl": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "externalReferences": [
         {
           "url": "https://github.com/ReactiveX/RxJS/issues",
@@ -469,7 +491,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
       "type": "library",
       "name": "tslib",
       "version": "2.6.3",
-      "bom-ref": "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "bom-ref": "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
       "author": "Microsoft Corp.",
       "description": "Runtime library for TypeScript helper functions",
       "licenses": [
@@ -480,7 +502,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
           }
         }
       ],
-      "purl": "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "purl": "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
       "externalReferences": [
         {
           "url": "https://github.com/Microsoft/TypeScript/issues",
@@ -517,7 +539,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
       "type": "library",
       "name": "zone.js",
       "version": "0.14.10",
-      "bom-ref": "pkg:npm/zone.js@0.14.10?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js",
+      "bom-ref": "pkg:npm/zone.js@0.14.10?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js",
       "author": "Brian Ford",
       "description": "Zones for JavaScript",
       "licenses": [
@@ -528,7 +550,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
           }
         }
       ],
-      "purl": "pkg:npm/zone.js@0.14.10?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js",
+      "purl": "pkg:npm/zone.js@0.14.10?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -564,61 +586,61 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "ref": "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "dependsOn": [
-        "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
-        "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
-        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"
+        "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
+        "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
+        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "ref": "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "dependsOn": [
-        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"
+        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "ref": "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "dependsOn": [
-        "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
-        "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"
+        "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
+        "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"
       ]
     },
     {
-      "ref": "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router",
+      "ref": "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router",
       "dependsOn": [
-        "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
-        "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
-        "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
-        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"
+        "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
+        "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
+        "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
+        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime"
+      "ref": "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime"
     },
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/feature-issue676",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Ffeature-issue676",
       "dependsOn": [
-        "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
-        "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
-        "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router",
-        "pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"
+        "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
+        "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
+        "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router",
+        "pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"
       ]
     },
     {
-      "ref": "pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"
+      "ref": "pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"
     },
     {
-      "ref": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "ref": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "dependsOn": [
-        "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+        "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
       ]
     },
     {
-      "ref": "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      "ref": "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
     },
     {
-      "ref": "pkg:npm/zone.js@0.14.10?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js"
+      "ref": "pkg:npm/zone.js@0.14.10?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js"
     }
   ]
 }"
@@ -636,58 +658,80 @@ exports[`integration feature: component evidence generated json file: dist/.well
         "phase": "build"
       }
     ],
-    "tools": [
-      {
-        "vendor": "@cyclonedx",
-        "name": "cyclonedx-library",
-        "version": "libVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      },
-      {
-        "vendor": "@cyclonedx",
-        "name": "webpack-plugin",
-        "version": "thisVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      }
-    ],
+    "tools": {
+      "components": [
+        {
+          "type": "library",
+          "name": "cyclonedx-library",
+          "group": "@cyclonedx",
+          "version": "7.0.0",
+          "author": "Jan Kowalleck",
+          "description": "Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "name": "webpack-plugin",
+          "group": "@cyclonedx",
+          "version": "3.15.1",
+          "author": "Jan Kowalleck",
+          "description": "Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
       "name": "feature-issue676",
       "group": "@cyclonedx-webpack-plugin-tests",
       "version": "0.0.0",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/feature-issue676",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Ffeature-issue676",
       "author": "Jan Kowalleck",
       "description": "example setup for testing evidence collection",
       "licenses": [
@@ -698,7 +742,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/feature-issue676",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Ffeature-issue676",
       "externalReferences": [
         {
           "url": "git+ssh://git@gitlab.example.com/demos/feature-issue676",
@@ -753,7 +797,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
       "name": "common",
       "group": "@angular",
       "version": "18.2.7",
-      "bom-ref": "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "bom-ref": "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "author": "angular",
       "description": "Angular - commonly needed directives and services",
       "licenses": [
@@ -764,7 +808,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "purl": "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -802,7 +846,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
       "name": "core",
       "group": "@angular",
       "version": "18.2.7",
-      "bom-ref": "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "bom-ref": "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "author": "angular",
       "description": "Angular - the core framework",
       "licenses": [
@@ -813,7 +857,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "purl": "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -851,7 +895,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
       "name": "platform-browser",
       "group": "@angular",
       "version": "18.2.7",
-      "bom-ref": "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "bom-ref": "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "author": "angular",
       "description": "Angular - library for using Angular in a web browser",
       "licenses": [
@@ -862,7 +906,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "purl": "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -900,7 +944,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
       "name": "router",
       "group": "@angular",
       "version": "18.2.7",
-      "bom-ref": "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router",
+      "bom-ref": "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router",
       "author": "angular",
       "description": "Angular - the routing library",
       "licenses": [
@@ -911,7 +955,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router",
+      "purl": "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -949,7 +993,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
       "name": "runtime",
       "group": "@babel",
       "version": "7.25.0",
-      "bom-ref": "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
+      "bom-ref": "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
       "author": "The Babel Team",
       "description": "babel's modular runtime helpers",
       "licenses": [
@@ -960,7 +1004,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
           }
         }
       ],
-      "purl": "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
+      "purl": "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
       "externalReferences": [
         {
           "url": "https://github.com/babel/babel/issues",
@@ -997,7 +1041,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
       "type": "library",
       "name": "css-loader",
       "version": "7.1.2",
-      "bom-ref": "pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
+      "bom-ref": "pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
       "author": "Tobias Koppers @sokra",
       "description": "css loader module for webpack",
       "licenses": [
@@ -1008,7 +1052,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
           }
         }
       ],
-      "purl": "pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
+      "purl": "pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
       "externalReferences": [
         {
           "url": "https://github.com/webpack-contrib/css-loader/issues",
@@ -1045,7 +1089,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
       "type": "library",
       "name": "rxjs",
       "version": "7.8.1",
-      "bom-ref": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "bom-ref": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "author": "Ben Lesh",
       "description": "Reactive Extensions for modern JavaScript",
       "licenses": [
@@ -1056,7 +1100,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
           }
         }
       ],
-      "purl": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "purl": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "externalReferences": [
         {
           "url": "https://github.com/ReactiveX/RxJS/issues",
@@ -1093,7 +1137,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
       "type": "library",
       "name": "tslib",
       "version": "2.6.3",
-      "bom-ref": "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "bom-ref": "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
       "author": "Microsoft Corp.",
       "description": "Runtime library for TypeScript helper functions",
       "licenses": [
@@ -1104,7 +1148,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
           }
         }
       ],
-      "purl": "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "purl": "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
       "externalReferences": [
         {
           "url": "https://github.com/Microsoft/TypeScript/issues",
@@ -1141,7 +1185,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
       "type": "library",
       "name": "zone.js",
       "version": "0.14.10",
-      "bom-ref": "pkg:npm/zone.js@0.14.10?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js",
+      "bom-ref": "pkg:npm/zone.js@0.14.10?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js",
       "author": "Brian Ford",
       "description": "Zones for JavaScript",
       "licenses": [
@@ -1152,7 +1196,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
           }
         }
       ],
-      "purl": "pkg:npm/zone.js@0.14.10?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js",
+      "purl": "pkg:npm/zone.js@0.14.10?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -1188,61 +1232,61 @@ exports[`integration feature: component evidence generated json file: dist/.well
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "ref": "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "dependsOn": [
-        "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
-        "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
-        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"
+        "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
+        "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
+        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "ref": "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "dependsOn": [
-        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"
+        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "ref": "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "dependsOn": [
-        "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
-        "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"
+        "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
+        "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"
       ]
     },
     {
-      "ref": "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router",
+      "ref": "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router",
       "dependsOn": [
-        "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
-        "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
-        "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
-        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"
+        "pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
+        "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
+        "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
+        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime"
+      "ref": "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime"
     },
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/feature-issue676",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Ffeature-issue676",
       "dependsOn": [
-        "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
-        "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
-        "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router",
-        "pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"
+        "pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
+        "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
+        "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router",
+        "pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"
       ]
     },
     {
-      "ref": "pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"
+      "ref": "pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"
     },
     {
-      "ref": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "ref": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "dependsOn": [
-        "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+        "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
       ]
     },
     {
-      "ref": "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      "ref": "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
     },
     {
-      "ref": "pkg:npm/zone.js@0.14.10?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js"
+      "ref": "pkg:npm/zone.js@0.14.10?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js"
     }
   ]
 }"
@@ -1258,46 +1302,62 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
       </lifecycle>
     </lifecycles>
     <tools>
-      <tool>
-        <vendor>@cyclonedx</vendor>
-        <name>cyclonedx-library</name>
-        <version>libVersion-testing</version>
-        <externalReferences>
-          <reference type="issue-tracker">
-            <url>https://github.com/CycloneDX/cyclonedx-javascript-library/issues</url>
-            <comment>as detected from PackageJson property "bugs.url"</comment>
-          </reference>
-          <reference type="vcs">
-            <url>git+https://github.com/CycloneDX/cyclonedx-javascript-library.git</url>
-            <comment>as detected from PackageJson property "repository.url"</comment>
-          </reference>
-          <reference type="website">
-            <url>https://github.com/CycloneDX/cyclonedx-javascript-library#readme</url>
-            <comment>as detected from PackageJson property "homepage"</comment>
-          </reference>
-        </externalReferences>
-      </tool>
-      <tool>
-        <vendor>@cyclonedx</vendor>
-        <name>webpack-plugin</name>
-        <version>thisVersion-testing</version>
-        <externalReferences>
-          <reference type="issue-tracker">
-            <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
-            <comment>as detected from PackageJson property "bugs.url"</comment>
-          </reference>
-          <reference type="vcs">
-            <url>git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git</url>
-            <comment>as detected from PackageJson property "repository.url"</comment>
-          </reference>
-          <reference type="website">
-            <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme</url>
-            <comment>as detected from PackageJson property "homepage"</comment>
-          </reference>
-        </externalReferences>
-      </tool>
+      <components>
+        <component type="library">
+          <author>Jan Kowalleck</author>
+          <group>@cyclonedx</group>
+          <name>cyclonedx-library</name>
+          <version>7.0.0</version>
+          <description>Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).</description>
+          <licenses>
+            <license>
+              <id>Apache-2.0</id>
+            </license>
+          </licenses>
+          <externalReferences>
+            <reference type="issue-tracker">
+              <url>https://github.com/CycloneDX/cyclonedx-javascript-library/issues</url>
+              <comment>as detected from PackageJson property "bugs.url"</comment>
+            </reference>
+            <reference type="vcs">
+              <url>git+https://github.com/CycloneDX/cyclonedx-javascript-library.git</url>
+              <comment>as detected from PackageJson property "repository.url"</comment>
+            </reference>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-javascript-library#readme</url>
+              <comment>as detected from PackageJson property "homepage"</comment>
+            </reference>
+          </externalReferences>
+        </component>
+        <component type="library">
+          <author>Jan Kowalleck</author>
+          <group>@cyclonedx</group>
+          <name>webpack-plugin</name>
+          <version>3.15.1</version>
+          <description>Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects</description>
+          <licenses>
+            <license>
+              <id>Apache-2.0</id>
+            </license>
+          </licenses>
+          <externalReferences>
+            <reference type="issue-tracker">
+              <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
+              <comment>as detected from PackageJson property "bugs.url"</comment>
+            </reference>
+            <reference type="vcs">
+              <url>git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git</url>
+              <comment>as detected from PackageJson property "repository.url"</comment>
+            </reference>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme</url>
+              <comment>as detected from PackageJson property "homepage"</comment>
+            </reference>
+          </externalReferences>
+        </component>
+      </components>
     </tools>
-    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/feature-issue676">
+    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Ffeature-issue676">
       <author>Jan Kowalleck</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>feature-issue676</name>
@@ -1308,7 +1368,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
           <id>Apache-2.0</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/feature-issue676</purl>
+      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Ffeature-issue676</purl>
       <externalReferences>
         <reference type="vcs">
           <url>git+ssh://git@gitlab.example.com/demos/feature-issue676</url>
@@ -1338,7 +1398,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common">
+    <component type="library" bom-ref="pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common">
       <author>angular</author>
       <group>@angular</group>
       <name>common</name>
@@ -1349,7 +1409,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common</purl>
+      <purl>pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/angular/angular/issues</url>
@@ -1373,7 +1433,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core">
+    <component type="library" bom-ref="pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core">
       <author>angular</author>
       <group>@angular</group>
       <name>core</name>
@@ -1384,7 +1444,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core</purl>
+      <purl>pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/angular/angular/issues</url>
@@ -1408,7 +1468,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser">
+    <component type="library" bom-ref="pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser">
       <author>angular</author>
       <group>@angular</group>
       <name>platform-browser</name>
@@ -1419,7 +1479,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser</purl>
+      <purl>pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/angular/angular/issues</url>
@@ -1443,7 +1503,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router">
+    <component type="library" bom-ref="pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router">
       <author>angular</author>
       <group>@angular</group>
       <name>router</name>
@@ -1454,7 +1514,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router</purl>
+      <purl>pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/angular/angular/issues</url>
@@ -1478,7 +1538,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime">
+    <component type="library" bom-ref="pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime">
       <author>The Babel Team</author>
       <group>@babel</group>
       <name>runtime</name>
@@ -1489,7 +1549,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime</purl>
+      <purl>pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/babel/babel/issues</url>
@@ -1513,7 +1573,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git">
+    <component type="library" bom-ref="pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git">
       <author>Tobias Koppers @sokra</author>
       <name>css-loader</name>
       <version>7.1.2</version>
@@ -1523,7 +1583,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git</purl>
+      <purl>pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/webpack-contrib/css-loader/issues</url>
@@ -1547,7 +1607,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git">
+    <component type="library" bom-ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git">
       <author>Ben Lesh</author>
       <name>rxjs</name>
       <version>7.8.1</version>
@@ -1557,7 +1617,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
           <id>Apache-2.0</id>
         </license>
       </licenses>
-      <purl>pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git</purl>
+      <purl>pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/ReactiveX/RxJS/issues</url>
@@ -1581,7 +1641,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git">
+    <component type="library" bom-ref="pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git">
       <author>Microsoft Corp.</author>
       <name>tslib</name>
       <version>2.6.3</version>
@@ -1591,7 +1651,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
           <id>0BSD</id>
         </license>
       </licenses>
-      <purl>pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git</purl>
+      <purl>pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/Microsoft/TypeScript/issues</url>
@@ -1615,7 +1675,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/zone.js@0.14.10?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js">
+    <component type="library" bom-ref="pkg:npm/zone.js@0.14.10?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js">
       <author>Brian Ford</author>
       <name>zone.js</name>
       <version>0.14.10</version>
@@ -1625,7 +1685,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/zone.js@0.14.10?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js</purl>
+      <purl>pkg:npm/zone.js@0.14.10?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/angular/angular/issues</url>
@@ -1651,37 +1711,37 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
     </component>
   </components>
   <dependencies>
-    <dependency ref="pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common">
-      <dependency ref="pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"/>
-      <dependency ref="pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime"/>
-      <dependency ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"/>
+    <dependency ref="pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common">
+      <dependency ref="pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"/>
+      <dependency ref="pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime"/>
+      <dependency ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"/>
     </dependency>
-    <dependency ref="pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core">
-      <dependency ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"/>
+    <dependency ref="pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core">
+      <dependency ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"/>
     </dependency>
-    <dependency ref="pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser">
-      <dependency ref="pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common"/>
-      <dependency ref="pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"/>
+    <dependency ref="pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser">
+      <dependency ref="pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common"/>
+      <dependency ref="pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"/>
     </dependency>
-    <dependency ref="pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router">
-      <dependency ref="pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common"/>
-      <dependency ref="pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"/>
-      <dependency ref="pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser"/>
-      <dependency ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"/>
+    <dependency ref="pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router">
+      <dependency ref="pkg:npm/%40angular/common@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common"/>
+      <dependency ref="pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"/>
+      <dependency ref="pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser"/>
+      <dependency ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"/>
     </dependency>
-    <dependency ref="pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime"/>
-    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/feature-issue676">
-      <dependency ref="pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"/>
-      <dependency ref="pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser"/>
-      <dependency ref="pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router"/>
-      <dependency ref="pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"/>
+    <dependency ref="pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime"/>
+    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Ffeature-issue676">
+      <dependency ref="pkg:npm/%40angular/core@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"/>
+      <dependency ref="pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser"/>
+      <dependency ref="pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router"/>
+      <dependency ref="pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"/>
     </dependency>
-    <dependency ref="pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"/>
-    <dependency ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git">
-      <dependency ref="pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+    <dependency ref="pkg:npm/css-loader@7.1.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"/>
+    <dependency ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git">
+      <dependency ref="pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"/>
     </dependency>
-    <dependency ref="pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-    <dependency ref="pkg:npm/zone.js@0.14.10?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js"/>
+    <dependency ref="pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"/>
+    <dependency ref="pkg:npm/zone.js@0.14.10?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js"/>
   </dependencies>
 </bom>"
 `;
@@ -1698,57 +1758,79 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
         "phase": "build"
       }
     ],
-    "tools": [
-      {
-        "vendor": "@cyclonedx",
-        "name": "cyclonedx-library",
-        "version": "libVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      },
-      {
-        "vendor": "@cyclonedx",
-        "name": "webpack-plugin",
-        "version": "thisVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      }
-    ],
+    "tools": {
+      "components": [
+        {
+          "type": "library",
+          "name": "cyclonedx-library",
+          "group": "@cyclonedx",
+          "version": "7.0.0",
+          "author": "Jan Kowalleck",
+          "description": "Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "name": "webpack-plugin",
+          "group": "@cyclonedx",
+          "version": "3.15.1",
+          "author": "Jan Kowalleck",
+          "description": "Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
       "name": "example-webpack5-angular13",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git",
       "author": "Jan Kowalleck",
       "description": "example setup witch Angular13 in WebPack5",
       "licenses": [
@@ -1759,7 +1841,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -1785,7 +1867,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "name": "common",
       "group": "@angular",
       "version": "13.3.12",
-      "bom-ref": "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "bom-ref": "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "author": "angular",
       "description": "Angular - commonly needed directives and services",
       "licenses": [
@@ -1796,7 +1878,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "purl": "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -1820,7 +1902,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "name": "core",
       "group": "@angular",
       "version": "13.3.12",
-      "bom-ref": "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "bom-ref": "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "author": "angular",
       "description": "Angular - the core framework",
       "licenses": [
@@ -1831,7 +1913,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "purl": "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -1855,7 +1937,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "name": "platform-browser",
       "group": "@angular",
       "version": "13.3.12",
-      "bom-ref": "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "bom-ref": "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "author": "angular",
       "description": "Angular - library for using Angular in a web browser",
       "licenses": [
@@ -1866,7 +1948,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "purl": "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -1889,7 +1971,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "type": "library",
       "name": "css-loader",
       "version": "6.5.1",
-      "bom-ref": "pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
+      "bom-ref": "pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
       "author": "Tobias Koppers @sokra",
       "description": "css loader module for webpack",
       "licenses": [
@@ -1900,7 +1982,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
+      "purl": "pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
       "externalReferences": [
         {
           "url": "https://github.com/webpack-contrib/css-loader/issues",
@@ -1923,7 +2005,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "type": "library",
       "name": "rxjs",
       "version": "7.5.7",
-      "bom-ref": "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "bom-ref": "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "author": "Ben Lesh",
       "description": "Reactive Extensions for modern JavaScript",
       "licenses": [
@@ -1934,7 +2016,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "purl": "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "externalReferences": [
         {
           "url": "https://github.com/ReactiveX/RxJS/issues",
@@ -1957,7 +2039,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "type": "library",
       "name": "tslib",
       "version": "2.3.1",
-      "bom-ref": "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "bom-ref": "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
       "author": "Microsoft Corp.",
       "description": "Runtime library for TypeScript helper functions",
       "licenses": [
@@ -1968,7 +2050,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "purl": "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
       "externalReferences": [
         {
           "url": "https://github.com/Microsoft/TypeScript/issues",
@@ -1991,7 +2073,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "type": "library",
       "name": "zone.js",
       "version": "0.11.8",
-      "bom-ref": "pkg:npm/zone.js@0.11.8?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js",
+      "bom-ref": "pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js",
       "author": "Brian Ford",
       "description": "Zones for JavaScript",
       "licenses": [
@@ -2002,7 +2084,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/zone.js@0.11.8?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js",
+      "purl": "pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -2024,48 +2106,48 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "ref": "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "dependsOn": [
-        "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"
+        "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"
       ]
     },
     {
-      "ref": "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "ref": "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "dependsOn": [
-        "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"
+        "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "ref": "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "dependsOn": [
-        "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
-        "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"
+        "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
+        "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"
       ]
     },
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git",
       "dependsOn": [
-        "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
-        "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
-        "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
-        "pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
-        "pkg:npm/zone.js@0.11.8?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js"
+        "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
+        "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
+        "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
+        "pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
+        "pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js"
       ]
     },
     {
-      "ref": "pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"
+      "ref": "pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"
     },
     {
-      "ref": "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "ref": "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "dependsOn": [
-        "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+        "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
       ]
     },
     {
-      "ref": "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      "ref": "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
     },
     {
-      "ref": "pkg:npm/zone.js@0.11.8?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js"
+      "ref": "pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js"
     }
   ]
 }"
@@ -2083,57 +2165,79 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
         "phase": "build"
       }
     ],
-    "tools": [
-      {
-        "vendor": "@cyclonedx",
-        "name": "cyclonedx-library",
-        "version": "libVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      },
-      {
-        "vendor": "@cyclonedx",
-        "name": "webpack-plugin",
-        "version": "thisVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      }
-    ],
+    "tools": {
+      "components": [
+        {
+          "type": "library",
+          "name": "cyclonedx-library",
+          "group": "@cyclonedx",
+          "version": "7.0.0",
+          "author": "Jan Kowalleck",
+          "description": "Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "name": "webpack-plugin",
+          "group": "@cyclonedx",
+          "version": "3.15.1",
+          "author": "Jan Kowalleck",
+          "description": "Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
       "name": "example-webpack5-angular13",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git",
       "author": "Jan Kowalleck",
       "description": "example setup witch Angular13 in WebPack5",
       "licenses": [
@@ -2144,7 +2248,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -2170,7 +2274,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "name": "common",
       "group": "@angular",
       "version": "13.3.12",
-      "bom-ref": "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "bom-ref": "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "author": "angular",
       "description": "Angular - commonly needed directives and services",
       "licenses": [
@@ -2181,7 +2285,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "purl": "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -2205,7 +2309,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "name": "core",
       "group": "@angular",
       "version": "13.3.12",
-      "bom-ref": "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "bom-ref": "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "author": "angular",
       "description": "Angular - the core framework",
       "licenses": [
@@ -2216,7 +2320,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "purl": "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -2240,7 +2344,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "name": "platform-browser",
       "group": "@angular",
       "version": "13.3.12",
-      "bom-ref": "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "bom-ref": "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "author": "angular",
       "description": "Angular - library for using Angular in a web browser",
       "licenses": [
@@ -2251,7 +2355,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "purl": "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -2274,7 +2378,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "type": "library",
       "name": "css-loader",
       "version": "6.5.1",
-      "bom-ref": "pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
+      "bom-ref": "pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
       "author": "Tobias Koppers @sokra",
       "description": "css loader module for webpack",
       "licenses": [
@@ -2285,7 +2389,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
+      "purl": "pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
       "externalReferences": [
         {
           "url": "https://github.com/webpack-contrib/css-loader/issues",
@@ -2308,7 +2412,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "type": "library",
       "name": "rxjs",
       "version": "7.5.7",
-      "bom-ref": "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "bom-ref": "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "author": "Ben Lesh",
       "description": "Reactive Extensions for modern JavaScript",
       "licenses": [
@@ -2319,7 +2423,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "purl": "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "externalReferences": [
         {
           "url": "https://github.com/ReactiveX/RxJS/issues",
@@ -2342,7 +2446,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "type": "library",
       "name": "tslib",
       "version": "2.3.1",
-      "bom-ref": "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "bom-ref": "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
       "author": "Microsoft Corp.",
       "description": "Runtime library for TypeScript helper functions",
       "licenses": [
@@ -2353,7 +2457,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "purl": "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
       "externalReferences": [
         {
           "url": "https://github.com/Microsoft/TypeScript/issues",
@@ -2376,7 +2480,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "type": "library",
       "name": "zone.js",
       "version": "0.11.8",
-      "bom-ref": "pkg:npm/zone.js@0.11.8?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js",
+      "bom-ref": "pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js",
       "author": "Brian Ford",
       "description": "Zones for JavaScript",
       "licenses": [
@@ -2387,7 +2491,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/zone.js@0.11.8?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js",
+      "purl": "pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -2409,48 +2513,48 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "ref": "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "dependsOn": [
-        "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"
+        "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"
       ]
     },
     {
-      "ref": "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "ref": "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "dependsOn": [
-        "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"
+        "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "ref": "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "dependsOn": [
-        "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
-        "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"
+        "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
+        "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"
       ]
     },
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git",
       "dependsOn": [
-        "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
-        "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
-        "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
-        "pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
-        "pkg:npm/zone.js@0.11.8?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js"
+        "pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
+        "pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
+        "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
+        "pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
+        "pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js"
       ]
     },
     {
-      "ref": "pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"
+      "ref": "pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"
     },
     {
-      "ref": "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "ref": "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "dependsOn": [
-        "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+        "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
       ]
     },
     {
-      "ref": "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      "ref": "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
     },
     {
-      "ref": "pkg:npm/zone.js@0.11.8?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js"
+      "ref": "pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js"
     }
   ]
 }"
@@ -2466,46 +2570,62 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
       </lifecycle>
     </lifecycles>
     <tools>
-      <tool>
-        <vendor>@cyclonedx</vendor>
-        <name>cyclonedx-library</name>
-        <version>libVersion-testing</version>
-        <externalReferences>
-          <reference type="issue-tracker">
-            <url>https://github.com/CycloneDX/cyclonedx-javascript-library/issues</url>
-            <comment>as detected from PackageJson property "bugs.url"</comment>
-          </reference>
-          <reference type="vcs">
-            <url>git+https://github.com/CycloneDX/cyclonedx-javascript-library.git</url>
-            <comment>as detected from PackageJson property "repository.url"</comment>
-          </reference>
-          <reference type="website">
-            <url>https://github.com/CycloneDX/cyclonedx-javascript-library#readme</url>
-            <comment>as detected from PackageJson property "homepage"</comment>
-          </reference>
-        </externalReferences>
-      </tool>
-      <tool>
-        <vendor>@cyclonedx</vendor>
-        <name>webpack-plugin</name>
-        <version>thisVersion-testing</version>
-        <externalReferences>
-          <reference type="issue-tracker">
-            <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
-            <comment>as detected from PackageJson property "bugs.url"</comment>
-          </reference>
-          <reference type="vcs">
-            <url>git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git</url>
-            <comment>as detected from PackageJson property "repository.url"</comment>
-          </reference>
-          <reference type="website">
-            <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme</url>
-            <comment>as detected from PackageJson property "homepage"</comment>
-          </reference>
-        </externalReferences>
-      </tool>
+      <components>
+        <component type="library">
+          <author>Jan Kowalleck</author>
+          <group>@cyclonedx</group>
+          <name>cyclonedx-library</name>
+          <version>7.0.0</version>
+          <description>Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).</description>
+          <licenses>
+            <license>
+              <id>Apache-2.0</id>
+            </license>
+          </licenses>
+          <externalReferences>
+            <reference type="issue-tracker">
+              <url>https://github.com/CycloneDX/cyclonedx-javascript-library/issues</url>
+              <comment>as detected from PackageJson property "bugs.url"</comment>
+            </reference>
+            <reference type="vcs">
+              <url>git+https://github.com/CycloneDX/cyclonedx-javascript-library.git</url>
+              <comment>as detected from PackageJson property "repository.url"</comment>
+            </reference>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-javascript-library#readme</url>
+              <comment>as detected from PackageJson property "homepage"</comment>
+            </reference>
+          </externalReferences>
+        </component>
+        <component type="library">
+          <author>Jan Kowalleck</author>
+          <group>@cyclonedx</group>
+          <name>webpack-plugin</name>
+          <version>3.15.1</version>
+          <description>Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects</description>
+          <licenses>
+            <license>
+              <id>Apache-2.0</id>
+            </license>
+          </licenses>
+          <externalReferences>
+            <reference type="issue-tracker">
+              <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
+              <comment>as detected from PackageJson property "bugs.url"</comment>
+            </reference>
+            <reference type="vcs">
+              <url>git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git</url>
+              <comment>as detected from PackageJson property "repository.url"</comment>
+            </reference>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme</url>
+              <comment>as detected from PackageJson property "homepage"</comment>
+            </reference>
+          </externalReferences>
+        </component>
+      </components>
     </tools>
-    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git">
+    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git">
       <author>Jan Kowalleck</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>example-webpack5-angular13</name>
@@ -2515,7 +2635,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
           <id>Apache-2.0</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git</purl>
+      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
@@ -2533,7 +2653,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common">
+    <component type="library" bom-ref="pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common">
       <author>angular</author>
       <group>@angular</group>
       <name>common</name>
@@ -2544,7 +2664,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common</purl>
+      <purl>pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/angular/angular/issues</url>
@@ -2560,7 +2680,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core">
+    <component type="library" bom-ref="pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core">
       <author>angular</author>
       <group>@angular</group>
       <name>core</name>
@@ -2571,7 +2691,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core</purl>
+      <purl>pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/angular/angular/issues</url>
@@ -2587,7 +2707,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser">
+    <component type="library" bom-ref="pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser">
       <author>angular</author>
       <group>@angular</group>
       <name>platform-browser</name>
@@ -2598,7 +2718,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser</purl>
+      <purl>pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/angular/angular/issues</url>
@@ -2614,7 +2734,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git">
+    <component type="library" bom-ref="pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git">
       <author>Tobias Koppers @sokra</author>
       <name>css-loader</name>
       <version>6.5.1</version>
@@ -2624,7 +2744,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git</purl>
+      <purl>pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/webpack-contrib/css-loader/issues</url>
@@ -2640,7 +2760,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git">
+    <component type="library" bom-ref="pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git">
       <author>Ben Lesh</author>
       <name>rxjs</name>
       <version>7.5.7</version>
@@ -2650,7 +2770,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
           <id>Apache-2.0</id>
         </license>
       </licenses>
-      <purl>pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git</purl>
+      <purl>pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/ReactiveX/RxJS/issues</url>
@@ -2666,7 +2786,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git">
+    <component type="library" bom-ref="pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git">
       <author>Microsoft Corp.</author>
       <name>tslib</name>
       <version>2.3.1</version>
@@ -2676,7 +2796,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
           <id>0BSD</id>
         </license>
       </licenses>
-      <purl>pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git</purl>
+      <purl>pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/Microsoft/TypeScript/issues</url>
@@ -2692,7 +2812,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/zone.js@0.11.8?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js">
+    <component type="library" bom-ref="pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js">
       <author>Brian Ford</author>
       <name>zone.js</name>
       <version>0.11.8</version>
@@ -2702,7 +2822,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/zone.js@0.11.8?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js</purl>
+      <purl>pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/angular/angular/issues</url>
@@ -2720,29 +2840,29 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
     </component>
   </components>
   <dependencies>
-    <dependency ref="pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common">
-      <dependency ref="pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"/>
+    <dependency ref="pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common">
+      <dependency ref="pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"/>
     </dependency>
-    <dependency ref="pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core">
-      <dependency ref="pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"/>
+    <dependency ref="pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core">
+      <dependency ref="pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"/>
     </dependency>
-    <dependency ref="pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser">
-      <dependency ref="pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common"/>
-      <dependency ref="pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"/>
+    <dependency ref="pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser">
+      <dependency ref="pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common"/>
+      <dependency ref="pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"/>
     </dependency>
-    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git">
-      <dependency ref="pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common"/>
-      <dependency ref="pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"/>
-      <dependency ref="pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser"/>
-      <dependency ref="pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"/>
-      <dependency ref="pkg:npm/zone.js@0.11.8?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js"/>
+    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular13?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git">
+      <dependency ref="pkg:npm/%40angular/common@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common"/>
+      <dependency ref="pkg:npm/%40angular/core@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"/>
+      <dependency ref="pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser"/>
+      <dependency ref="pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"/>
+      <dependency ref="pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js"/>
     </dependency>
-    <dependency ref="pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"/>
-    <dependency ref="pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git">
-      <dependency ref="pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+    <dependency ref="pkg:npm/css-loader@6.5.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"/>
+    <dependency ref="pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git">
+      <dependency ref="pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"/>
     </dependency>
-    <dependency ref="pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-    <dependency ref="pkg:npm/zone.js@0.11.8?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js"/>
+    <dependency ref="pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"/>
+    <dependency ref="pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js"/>
   </dependencies>
 </bom>"
 `;
@@ -2759,58 +2879,80 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
         "phase": "build"
       }
     ],
-    "tools": [
-      {
-        "vendor": "@cyclonedx",
-        "name": "cyclonedx-library",
-        "version": "libVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      },
-      {
-        "vendor": "@cyclonedx",
-        "name": "webpack-plugin",
-        "version": "thisVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      }
-    ],
+    "tools": {
+      "components": [
+        {
+          "type": "library",
+          "name": "cyclonedx-library",
+          "group": "@cyclonedx",
+          "version": "7.0.0",
+          "author": "Jan Kowalleck",
+          "description": "Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "name": "webpack-plugin",
+          "group": "@cyclonedx",
+          "version": "3.15.1",
+          "author": "Jan Kowalleck",
+          "description": "Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
       "name": "example-webpack5-angular17",
       "group": "@cyclonedx-webpack-plugin-tests",
       "version": "0.0.0",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/webpack5-angular17",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Fwebpack5-angular17",
       "author": "Jan Kowalleck",
       "description": "example setup witch Angular17 in WebPack5",
       "licenses": [
@@ -2821,7 +2963,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/webpack5-angular17",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Fwebpack5-angular17",
       "externalReferences": [
         {
           "url": "git+ssh://git@gitlab.example.com/demos/webpack5-angular17",
@@ -2842,7 +2984,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "name": "common",
       "group": "@angular",
       "version": "17.3.0",
-      "bom-ref": "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "bom-ref": "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "author": "angular",
       "description": "Angular - commonly needed directives and services",
       "licenses": [
@@ -2853,7 +2995,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "purl": "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -2877,7 +3019,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "name": "core",
       "group": "@angular",
       "version": "17.3.0",
-      "bom-ref": "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "bom-ref": "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "author": "angular",
       "description": "Angular - the core framework",
       "licenses": [
@@ -2888,7 +3030,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "purl": "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -2912,7 +3054,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "name": "platform-browser",
       "group": "@angular",
       "version": "17.3.0",
-      "bom-ref": "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "bom-ref": "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "author": "angular",
       "description": "Angular - library for using Angular in a web browser",
       "licenses": [
@@ -2923,7 +3065,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "purl": "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -2947,7 +3089,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "name": "router",
       "group": "@angular",
       "version": "17.3.0",
-      "bom-ref": "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router",
+      "bom-ref": "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router",
       "author": "angular",
       "description": "Angular - the routing library",
       "licenses": [
@@ -2958,7 +3100,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router",
+      "purl": "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -2982,7 +3124,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "name": "runtime",
       "group": "@babel",
       "version": "7.24.0",
-      "bom-ref": "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
+      "bom-ref": "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
       "author": "The Babel Team",
       "description": "babel's modular runtime helpers",
       "licenses": [
@@ -2993,7 +3135,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
+      "purl": "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
       "externalReferences": [
         {
           "url": "https://github.com/babel/babel/issues",
@@ -3016,7 +3158,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "type": "library",
       "name": "css-loader",
       "version": "6.10.0",
-      "bom-ref": "pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
+      "bom-ref": "pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
       "author": "Tobias Koppers @sokra",
       "description": "css loader module for webpack",
       "licenses": [
@@ -3027,7 +3169,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
+      "purl": "pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
       "externalReferences": [
         {
           "url": "https://github.com/webpack-contrib/css-loader/issues",
@@ -3050,7 +3192,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "type": "library",
       "name": "rxjs",
       "version": "7.8.1",
-      "bom-ref": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "bom-ref": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "author": "Ben Lesh",
       "description": "Reactive Extensions for modern JavaScript",
       "licenses": [
@@ -3061,7 +3203,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "purl": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "externalReferences": [
         {
           "url": "https://github.com/ReactiveX/RxJS/issues",
@@ -3084,7 +3226,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "type": "library",
       "name": "tslib",
       "version": "2.6.2",
-      "bom-ref": "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "bom-ref": "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
       "author": "Microsoft Corp.",
       "description": "Runtime library for TypeScript helper functions",
       "licenses": [
@@ -3095,7 +3237,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "purl": "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
       "externalReferences": [
         {
           "url": "https://github.com/Microsoft/TypeScript/issues",
@@ -3118,7 +3260,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "type": "library",
       "name": "zone.js",
       "version": "0.14.4",
-      "bom-ref": "pkg:npm/zone.js@0.14.4?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js",
+      "bom-ref": "pkg:npm/zone.js@0.14.4?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js",
       "author": "Brian Ford",
       "description": "Zones for JavaScript",
       "licenses": [
@@ -3129,7 +3271,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/zone.js@0.14.4?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js",
+      "purl": "pkg:npm/zone.js@0.14.4?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -3151,62 +3293,62 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "ref": "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "dependsOn": [
-        "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
-        "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
-        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"
+        "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
+        "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
+        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "ref": "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "dependsOn": [
-        "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
-        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"
+        "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
+        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "ref": "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "dependsOn": [
-        "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
-        "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"
+        "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
+        "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"
       ]
     },
     {
-      "ref": "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router",
+      "ref": "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router",
       "dependsOn": [
-        "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
-        "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
-        "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
-        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"
+        "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
+        "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
+        "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
+        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime"
+      "ref": "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime"
     },
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/webpack5-angular17",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Fwebpack5-angular17",
       "dependsOn": [
-        "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
-        "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
-        "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router",
-        "pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"
+        "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
+        "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
+        "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router",
+        "pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"
       ]
     },
     {
-      "ref": "pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"
+      "ref": "pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"
     },
     {
-      "ref": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "ref": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "dependsOn": [
-        "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+        "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
       ]
     },
     {
-      "ref": "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      "ref": "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
     },
     {
-      "ref": "pkg:npm/zone.js@0.14.4?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js"
+      "ref": "pkg:npm/zone.js@0.14.4?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js"
     }
   ]
 }"
@@ -3224,58 +3366,80 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
         "phase": "build"
       }
     ],
-    "tools": [
-      {
-        "vendor": "@cyclonedx",
-        "name": "cyclonedx-library",
-        "version": "libVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      },
-      {
-        "vendor": "@cyclonedx",
-        "name": "webpack-plugin",
-        "version": "thisVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      }
-    ],
+    "tools": {
+      "components": [
+        {
+          "type": "library",
+          "name": "cyclonedx-library",
+          "group": "@cyclonedx",
+          "version": "7.0.0",
+          "author": "Jan Kowalleck",
+          "description": "Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "name": "webpack-plugin",
+          "group": "@cyclonedx",
+          "version": "3.15.1",
+          "author": "Jan Kowalleck",
+          "description": "Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
       "name": "example-webpack5-angular17",
       "group": "@cyclonedx-webpack-plugin-tests",
       "version": "0.0.0",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/webpack5-angular17",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Fwebpack5-angular17",
       "author": "Jan Kowalleck",
       "description": "example setup witch Angular17 in WebPack5",
       "licenses": [
@@ -3286,7 +3450,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/webpack5-angular17",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Fwebpack5-angular17",
       "externalReferences": [
         {
           "url": "git+ssh://git@gitlab.example.com/demos/webpack5-angular17",
@@ -3307,7 +3471,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "name": "common",
       "group": "@angular",
       "version": "17.3.0",
-      "bom-ref": "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "bom-ref": "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "author": "angular",
       "description": "Angular - commonly needed directives and services",
       "licenses": [
@@ -3318,7 +3482,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "purl": "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -3342,7 +3506,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "name": "core",
       "group": "@angular",
       "version": "17.3.0",
-      "bom-ref": "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "bom-ref": "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "author": "angular",
       "description": "Angular - the core framework",
       "licenses": [
@@ -3353,7 +3517,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "purl": "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -3377,7 +3541,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "name": "platform-browser",
       "group": "@angular",
       "version": "17.3.0",
-      "bom-ref": "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "bom-ref": "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "author": "angular",
       "description": "Angular - library for using Angular in a web browser",
       "licenses": [
@@ -3388,7 +3552,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "purl": "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -3412,7 +3576,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "name": "router",
       "group": "@angular",
       "version": "17.3.0",
-      "bom-ref": "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router",
+      "bom-ref": "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router",
       "author": "angular",
       "description": "Angular - the routing library",
       "licenses": [
@@ -3423,7 +3587,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router",
+      "purl": "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -3447,7 +3611,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "name": "runtime",
       "group": "@babel",
       "version": "7.24.0",
-      "bom-ref": "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
+      "bom-ref": "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
       "author": "The Babel Team",
       "description": "babel's modular runtime helpers",
       "licenses": [
@@ -3458,7 +3622,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
+      "purl": "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
       "externalReferences": [
         {
           "url": "https://github.com/babel/babel/issues",
@@ -3481,7 +3645,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "type": "library",
       "name": "css-loader",
       "version": "6.10.0",
-      "bom-ref": "pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
+      "bom-ref": "pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
       "author": "Tobias Koppers @sokra",
       "description": "css loader module for webpack",
       "licenses": [
@@ -3492,7 +3656,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
+      "purl": "pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
       "externalReferences": [
         {
           "url": "https://github.com/webpack-contrib/css-loader/issues",
@@ -3515,7 +3679,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "type": "library",
       "name": "rxjs",
       "version": "7.8.1",
-      "bom-ref": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "bom-ref": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "author": "Ben Lesh",
       "description": "Reactive Extensions for modern JavaScript",
       "licenses": [
@@ -3526,7 +3690,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "purl": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "externalReferences": [
         {
           "url": "https://github.com/ReactiveX/RxJS/issues",
@@ -3549,7 +3713,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "type": "library",
       "name": "tslib",
       "version": "2.6.2",
-      "bom-ref": "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "bom-ref": "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
       "author": "Microsoft Corp.",
       "description": "Runtime library for TypeScript helper functions",
       "licenses": [
@@ -3560,7 +3724,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "purl": "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
       "externalReferences": [
         {
           "url": "https://github.com/Microsoft/TypeScript/issues",
@@ -3583,7 +3747,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "type": "library",
       "name": "zone.js",
       "version": "0.14.4",
-      "bom-ref": "pkg:npm/zone.js@0.14.4?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js",
+      "bom-ref": "pkg:npm/zone.js@0.14.4?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js",
       "author": "Brian Ford",
       "description": "Zones for JavaScript",
       "licenses": [
@@ -3594,7 +3758,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           }
         }
       ],
-      "purl": "pkg:npm/zone.js@0.14.4?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js",
+      "purl": "pkg:npm/zone.js@0.14.4?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js",
       "externalReferences": [
         {
           "url": "https://github.com/angular/angular/issues",
@@ -3616,62 +3780,62 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
+      "ref": "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
       "dependsOn": [
-        "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
-        "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
-        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"
+        "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
+        "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
+        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
+      "ref": "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
       "dependsOn": [
-        "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
-        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"
+        "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
+        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
+      "ref": "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
       "dependsOn": [
-        "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
-        "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"
+        "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
+        "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"
       ]
     },
     {
-      "ref": "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router",
+      "ref": "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router",
       "dependsOn": [
-        "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common",
-        "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
-        "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
-        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"
+        "pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common",
+        "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
+        "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
+        "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime"
+      "ref": "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime"
     },
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/webpack5-angular17",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Fwebpack5-angular17",
       "dependsOn": [
-        "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core",
-        "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser",
-        "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router",
-        "pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"
+        "pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core",
+        "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser",
+        "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router",
+        "pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"
       ]
     },
     {
-      "ref": "pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"
+      "ref": "pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"
     },
     {
-      "ref": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git",
+      "ref": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
       "dependsOn": [
-        "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+        "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
       ]
     },
     {
-      "ref": "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      "ref": "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
     },
     {
-      "ref": "pkg:npm/zone.js@0.14.4?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js"
+      "ref": "pkg:npm/zone.js@0.14.4?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js"
     }
   ]
 }"
@@ -3687,46 +3851,62 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
       </lifecycle>
     </lifecycles>
     <tools>
-      <tool>
-        <vendor>@cyclonedx</vendor>
-        <name>cyclonedx-library</name>
-        <version>libVersion-testing</version>
-        <externalReferences>
-          <reference type="issue-tracker">
-            <url>https://github.com/CycloneDX/cyclonedx-javascript-library/issues</url>
-            <comment>as detected from PackageJson property "bugs.url"</comment>
-          </reference>
-          <reference type="vcs">
-            <url>git+https://github.com/CycloneDX/cyclonedx-javascript-library.git</url>
-            <comment>as detected from PackageJson property "repository.url"</comment>
-          </reference>
-          <reference type="website">
-            <url>https://github.com/CycloneDX/cyclonedx-javascript-library#readme</url>
-            <comment>as detected from PackageJson property "homepage"</comment>
-          </reference>
-        </externalReferences>
-      </tool>
-      <tool>
-        <vendor>@cyclonedx</vendor>
-        <name>webpack-plugin</name>
-        <version>thisVersion-testing</version>
-        <externalReferences>
-          <reference type="issue-tracker">
-            <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
-            <comment>as detected from PackageJson property "bugs.url"</comment>
-          </reference>
-          <reference type="vcs">
-            <url>git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git</url>
-            <comment>as detected from PackageJson property "repository.url"</comment>
-          </reference>
-          <reference type="website">
-            <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme</url>
-            <comment>as detected from PackageJson property "homepage"</comment>
-          </reference>
-        </externalReferences>
-      </tool>
+      <components>
+        <component type="library">
+          <author>Jan Kowalleck</author>
+          <group>@cyclonedx</group>
+          <name>cyclonedx-library</name>
+          <version>7.0.0</version>
+          <description>Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).</description>
+          <licenses>
+            <license>
+              <id>Apache-2.0</id>
+            </license>
+          </licenses>
+          <externalReferences>
+            <reference type="issue-tracker">
+              <url>https://github.com/CycloneDX/cyclonedx-javascript-library/issues</url>
+              <comment>as detected from PackageJson property "bugs.url"</comment>
+            </reference>
+            <reference type="vcs">
+              <url>git+https://github.com/CycloneDX/cyclonedx-javascript-library.git</url>
+              <comment>as detected from PackageJson property "repository.url"</comment>
+            </reference>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-javascript-library#readme</url>
+              <comment>as detected from PackageJson property "homepage"</comment>
+            </reference>
+          </externalReferences>
+        </component>
+        <component type="library">
+          <author>Jan Kowalleck</author>
+          <group>@cyclonedx</group>
+          <name>webpack-plugin</name>
+          <version>3.15.1</version>
+          <description>Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects</description>
+          <licenses>
+            <license>
+              <id>Apache-2.0</id>
+            </license>
+          </licenses>
+          <externalReferences>
+            <reference type="issue-tracker">
+              <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
+              <comment>as detected from PackageJson property "bugs.url"</comment>
+            </reference>
+            <reference type="vcs">
+              <url>git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git</url>
+              <comment>as detected from PackageJson property "repository.url"</comment>
+            </reference>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme</url>
+              <comment>as detected from PackageJson property "homepage"</comment>
+            </reference>
+          </externalReferences>
+        </component>
+      </components>
     </tools>
-    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/webpack5-angular17">
+    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Fwebpack5-angular17">
       <author>Jan Kowalleck</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>example-webpack5-angular17</name>
@@ -3737,7 +3917,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
           <id>Apache-2.0</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/webpack5-angular17</purl>
+      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Fwebpack5-angular17</purl>
       <externalReferences>
         <reference type="vcs">
           <url>git+ssh://git@gitlab.example.com/demos/webpack5-angular17</url>
@@ -3751,7 +3931,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common">
+    <component type="library" bom-ref="pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common">
       <author>angular</author>
       <group>@angular</group>
       <name>common</name>
@@ -3762,7 +3942,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common</purl>
+      <purl>pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/angular/angular/issues</url>
@@ -3778,7 +3958,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core">
+    <component type="library" bom-ref="pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core">
       <author>angular</author>
       <group>@angular</group>
       <name>core</name>
@@ -3789,7 +3969,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core</purl>
+      <purl>pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/angular/angular/issues</url>
@@ -3805,7 +3985,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser">
+    <component type="library" bom-ref="pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser">
       <author>angular</author>
       <group>@angular</group>
       <name>platform-browser</name>
@@ -3816,7 +3996,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser</purl>
+      <purl>pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/angular/angular/issues</url>
@@ -3832,7 +4012,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router">
+    <component type="library" bom-ref="pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router">
       <author>angular</author>
       <group>@angular</group>
       <name>router</name>
@@ -3843,7 +4023,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router</purl>
+      <purl>pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/angular/angular/issues</url>
@@ -3859,7 +4039,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime">
+    <component type="library" bom-ref="pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime">
       <author>The Babel Team</author>
       <group>@babel</group>
       <name>runtime</name>
@@ -3870,7 +4050,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime</purl>
+      <purl>pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/babel/babel/issues</url>
@@ -3886,7 +4066,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git">
+    <component type="library" bom-ref="pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git">
       <author>Tobias Koppers @sokra</author>
       <name>css-loader</name>
       <version>6.10.0</version>
@@ -3896,7 +4076,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git</purl>
+      <purl>pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/webpack-contrib/css-loader/issues</url>
@@ -3912,7 +4092,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git">
+    <component type="library" bom-ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git">
       <author>Ben Lesh</author>
       <name>rxjs</name>
       <version>7.8.1</version>
@@ -3922,7 +4102,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
           <id>Apache-2.0</id>
         </license>
       </licenses>
-      <purl>pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git</purl>
+      <purl>pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/ReactiveX/RxJS/issues</url>
@@ -3938,7 +4118,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git">
+    <component type="library" bom-ref="pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git">
       <author>Microsoft Corp.</author>
       <name>tslib</name>
       <version>2.6.2</version>
@@ -3948,7 +4128,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
           <id>0BSD</id>
         </license>
       </licenses>
-      <purl>pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git</purl>
+      <purl>pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/Microsoft/TypeScript/issues</url>
@@ -3964,7 +4144,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/zone.js@0.14.4?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js">
+    <component type="library" bom-ref="pkg:npm/zone.js@0.14.4?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js">
       <author>Brian Ford</author>
       <name>zone.js</name>
       <version>0.14.4</version>
@@ -3974,7 +4154,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/zone.js@0.14.4?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js</purl>
+      <purl>pkg:npm/zone.js@0.14.4?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/angular/angular/issues</url>
@@ -3992,38 +4172,38 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
     </component>
   </components>
   <dependencies>
-    <dependency ref="pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common">
-      <dependency ref="pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"/>
-      <dependency ref="pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime"/>
-      <dependency ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"/>
+    <dependency ref="pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common">
+      <dependency ref="pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"/>
+      <dependency ref="pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime"/>
+      <dependency ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"/>
     </dependency>
-    <dependency ref="pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core">
-      <dependency ref="pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime"/>
-      <dependency ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"/>
+    <dependency ref="pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core">
+      <dependency ref="pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime"/>
+      <dependency ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"/>
     </dependency>
-    <dependency ref="pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser">
-      <dependency ref="pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common"/>
-      <dependency ref="pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"/>
+    <dependency ref="pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser">
+      <dependency ref="pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common"/>
+      <dependency ref="pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"/>
     </dependency>
-    <dependency ref="pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router">
-      <dependency ref="pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/common"/>
-      <dependency ref="pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"/>
-      <dependency ref="pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser"/>
-      <dependency ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git"/>
+    <dependency ref="pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router">
+      <dependency ref="pkg:npm/%40angular/common@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/common"/>
+      <dependency ref="pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"/>
+      <dependency ref="pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser"/>
+      <dependency ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git"/>
     </dependency>
-    <dependency ref="pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime"/>
-    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A//git%40gitlab.example.com/demos/webpack5-angular17">
-      <dependency ref="pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/core"/>
-      <dependency ref="pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/platform-browser"/>
-      <dependency ref="pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A//github.com/angular/angular.git#packages/router"/>
-      <dependency ref="pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"/>
+    <dependency ref="pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime"/>
+    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0?vcs_url=git%2Bssh%3A%2F%2Fgit%40gitlab.example.com%2Fdemos%2Fwebpack5-angular17">
+      <dependency ref="pkg:npm/%40angular/core@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/core"/>
+      <dependency ref="pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/platform-browser"/>
+      <dependency ref="pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/router"/>
+      <dependency ref="pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"/>
     </dependency>
-    <dependency ref="pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"/>
-    <dependency ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A//github.com/reactivex/rxjs.git">
-      <dependency ref="pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+    <dependency ref="pkg:npm/css-loader@6.10.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"/>
+    <dependency ref="pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git">
+      <dependency ref="pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"/>
     </dependency>
-    <dependency ref="pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-    <dependency ref="pkg:npm/zone.js@0.14.4?vcs_url=git%3A//github.com/angular/angular.git#packages/zone.js"/>
+    <dependency ref="pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"/>
+    <dependency ref="pkg:npm/zone.js@0.14.4?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git#packages/zone.js"/>
   </dependencies>
 </bom>"
 `;
@@ -4040,58 +4220,80 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
         "phase": "build"
       }
     ],
-    "tools": [
-      {
-        "vendor": "@cyclonedx",
-        "name": "cyclonedx-library",
-        "version": "libVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      },
-      {
-        "vendor": "@cyclonedx",
-        "name": "webpack-plugin",
-        "version": "thisVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      }
-    ],
+    "tools": {
+      "components": [
+        {
+          "type": "library",
+          "name": "cyclonedx-library",
+          "group": "@cyclonedx",
+          "version": "7.0.0",
+          "author": "Jan Kowalleck",
+          "description": "Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "name": "webpack-plugin",
+          "group": "@cyclonedx",
+          "version": "3.15.1",
+          "author": "Jan Kowalleck",
+          "description": "Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
       "name": "example-webpack5-react18",
       "group": "@cyclonedx-webpack-plugin-tests",
       "version": "0.0.1",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-react18",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-react18",
       "author": "Jan Kowalleck",
       "description": "example setup with react and webpack5",
       "licenses": [
@@ -4102,7 +4304,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-react18",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-react18",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -4128,7 +4330,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "name": "runtime",
       "group": "@babel",
       "version": "7.18.3",
-      "bom-ref": "pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
+      "bom-ref": "pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
       "author": "The Babel Team",
       "description": "babel's modular runtime helpers",
       "licenses": [
@@ -4139,7 +4341,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
           }
         }
       ],
-      "purl": "pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
+      "purl": "pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
       "externalReferences": [
         {
           "url": "https://github.com/babel/babel/issues",
@@ -4162,7 +4364,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "type": "library",
       "name": "css-loader",
       "version": "6.7.1",
-      "bom-ref": "pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
+      "bom-ref": "pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
       "author": "Tobias Koppers @sokra",
       "description": "css loader module for webpack",
       "licenses": [
@@ -4173,7 +4375,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
           }
         }
       ],
-      "purl": "pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
+      "purl": "pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
       "externalReferences": [
         {
           "url": "https://github.com/webpack-contrib/css-loader/issues",
@@ -4196,7 +4398,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "type": "library",
       "name": "react-dom",
       "version": "18.2.0",
-      "bom-ref": "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react-dom",
+      "bom-ref": "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react-dom",
       "description": "React package for working with the DOM.",
       "licenses": [
         {
@@ -4206,7 +4408,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
           }
         }
       ],
-      "purl": "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react-dom",
+      "purl": "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react-dom",
       "externalReferences": [
         {
           "url": "https://github.com/facebook/react/issues",
@@ -4229,7 +4431,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "type": "library",
       "name": "react",
       "version": "18.2.0",
-      "bom-ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+      "bom-ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react",
       "description": "React is a JavaScript library for building user interfaces.",
       "licenses": [
         {
@@ -4239,7 +4441,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
           }
         }
       ],
-      "purl": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+      "purl": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react",
       "externalReferences": [
         {
           "url": "https://github.com/facebook/react/issues",
@@ -4262,7 +4464,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "type": "library",
       "name": "scheduler",
       "version": "0.23.0",
-      "bom-ref": "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/scheduler",
+      "bom-ref": "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/scheduler",
       "description": "Cooperative scheduler for the browser environment.",
       "licenses": [
         {
@@ -4272,7 +4474,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
           }
         }
       ],
-      "purl": "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/scheduler",
+      "purl": "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/scheduler",
       "externalReferences": [
         {
           "url": "https://github.com/facebook/react/issues",
@@ -4295,7 +4497,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "type": "library",
       "name": "web-vitals",
       "version": "2.1.4",
-      "bom-ref": "pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A//github.com/GoogleChrome/web-vitals.git",
+      "bom-ref": "pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FGoogleChrome%2Fweb-vitals.git",
       "author": "Philip Walton",
       "description": "Easily measure performance metrics in JavaScript",
       "licenses": [
@@ -4306,7 +4508,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
           }
         }
       ],
-      "purl": "pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A//github.com/GoogleChrome/web-vitals.git",
+      "purl": "pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FGoogleChrome%2Fweb-vitals.git",
       "externalReferences": [
         {
           "url": "https://github.com/GoogleChrome/web-vitals/issues",
@@ -4328,35 +4530,35 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime"
+      "ref": "pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime"
     },
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-react18",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-react18",
       "dependsOn": [
-        "pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
-        "pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
-        "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react-dom",
-        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
+        "pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
+        "pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
+        "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react-dom",
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react"
       ]
     },
     {
-      "ref": "pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"
+      "ref": "pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"
     },
     {
-      "ref": "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react-dom",
+      "ref": "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react-dom",
       "dependsOn": [
-        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
-        "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/scheduler"
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react",
+        "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/scheduler"
       ]
     },
     {
-      "ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
+      "ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react"
     },
     {
-      "ref": "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/scheduler"
+      "ref": "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/scheduler"
     },
     {
-      "ref": "pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A//github.com/GoogleChrome/web-vitals.git"
+      "ref": "pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FGoogleChrome%2Fweb-vitals.git"
     }
   ]
 }"
@@ -4374,58 +4576,80 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
         "phase": "build"
       }
     ],
-    "tools": [
-      {
-        "vendor": "@cyclonedx",
-        "name": "cyclonedx-library",
-        "version": "libVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      },
-      {
-        "vendor": "@cyclonedx",
-        "name": "webpack-plugin",
-        "version": "thisVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      }
-    ],
+    "tools": {
+      "components": [
+        {
+          "type": "library",
+          "name": "cyclonedx-library",
+          "group": "@cyclonedx",
+          "version": "7.0.0",
+          "author": "Jan Kowalleck",
+          "description": "Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "name": "webpack-plugin",
+          "group": "@cyclonedx",
+          "version": "3.15.1",
+          "author": "Jan Kowalleck",
+          "description": "Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
       "name": "example-webpack5-react18",
       "group": "@cyclonedx-webpack-plugin-tests",
       "version": "0.0.1",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-react18",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-react18",
       "author": "Jan Kowalleck",
       "description": "example setup with react and webpack5",
       "licenses": [
@@ -4436,7 +4660,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-react18",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-react18",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -4462,7 +4686,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "name": "runtime",
       "group": "@babel",
       "version": "7.18.3",
-      "bom-ref": "pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
+      "bom-ref": "pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
       "author": "The Babel Team",
       "description": "babel's modular runtime helpers",
       "licenses": [
@@ -4473,7 +4697,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
           }
         }
       ],
-      "purl": "pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
+      "purl": "pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
       "externalReferences": [
         {
           "url": "https://github.com/babel/babel/issues",
@@ -4496,7 +4720,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "type": "library",
       "name": "css-loader",
       "version": "6.7.1",
-      "bom-ref": "pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
+      "bom-ref": "pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
       "author": "Tobias Koppers @sokra",
       "description": "css loader module for webpack",
       "licenses": [
@@ -4507,7 +4731,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
           }
         }
       ],
-      "purl": "pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
+      "purl": "pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
       "externalReferences": [
         {
           "url": "https://github.com/webpack-contrib/css-loader/issues",
@@ -4530,7 +4754,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "type": "library",
       "name": "react-dom",
       "version": "18.2.0",
-      "bom-ref": "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react-dom",
+      "bom-ref": "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react-dom",
       "description": "React package for working with the DOM.",
       "licenses": [
         {
@@ -4540,7 +4764,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
           }
         }
       ],
-      "purl": "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react-dom",
+      "purl": "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react-dom",
       "externalReferences": [
         {
           "url": "https://github.com/facebook/react/issues",
@@ -4563,7 +4787,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "type": "library",
       "name": "react",
       "version": "18.2.0",
-      "bom-ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+      "bom-ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react",
       "description": "React is a JavaScript library for building user interfaces.",
       "licenses": [
         {
@@ -4573,7 +4797,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
           }
         }
       ],
-      "purl": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+      "purl": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react",
       "externalReferences": [
         {
           "url": "https://github.com/facebook/react/issues",
@@ -4596,7 +4820,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "type": "library",
       "name": "scheduler",
       "version": "0.23.0",
-      "bom-ref": "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/scheduler",
+      "bom-ref": "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/scheduler",
       "description": "Cooperative scheduler for the browser environment.",
       "licenses": [
         {
@@ -4606,7 +4830,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
           }
         }
       ],
-      "purl": "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/scheduler",
+      "purl": "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/scheduler",
       "externalReferences": [
         {
           "url": "https://github.com/facebook/react/issues",
@@ -4629,7 +4853,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "type": "library",
       "name": "web-vitals",
       "version": "2.1.4",
-      "bom-ref": "pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A//github.com/GoogleChrome/web-vitals.git",
+      "bom-ref": "pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FGoogleChrome%2Fweb-vitals.git",
       "author": "Philip Walton",
       "description": "Easily measure performance metrics in JavaScript",
       "licenses": [
@@ -4640,7 +4864,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
           }
         }
       ],
-      "purl": "pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A//github.com/GoogleChrome/web-vitals.git",
+      "purl": "pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FGoogleChrome%2Fweb-vitals.git",
       "externalReferences": [
         {
           "url": "https://github.com/GoogleChrome/web-vitals/issues",
@@ -4662,35 +4886,35 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime"
+      "ref": "pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime"
     },
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-react18",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-react18",
       "dependsOn": [
-        "pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime",
-        "pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git",
-        "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react-dom",
-        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
+        "pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime",
+        "pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git",
+        "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react-dom",
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react"
       ]
     },
     {
-      "ref": "pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"
+      "ref": "pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"
     },
     {
-      "ref": "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react-dom",
+      "ref": "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react-dom",
       "dependsOn": [
-        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
-        "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/scheduler"
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react",
+        "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/scheduler"
       ]
     },
     {
-      "ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
+      "ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react"
     },
     {
-      "ref": "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/scheduler"
+      "ref": "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/scheduler"
     },
     {
-      "ref": "pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A//github.com/GoogleChrome/web-vitals.git"
+      "ref": "pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FGoogleChrome%2Fweb-vitals.git"
     }
   ]
 }"
@@ -4706,46 +4930,62 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
       </lifecycle>
     </lifecycles>
     <tools>
-      <tool>
-        <vendor>@cyclonedx</vendor>
-        <name>cyclonedx-library</name>
-        <version>libVersion-testing</version>
-        <externalReferences>
-          <reference type="issue-tracker">
-            <url>https://github.com/CycloneDX/cyclonedx-javascript-library/issues</url>
-            <comment>as detected from PackageJson property "bugs.url"</comment>
-          </reference>
-          <reference type="vcs">
-            <url>git+https://github.com/CycloneDX/cyclonedx-javascript-library.git</url>
-            <comment>as detected from PackageJson property "repository.url"</comment>
-          </reference>
-          <reference type="website">
-            <url>https://github.com/CycloneDX/cyclonedx-javascript-library#readme</url>
-            <comment>as detected from PackageJson property "homepage"</comment>
-          </reference>
-        </externalReferences>
-      </tool>
-      <tool>
-        <vendor>@cyclonedx</vendor>
-        <name>webpack-plugin</name>
-        <version>thisVersion-testing</version>
-        <externalReferences>
-          <reference type="issue-tracker">
-            <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
-            <comment>as detected from PackageJson property "bugs.url"</comment>
-          </reference>
-          <reference type="vcs">
-            <url>git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git</url>
-            <comment>as detected from PackageJson property "repository.url"</comment>
-          </reference>
-          <reference type="website">
-            <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme</url>
-            <comment>as detected from PackageJson property "homepage"</comment>
-          </reference>
-        </externalReferences>
-      </tool>
+      <components>
+        <component type="library">
+          <author>Jan Kowalleck</author>
+          <group>@cyclonedx</group>
+          <name>cyclonedx-library</name>
+          <version>7.0.0</version>
+          <description>Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).</description>
+          <licenses>
+            <license>
+              <id>Apache-2.0</id>
+            </license>
+          </licenses>
+          <externalReferences>
+            <reference type="issue-tracker">
+              <url>https://github.com/CycloneDX/cyclonedx-javascript-library/issues</url>
+              <comment>as detected from PackageJson property "bugs.url"</comment>
+            </reference>
+            <reference type="vcs">
+              <url>git+https://github.com/CycloneDX/cyclonedx-javascript-library.git</url>
+              <comment>as detected from PackageJson property "repository.url"</comment>
+            </reference>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-javascript-library#readme</url>
+              <comment>as detected from PackageJson property "homepage"</comment>
+            </reference>
+          </externalReferences>
+        </component>
+        <component type="library">
+          <author>Jan Kowalleck</author>
+          <group>@cyclonedx</group>
+          <name>webpack-plugin</name>
+          <version>3.15.1</version>
+          <description>Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects</description>
+          <licenses>
+            <license>
+              <id>Apache-2.0</id>
+            </license>
+          </licenses>
+          <externalReferences>
+            <reference type="issue-tracker">
+              <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
+              <comment>as detected from PackageJson property "bugs.url"</comment>
+            </reference>
+            <reference type="vcs">
+              <url>git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git</url>
+              <comment>as detected from PackageJson property "repository.url"</comment>
+            </reference>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme</url>
+              <comment>as detected from PackageJson property "homepage"</comment>
+            </reference>
+          </externalReferences>
+        </component>
+      </components>
     </tools>
-    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-react18">
+    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-react18">
       <author>Jan Kowalleck</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>example-webpack5-react18</name>
@@ -4756,7 +4996,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
           <id>Apache-2.0</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-react18</purl>
+      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-react18</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
@@ -4774,7 +5014,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime">
+    <component type="library" bom-ref="pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime">
       <author>The Babel Team</author>
       <group>@babel</group>
       <name>runtime</name>
@@ -4785,7 +5025,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime</purl>
+      <purl>pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/babel/babel/issues</url>
@@ -4801,7 +5041,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git">
+    <component type="library" bom-ref="pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git">
       <author>Tobias Koppers @sokra</author>
       <name>css-loader</name>
       <version>6.7.1</version>
@@ -4811,7 +5051,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git</purl>
+      <purl>pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/webpack-contrib/css-loader/issues</url>
@@ -4827,7 +5067,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react-dom">
+    <component type="library" bom-ref="pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react-dom">
       <name>react-dom</name>
       <version>18.2.0</version>
       <description>React package for working with the DOM.</description>
@@ -4836,7 +5076,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react-dom</purl>
+      <purl>pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react-dom</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/facebook/react/issues</url>
@@ -4852,7 +5092,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react">
+    <component type="library" bom-ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react">
       <name>react</name>
       <version>18.2.0</version>
       <description>React is a JavaScript library for building user interfaces.</description>
@@ -4861,7 +5101,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react</purl>
+      <purl>pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/facebook/react/issues</url>
@@ -4877,7 +5117,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/scheduler">
+    <component type="library" bom-ref="pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/scheduler">
       <name>scheduler</name>
       <version>0.23.0</version>
       <description>Cooperative scheduler for the browser environment.</description>
@@ -4886,7 +5126,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/scheduler</purl>
+      <purl>pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/scheduler</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/facebook/react/issues</url>
@@ -4902,7 +5142,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A//github.com/GoogleChrome/web-vitals.git">
+    <component type="library" bom-ref="pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FGoogleChrome%2Fweb-vitals.git">
       <author>Philip Walton</author>
       <name>web-vitals</name>
       <version>2.1.4</version>
@@ -4912,7 +5152,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
           <id>Apache-2.0</id>
         </license>
       </licenses>
-      <purl>pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A//github.com/GoogleChrome/web-vitals.git</purl>
+      <purl>pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FGoogleChrome%2Fweb-vitals.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/GoogleChrome/web-vitals/issues</url>
@@ -4930,21 +5170,21 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
     </component>
   </components>
   <dependencies>
-    <dependency ref="pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime"/>
-    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-react18">
-      <dependency ref="pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A//github.com/babel/babel.git#packages/babel-runtime"/>
-      <dependency ref="pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"/>
-      <dependency ref="pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react-dom"/>
-      <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"/>
+    <dependency ref="pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime"/>
+    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-react18">
+      <dependency ref="pkg:npm/%40babel/runtime@7.18.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git#packages/babel-runtime"/>
+      <dependency ref="pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"/>
+      <dependency ref="pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react-dom"/>
+      <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react"/>
     </dependency>
-    <dependency ref="pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A//github.com/webpack-contrib/css-loader.git"/>
-    <dependency ref="pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react-dom">
-      <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"/>
-      <dependency ref="pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/scheduler"/>
+    <dependency ref="pkg:npm/css-loader@6.7.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fwebpack-contrib%2Fcss-loader.git"/>
+    <dependency ref="pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react-dom">
+      <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react"/>
+      <dependency ref="pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/scheduler"/>
     </dependency>
-    <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"/>
-    <dependency ref="pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/scheduler"/>
-    <dependency ref="pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A//github.com/GoogleChrome/web-vitals.git"/>
+    <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react"/>
+    <dependency ref="pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/scheduler"/>
+    <dependency ref="pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FGoogleChrome%2Fweb-vitals.git"/>
   </dependencies>
 </bom>"
 `;
@@ -4961,57 +5201,79 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.b
         "phase": "build"
       }
     ],
-    "tools": [
-      {
-        "vendor": "@cyclonedx",
-        "name": "cyclonedx-library",
-        "version": "libVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      },
-      {
-        "vendor": "@cyclonedx",
-        "name": "webpack-plugin",
-        "version": "thisVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      }
-    ],
+    "tools": {
+      "components": [
+        {
+          "type": "library",
+          "name": "cyclonedx-library",
+          "group": "@cyclonedx",
+          "version": "7.0.0",
+          "author": "Jan Kowalleck",
+          "description": "Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "name": "webpack-plugin",
+          "group": "@cyclonedx",
+          "version": "3.15.1",
+          "author": "Jan Kowalleck",
+          "description": "Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
       "name": "example-webpack5-vue2",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
       "author": "Jan Kowalleck",
       "description": "example setup witch Vue2 in WebPack5",
       "licenses": [
@@ -5022,7 +5284,7 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.b
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -5047,7 +5309,7 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.b
       "type": "library",
       "name": "vue",
       "version": "2.6.14",
-      "bom-ref": "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git",
+      "bom-ref": "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git",
       "author": "Evan You",
       "description": "Reactive, component-oriented view layer for modern web interfaces.",
       "licenses": [
@@ -5058,7 +5320,7 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.b
           }
         }
       ],
-      "purl": "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git",
+      "purl": "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git",
       "externalReferences": [
         {
           "url": "https://github.com/vuejs/vue/issues",
@@ -5080,13 +5342,13 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.b
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
       "dependsOn": [
-        "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"
+        "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"
       ]
     },
     {
-      "ref": "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"
+      "ref": "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"
     }
   ]
 }"
@@ -5104,57 +5366,79 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.w
         "phase": "build"
       }
     ],
-    "tools": [
-      {
-        "vendor": "@cyclonedx",
-        "name": "cyclonedx-library",
-        "version": "libVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      },
-      {
-        "vendor": "@cyclonedx",
-        "name": "webpack-plugin",
-        "version": "thisVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      }
-    ],
+    "tools": {
+      "components": [
+        {
+          "type": "library",
+          "name": "cyclonedx-library",
+          "group": "@cyclonedx",
+          "version": "7.0.0",
+          "author": "Jan Kowalleck",
+          "description": "Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "name": "webpack-plugin",
+          "group": "@cyclonedx",
+          "version": "3.15.1",
+          "author": "Jan Kowalleck",
+          "description": "Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
       "name": "example-webpack5-vue2",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
       "author": "Jan Kowalleck",
       "description": "example setup witch Vue2 in WebPack5",
       "licenses": [
@@ -5165,7 +5449,7 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.w
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -5190,7 +5474,7 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.w
       "type": "library",
       "name": "vue",
       "version": "2.6.14",
-      "bom-ref": "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git",
+      "bom-ref": "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git",
       "author": "Evan You",
       "description": "Reactive, component-oriented view layer for modern web interfaces.",
       "licenses": [
@@ -5201,7 +5485,7 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.w
           }
         }
       ],
-      "purl": "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git",
+      "purl": "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git",
       "externalReferences": [
         {
           "url": "https://github.com/vuejs/vue/issues",
@@ -5223,13 +5507,13 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.w
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2",
       "dependsOn": [
-        "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"
+        "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"
       ]
     },
     {
-      "ref": "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"
+      "ref": "pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"
     }
   ]
 }"
@@ -5245,46 +5529,62 @@ exports[`integration functional: webpack5 with vue2 generated xml file: dist/.bo
       </lifecycle>
     </lifecycles>
     <tools>
-      <tool>
-        <vendor>@cyclonedx</vendor>
-        <name>cyclonedx-library</name>
-        <version>libVersion-testing</version>
-        <externalReferences>
-          <reference type="issue-tracker">
-            <url>https://github.com/CycloneDX/cyclonedx-javascript-library/issues</url>
-            <comment>as detected from PackageJson property "bugs.url"</comment>
-          </reference>
-          <reference type="vcs">
-            <url>git+https://github.com/CycloneDX/cyclonedx-javascript-library.git</url>
-            <comment>as detected from PackageJson property "repository.url"</comment>
-          </reference>
-          <reference type="website">
-            <url>https://github.com/CycloneDX/cyclonedx-javascript-library#readme</url>
-            <comment>as detected from PackageJson property "homepage"</comment>
-          </reference>
-        </externalReferences>
-      </tool>
-      <tool>
-        <vendor>@cyclonedx</vendor>
-        <name>webpack-plugin</name>
-        <version>thisVersion-testing</version>
-        <externalReferences>
-          <reference type="issue-tracker">
-            <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
-            <comment>as detected from PackageJson property "bugs.url"</comment>
-          </reference>
-          <reference type="vcs">
-            <url>git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git</url>
-            <comment>as detected from PackageJson property "repository.url"</comment>
-          </reference>
-          <reference type="website">
-            <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme</url>
-            <comment>as detected from PackageJson property "homepage"</comment>
-          </reference>
-        </externalReferences>
-      </tool>
+      <components>
+        <component type="library">
+          <author>Jan Kowalleck</author>
+          <group>@cyclonedx</group>
+          <name>cyclonedx-library</name>
+          <version>7.0.0</version>
+          <description>Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).</description>
+          <licenses>
+            <license>
+              <id>Apache-2.0</id>
+            </license>
+          </licenses>
+          <externalReferences>
+            <reference type="issue-tracker">
+              <url>https://github.com/CycloneDX/cyclonedx-javascript-library/issues</url>
+              <comment>as detected from PackageJson property "bugs.url"</comment>
+            </reference>
+            <reference type="vcs">
+              <url>git+https://github.com/CycloneDX/cyclonedx-javascript-library.git</url>
+              <comment>as detected from PackageJson property "repository.url"</comment>
+            </reference>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-javascript-library#readme</url>
+              <comment>as detected from PackageJson property "homepage"</comment>
+            </reference>
+          </externalReferences>
+        </component>
+        <component type="library">
+          <author>Jan Kowalleck</author>
+          <group>@cyclonedx</group>
+          <name>webpack-plugin</name>
+          <version>3.15.1</version>
+          <description>Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects</description>
+          <licenses>
+            <license>
+              <id>Apache-2.0</id>
+            </license>
+          </licenses>
+          <externalReferences>
+            <reference type="issue-tracker">
+              <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
+              <comment>as detected from PackageJson property "bugs.url"</comment>
+            </reference>
+            <reference type="vcs">
+              <url>git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git</url>
+              <comment>as detected from PackageJson property "repository.url"</comment>
+            </reference>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme</url>
+              <comment>as detected from PackageJson property "homepage"</comment>
+            </reference>
+          </externalReferences>
+        </component>
+      </components>
     </tools>
-    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2">
+    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2">
       <author>Jan Kowalleck</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>example-webpack5-vue2</name>
@@ -5294,7 +5594,7 @@ exports[`integration functional: webpack5 with vue2 generated xml file: dist/.bo
           <id>Apache-2.0</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2</purl>
+      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
@@ -5312,7 +5612,7 @@ exports[`integration functional: webpack5 with vue2 generated xml file: dist/.bo
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git">
+    <component type="library" bom-ref="pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git">
       <author>Evan You</author>
       <name>vue</name>
       <version>2.6.14</version>
@@ -5322,7 +5622,7 @@ exports[`integration functional: webpack5 with vue2 generated xml file: dist/.bo
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git</purl>
+      <purl>pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/vuejs/vue/issues</url>
@@ -5340,10 +5640,10 @@ exports[`integration functional: webpack5 with vue2 generated xml file: dist/.bo
     </component>
   </components>
   <dependencies>
-    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A//git%40github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2">
-      <dependency ref="pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"/>
+    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2?vcs_url=git%2Bssh%3A%2F%2Fgit%40github.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2">
+      <dependency ref="pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"/>
     </dependency>
-    <dependency ref="pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"/>
+    <dependency ref="pkg:npm/vue@2.6.14?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"/>
   </dependencies>
 </bom>"
 `;
@@ -5360,57 +5660,79 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
         "phase": "build"
       }
     ],
-    "tools": [
-      {
-        "vendor": "@cyclonedx",
-        "name": "cyclonedx-library",
-        "version": "libVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      },
-      {
-        "vendor": "@cyclonedx",
-        "name": "webpack-plugin",
-        "version": "thisVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      }
-    ],
+    "tools": {
+      "components": [
+        {
+          "type": "library",
+          "name": "cyclonedx-library",
+          "group": "@cyclonedx",
+          "version": "7.0.0",
+          "author": "Jan Kowalleck",
+          "description": "Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "name": "webpack-plugin",
+          "group": "@cyclonedx",
+          "version": "3.15.1",
+          "author": "Jan Kowalleck",
+          "description": "Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
       "name": "example-webpack5-vue2-yarn",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn",
       "author": "Jan Kowalleck",
       "description": "example setup witch Vue2 in WebPack5 with yarn setup",
       "licenses": [
@@ -5421,7 +5743,7 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -5446,7 +5768,7 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
       "type": "library",
       "name": "vue",
       "version": "2.7.16",
-      "bom-ref": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git",
+      "bom-ref": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git",
       "author": "Evan You",
       "description": "Reactive, component-oriented view layer for modern web interfaces.",
       "licenses": [
@@ -5457,7 +5779,7 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
           }
         }
       ],
-      "purl": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git",
+      "purl": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git",
       "externalReferences": [
         {
           "url": "https://github.com/vuejs/vue/issues",
@@ -5479,13 +5801,13 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn",
       "dependsOn": [
-        "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"
+        "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"
       ]
     },
     {
-      "ref": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"
+      "ref": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"
     }
   ]
 }"
@@ -5503,57 +5825,79 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
         "phase": "build"
       }
     ],
-    "tools": [
-      {
-        "vendor": "@cyclonedx",
-        "name": "cyclonedx-library",
-        "version": "libVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      },
-      {
-        "vendor": "@cyclonedx",
-        "name": "webpack-plugin",
-        "version": "thisVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      }
-    ],
+    "tools": {
+      "components": [
+        {
+          "type": "library",
+          "name": "cyclonedx-library",
+          "group": "@cyclonedx",
+          "version": "7.0.0",
+          "author": "Jan Kowalleck",
+          "description": "Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "name": "webpack-plugin",
+          "group": "@cyclonedx",
+          "version": "3.15.1",
+          "author": "Jan Kowalleck",
+          "description": "Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
       "name": "example-webpack5-vue2-yarn",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn",
       "author": "Jan Kowalleck",
       "description": "example setup witch Vue2 in WebPack5 with yarn setup",
       "licenses": [
@@ -5564,7 +5908,7 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -5589,7 +5933,7 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
       "type": "library",
       "name": "vue",
       "version": "2.7.16",
-      "bom-ref": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git",
+      "bom-ref": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git",
       "author": "Evan You",
       "description": "Reactive, component-oriented view layer for modern web interfaces.",
       "licenses": [
@@ -5600,7 +5944,7 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
           }
         }
       ],
-      "purl": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git",
+      "purl": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git",
       "externalReferences": [
         {
           "url": "https://github.com/vuejs/vue/issues",
@@ -5622,13 +5966,13 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn",
       "dependsOn": [
-        "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"
+        "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"
       ]
     },
     {
-      "ref": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"
+      "ref": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"
     }
   ]
 }"
@@ -5644,46 +5988,62 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated xml 
       </lifecycle>
     </lifecycles>
     <tools>
-      <tool>
-        <vendor>@cyclonedx</vendor>
-        <name>cyclonedx-library</name>
-        <version>libVersion-testing</version>
-        <externalReferences>
-          <reference type="issue-tracker">
-            <url>https://github.com/CycloneDX/cyclonedx-javascript-library/issues</url>
-            <comment>as detected from PackageJson property "bugs.url"</comment>
-          </reference>
-          <reference type="vcs">
-            <url>git+https://github.com/CycloneDX/cyclonedx-javascript-library.git</url>
-            <comment>as detected from PackageJson property "repository.url"</comment>
-          </reference>
-          <reference type="website">
-            <url>https://github.com/CycloneDX/cyclonedx-javascript-library#readme</url>
-            <comment>as detected from PackageJson property "homepage"</comment>
-          </reference>
-        </externalReferences>
-      </tool>
-      <tool>
-        <vendor>@cyclonedx</vendor>
-        <name>webpack-plugin</name>
-        <version>thisVersion-testing</version>
-        <externalReferences>
-          <reference type="issue-tracker">
-            <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
-            <comment>as detected from PackageJson property "bugs.url"</comment>
-          </reference>
-          <reference type="vcs">
-            <url>git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git</url>
-            <comment>as detected from PackageJson property "repository.url"</comment>
-          </reference>
-          <reference type="website">
-            <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme</url>
-            <comment>as detected from PackageJson property "homepage"</comment>
-          </reference>
-        </externalReferences>
-      </tool>
+      <components>
+        <component type="library">
+          <author>Jan Kowalleck</author>
+          <group>@cyclonedx</group>
+          <name>cyclonedx-library</name>
+          <version>7.0.0</version>
+          <description>Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).</description>
+          <licenses>
+            <license>
+              <id>Apache-2.0</id>
+            </license>
+          </licenses>
+          <externalReferences>
+            <reference type="issue-tracker">
+              <url>https://github.com/CycloneDX/cyclonedx-javascript-library/issues</url>
+              <comment>as detected from PackageJson property "bugs.url"</comment>
+            </reference>
+            <reference type="vcs">
+              <url>git+https://github.com/CycloneDX/cyclonedx-javascript-library.git</url>
+              <comment>as detected from PackageJson property "repository.url"</comment>
+            </reference>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-javascript-library#readme</url>
+              <comment>as detected from PackageJson property "homepage"</comment>
+            </reference>
+          </externalReferences>
+        </component>
+        <component type="library">
+          <author>Jan Kowalleck</author>
+          <group>@cyclonedx</group>
+          <name>webpack-plugin</name>
+          <version>3.15.1</version>
+          <description>Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects</description>
+          <licenses>
+            <license>
+              <id>Apache-2.0</id>
+            </license>
+          </licenses>
+          <externalReferences>
+            <reference type="issue-tracker">
+              <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
+              <comment>as detected from PackageJson property "bugs.url"</comment>
+            </reference>
+            <reference type="vcs">
+              <url>git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git</url>
+              <comment>as detected from PackageJson property "repository.url"</comment>
+            </reference>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme</url>
+              <comment>as detected from PackageJson property "homepage"</comment>
+            </reference>
+          </externalReferences>
+        </component>
+      </components>
     </tools>
-    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn">
+    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn">
       <author>Jan Kowalleck</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>example-webpack5-vue2-yarn</name>
@@ -5693,7 +6053,7 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated xml 
           <id>Apache-2.0</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn</purl>
+      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
@@ -5711,7 +6071,7 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated xml 
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git">
+    <component type="library" bom-ref="pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git">
       <author>Evan You</author>
       <name>vue</name>
       <version>2.7.16</version>
@@ -5721,7 +6081,7 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated xml 
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git</purl>
+      <purl>pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/vuejs/vue/issues</url>
@@ -5739,10 +6099,10 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated xml 
     </component>
   </components>
   <dependencies>
-    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn">
-      <dependency ref="pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"/>
+    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-yarn">
+      <dependency ref="pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"/>
     </dependency>
-    <dependency ref="pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"/>
+    <dependency ref="pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"/>
   </dependencies>
 </bom>"
 `;
@@ -5759,57 +6119,79 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
         "phase": "build"
       }
     ],
-    "tools": [
-      {
-        "vendor": "@cyclonedx",
-        "name": "cyclonedx-library",
-        "version": "libVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      },
-      {
-        "vendor": "@cyclonedx",
-        "name": "webpack-plugin",
-        "version": "thisVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      }
-    ],
+    "tools": {
+      "components": [
+        {
+          "type": "library",
+          "name": "cyclonedx-library",
+          "group": "@cyclonedx",
+          "version": "7.0.0",
+          "author": "Jan Kowalleck",
+          "description": "Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "name": "webpack-plugin",
+          "group": "@cyclonedx",
+          "version": "3.15.1",
+          "author": "Jan Kowalleck",
+          "description": "Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
       "name": "example-webpack5-vue2-cli",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service",
       "description": "example setup witch Vue2 in WebPack5",
       "licenses": [
         {
@@ -5819,7 +6201,7 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -5844,7 +6226,7 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
       "type": "library",
       "name": "vue",
       "version": "2.7.16",
-      "bom-ref": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git",
+      "bom-ref": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git",
       "author": "Evan You",
       "description": "Reactive, component-oriented view layer for modern web interfaces.",
       "licenses": [
@@ -5855,7 +6237,7 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
           }
         }
       ],
-      "purl": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git",
+      "purl": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git",
       "externalReferences": [
         {
           "url": "https://github.com/vuejs/vue/issues",
@@ -5877,13 +6259,13 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service",
       "dependsOn": [
-        "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"
+        "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"
       ]
     },
     {
-      "ref": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"
+      "ref": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"
     }
   ]
 }"
@@ -5901,57 +6283,79 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
         "phase": "build"
       }
     ],
-    "tools": [
-      {
-        "vendor": "@cyclonedx",
-        "name": "cyclonedx-library",
-        "version": "libVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      },
-      {
-        "vendor": "@cyclonedx",
-        "name": "webpack-plugin",
-        "version": "thisVersion-testing",
-        "externalReferences": [
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
-            "type": "issue-tracker",
-            "comment": "as detected from PackageJson property \\"bugs.url\\""
-          },
-          {
-            "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
-            "type": "vcs",
-            "comment": "as detected from PackageJson property \\"repository.url\\""
-          },
-          {
-            "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
-            "type": "website",
-            "comment": "as detected from PackageJson property \\"homepage\\""
-          }
-        ]
-      }
-    ],
+    "tools": {
+      "components": [
+        {
+          "type": "library",
+          "name": "cyclonedx-library",
+          "group": "@cyclonedx",
+          "version": "7.0.0",
+          "author": "Jan Kowalleck",
+          "description": "Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        },
+        {
+          "type": "library",
+          "name": "webpack-plugin",
+          "group": "@cyclonedx",
+          "version": "3.15.1",
+          "author": "Jan Kowalleck",
+          "description": "Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "externalReferences": [
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
+              "type": "issue-tracker",
+              "comment": "as detected from PackageJson property \\"bugs.url\\""
+            },
+            {
+              "url": "git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git",
+              "type": "vcs",
+              "comment": "as detected from PackageJson property \\"repository.url\\""
+            },
+            {
+              "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme",
+              "type": "website",
+              "comment": "as detected from PackageJson property \\"homepage\\""
+            }
+          ]
+        }
+      ]
+    },
     "component": {
       "type": "application",
       "name": "example-webpack5-vue2-cli",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service",
       "description": "example setup witch Vue2 in WebPack5",
       "licenses": [
         {
@@ -5961,7 +6365,7 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -5986,7 +6390,7 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
       "type": "library",
       "name": "vue",
       "version": "2.7.16",
-      "bom-ref": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git",
+      "bom-ref": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git",
       "author": "Evan You",
       "description": "Reactive, component-oriented view layer for modern web interfaces.",
       "licenses": [
@@ -5997,7 +6401,7 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
           }
         }
       ],
-      "purl": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git",
+      "purl": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git",
       "externalReferences": [
         {
           "url": "https://github.com/vuejs/vue/issues",
@@ -6019,13 +6423,13 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service",
       "dependsOn": [
-        "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"
+        "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"
       ]
     },
     {
-      "ref": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"
+      "ref": "pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"
     }
   ]
 }"
@@ -6041,46 +6445,62 @@ exports[`integration functional: webpack5 with vue2-cli-service generated xml fi
       </lifecycle>
     </lifecycles>
     <tools>
-      <tool>
-        <vendor>@cyclonedx</vendor>
-        <name>cyclonedx-library</name>
-        <version>libVersion-testing</version>
-        <externalReferences>
-          <reference type="issue-tracker">
-            <url>https://github.com/CycloneDX/cyclonedx-javascript-library/issues</url>
-            <comment>as detected from PackageJson property "bugs.url"</comment>
-          </reference>
-          <reference type="vcs">
-            <url>git+https://github.com/CycloneDX/cyclonedx-javascript-library.git</url>
-            <comment>as detected from PackageJson property "repository.url"</comment>
-          </reference>
-          <reference type="website">
-            <url>https://github.com/CycloneDX/cyclonedx-javascript-library#readme</url>
-            <comment>as detected from PackageJson property "homepage"</comment>
-          </reference>
-        </externalReferences>
-      </tool>
-      <tool>
-        <vendor>@cyclonedx</vendor>
-        <name>webpack-plugin</name>
-        <version>thisVersion-testing</version>
-        <externalReferences>
-          <reference type="issue-tracker">
-            <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
-            <comment>as detected from PackageJson property "bugs.url"</comment>
-          </reference>
-          <reference type="vcs">
-            <url>git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git</url>
-            <comment>as detected from PackageJson property "repository.url"</comment>
-          </reference>
-          <reference type="website">
-            <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme</url>
-            <comment>as detected from PackageJson property "homepage"</comment>
-          </reference>
-        </externalReferences>
-      </tool>
+      <components>
+        <component type="library">
+          <author>Jan Kowalleck</author>
+          <group>@cyclonedx</group>
+          <name>cyclonedx-library</name>
+          <version>7.0.0</version>
+          <description>Core functionality of CycloneDX for JavaScript (Node.js or WebBrowser).</description>
+          <licenses>
+            <license>
+              <id>Apache-2.0</id>
+            </license>
+          </licenses>
+          <externalReferences>
+            <reference type="issue-tracker">
+              <url>https://github.com/CycloneDX/cyclonedx-javascript-library/issues</url>
+              <comment>as detected from PackageJson property "bugs.url"</comment>
+            </reference>
+            <reference type="vcs">
+              <url>git+https://github.com/CycloneDX/cyclonedx-javascript-library.git</url>
+              <comment>as detected from PackageJson property "repository.url"</comment>
+            </reference>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-javascript-library#readme</url>
+              <comment>as detected from PackageJson property "homepage"</comment>
+            </reference>
+          </externalReferences>
+        </component>
+        <component type="library">
+          <author>Jan Kowalleck</author>
+          <group>@cyclonedx</group>
+          <name>webpack-plugin</name>
+          <version>3.15.1</version>
+          <description>Creates CycloneDX Software Bill of Materials (SBoM) from webpack projects</description>
+          <licenses>
+            <license>
+              <id>Apache-2.0</id>
+            </license>
+          </licenses>
+          <externalReferences>
+            <reference type="issue-tracker">
+              <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
+              <comment>as detected from PackageJson property "bugs.url"</comment>
+            </reference>
+            <reference type="vcs">
+              <url>git+https://github.com/CycloneDX/cyclonedx-webpack-plugin.git</url>
+              <comment>as detected from PackageJson property "repository.url"</comment>
+            </reference>
+            <reference type="website">
+              <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin#readme</url>
+              <comment>as detected from PackageJson property "homepage"</comment>
+            </reference>
+          </externalReferences>
+        </component>
+      </components>
     </tools>
-    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service">
+    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service">
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>example-webpack5-vue2-cli</name>
       <description>example setup witch Vue2 in WebPack5</description>
@@ -6089,7 +6509,7 @@ exports[`integration functional: webpack5 with vue2-cli-service generated xml fi
           <id>Apache-2.0</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service</purl>
+      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
@@ -6107,7 +6527,7 @@ exports[`integration functional: webpack5 with vue2-cli-service generated xml fi
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git">
+    <component type="library" bom-ref="pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git">
       <author>Evan You</author>
       <name>vue</name>
       <version>2.7.16</version>
@@ -6117,7 +6537,7 @@ exports[`integration functional: webpack5 with vue2-cli-service generated xml fi
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git</purl>
+      <purl>pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/vuejs/vue/issues</url>
@@ -6135,10 +6555,10 @@ exports[`integration functional: webpack5 with vue2-cli-service generated xml fi
     </component>
   </components>
   <dependencies>
-    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service">
-      <dependency ref="pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"/>
+    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/webpack5-vue2-cli-service">
+      <dependency ref="pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"/>
     </dependency>
-    <dependency ref="pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A//github.com/vuejs/vue.git"/>
+    <dependency ref="pkg:npm/vue@2.7.16?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fvuejs%2Fvue.git"/>
   </dependencies>
 </bom>"
 `;
@@ -6200,7 +6620,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "application",
       "name": "regression-issue1337",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue1337",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue1337",
       "author": "Jan Kowalleck",
       "description": "example setup for issue#1337",
       "licenses": [
@@ -6210,7 +6630,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue1337",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue1337",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -6236,7 +6656,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "base64-js",
       "version": "1.5.1",
-      "bom-ref": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A//github.com/beatgammit/base64-js.git",
+      "bom-ref": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git",
       "author": "T. Jameson Little",
       "description": "Base64 encoding/decoding in pure JS",
       "licenses": [
@@ -6246,7 +6666,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A//github.com/beatgammit/base64-js.git",
+      "purl": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git",
       "externalReferences": [
         {
           "url": "https://github.com/beatgammit/base64-js/issues",
@@ -6283,7 +6703,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "buffer",
       "version": "6.0.3",
-      "bom-ref": "pkg:npm/buffer@6.0.3?vcs_url=git%3A//github.com/feross/buffer.git",
+      "bom-ref": "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git",
       "author": "Feross Aboukhadijeh",
       "description": "Node.js Buffer API, for the browser",
       "licenses": [
@@ -6293,7 +6713,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/buffer@6.0.3?vcs_url=git%3A//github.com/feross/buffer.git",
+      "purl": "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git",
       "externalReferences": [
         {
           "url": "https://github.com/feross/buffer/issues",
@@ -6330,7 +6750,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "esprima",
       "version": "4.0.1",
-      "bom-ref": "pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A//github.com/jquery/esprima.git",
+      "bom-ref": "pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fjquery%2Fesprima.git",
       "author": "Ariya Hidayat",
       "description": "ECMAScript parsing infrastructure for multipurpose analysis",
       "licenses": [
@@ -6340,7 +6760,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A//github.com/jquery/esprima.git",
+      "purl": "pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fjquery%2Fesprima.git",
       "externalReferences": [
         {
           "url": "https://github.com/jquery/esprima/issues",
@@ -6377,7 +6797,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "events",
       "version": "3.3.0",
-      "bom-ref": "pkg:npm/events@3.3.0?vcs_url=git%3A//github.com/Gozala/events.git",
+      "bom-ref": "pkg:npm/events@3.3.0?vcs_url=git%3A%2F%2Fgithub.com%2FGozala%2Fevents.git",
       "author": "Irakli Gozalishvili",
       "description": "Node's event emitter for all engines.",
       "licenses": [
@@ -6387,7 +6807,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/events@3.3.0?vcs_url=git%3A//github.com/Gozala/events.git",
+      "purl": "pkg:npm/events@3.3.0?vcs_url=git%3A%2F%2Fgithub.com%2FGozala%2Fevents.git",
       "externalReferences": [
         {
           "url": "http://github.com/Gozala/events/issues/",
@@ -6424,7 +6844,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "ieee754",
       "version": "1.2.1",
-      "bom-ref": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A//github.com/feross/ieee754.git",
+      "bom-ref": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git",
       "author": "Feross Aboukhadijeh",
       "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
       "licenses": [
@@ -6434,7 +6854,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A//github.com/feross/ieee754.git",
+      "purl": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git",
       "externalReferences": [
         {
           "url": "https://github.com/feross/ieee754/issues",
@@ -6471,7 +6891,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "inherits",
       "version": "2.0.4",
-      "bom-ref": "pkg:npm/inherits@2.0.4?vcs_url=git%3A//github.com/isaacs/inherits.git",
+      "bom-ref": "pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git",
       "description": "Browser-friendly inheritance fully compatible with standard node.js inherits()",
       "licenses": [
         {
@@ -6480,7 +6900,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/inherits@2.0.4?vcs_url=git%3A//github.com/isaacs/inherits.git",
+      "purl": "pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git",
       "externalReferences": [
         {
           "url": "https://github.com/isaacs/inherits/issues",
@@ -6517,7 +6937,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "libphonenumber-js",
       "version": "1.11.16",
-      "bom-ref": "pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
+      "bom-ref": "pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
       "author": "catamphetamine",
       "description": "A simpler (and smaller) rewrite of Google Android's libphonenumber library in javascript",
       "licenses": [
@@ -6527,7 +6947,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
+      "purl": "pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
       "externalReferences": [
         {
           "url": "https://gitlab.com/catamphetamine/libphonenumber-js/issues",
@@ -6574,7 +6994,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "readable-stream",
       "version": "3.6.2",
-      "bom-ref": "pkg:npm/readable-stream@3.6.2?vcs_url=git%3A//github.com/nodejs/readable-stream.git",
+      "bom-ref": "pkg:npm/readable-stream@3.6.2?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Freadable-stream.git",
       "description": "Streams3, a user-land copy of the stream library from Node.js",
       "licenses": [
         {
@@ -6583,7 +7003,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/readable-stream@3.6.2?vcs_url=git%3A//github.com/nodejs/readable-stream.git",
+      "purl": "pkg:npm/readable-stream@3.6.2?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Freadable-stream.git",
       "externalReferences": [
         {
           "url": "https://github.com/nodejs/readable-stream/issues",
@@ -6620,7 +7040,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "safe-buffer",
       "version": "5.2.1",
-      "bom-ref": "pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A//github.com/feross/safe-buffer.git",
+      "bom-ref": "pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fsafe-buffer.git",
       "author": "Feross Aboukhadijeh",
       "description": "Safer Node.js Buffer API",
       "licenses": [
@@ -6630,7 +7050,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A//github.com/feross/safe-buffer.git",
+      "purl": "pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fsafe-buffer.git",
       "externalReferences": [
         {
           "url": "https://github.com/feross/safe-buffer/issues",
@@ -6667,7 +7087,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "stream-browserify",
       "version": "3.0.0",
-      "bom-ref": "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A//github.com/browserify/stream-browserify.git",
+      "bom-ref": "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git",
       "author": "James Halliday",
       "description": "the stream module from node core for browsers",
       "licenses": [
@@ -6677,7 +7097,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A//github.com/browserify/stream-browserify.git",
+      "purl": "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git",
       "externalReferences": [
         {
           "url": "https://github.com/browserify/stream-browserify/issues",
@@ -6714,7 +7134,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "string_decoder",
       "version": "1.3.0",
-      "bom-ref": "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A//github.com/nodejs/string_decoder.git",
+      "bom-ref": "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git",
       "description": "The string_decoder module from Node core",
       "licenses": [
         {
@@ -6723,7 +7143,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A//github.com/nodejs/string_decoder.git",
+      "purl": "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git",
       "externalReferences": [
         {
           "url": "https://github.com/nodejs/string_decoder/issues",
@@ -6760,7 +7180,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "through",
       "version": "2.3.8",
-      "bom-ref": "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A//github.com/dominictarr/through.git",
+      "bom-ref": "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git",
       "author": "Dominic Tarr",
       "description": "simplified stream construction",
       "licenses": [
@@ -6770,7 +7190,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A//github.com/dominictarr/through.git",
+      "purl": "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git",
       "externalReferences": [
         {
           "url": "https://github.com/dominictarr/through/issues",
@@ -6807,7 +7227,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "util-deprecate",
       "version": "1.0.2",
-      "bom-ref": "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A//github.com/TooTallNate/util-deprecate.git",
+      "bom-ref": "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git",
       "author": "Nathan Rajlich",
       "description": "The Node.js \`util.deprecate()\` function with browser support",
       "licenses": [
@@ -6817,7 +7237,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A//github.com/TooTallNate/util-deprecate.git",
+      "purl": "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git",
       "externalReferences": [
         {
           "url": "https://github.com/TooTallNate/util-deprecate/issues",
@@ -6853,76 +7273,76 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue1337",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue1337",
       "dependsOn": [
-        "pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A//github.com/jquery/esprima.git",
-        "pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
-        "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A//github.com/dominictarr/through.git"
+        "pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fjquery%2Fesprima.git",
+        "pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
+        "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git"
       ]
     },
     {
-      "ref": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A//github.com/beatgammit/base64-js.git"
+      "ref": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git"
     },
     {
-      "ref": "pkg:npm/buffer@6.0.3?vcs_url=git%3A//github.com/feross/buffer.git",
+      "ref": "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git",
       "dependsOn": [
-        "pkg:npm/base64-js@1.5.1?vcs_url=git%3A//github.com/beatgammit/base64-js.git",
-        "pkg:npm/ieee754@1.2.1?vcs_url=git%3A//github.com/feross/ieee754.git"
+        "pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git",
+        "pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git"
       ]
     },
     {
-      "ref": "pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A//github.com/jquery/esprima.git"
+      "ref": "pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fjquery%2Fesprima.git"
     },
     {
-      "ref": "pkg:npm/events@3.3.0?vcs_url=git%3A//github.com/Gozala/events.git"
+      "ref": "pkg:npm/events@3.3.0?vcs_url=git%3A%2F%2Fgithub.com%2FGozala%2Fevents.git"
     },
     {
-      "ref": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A//github.com/feross/ieee754.git"
+      "ref": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git"
     },
     {
-      "ref": "pkg:npm/inherits@2.0.4?vcs_url=git%3A//github.com/isaacs/inherits.git"
+      "ref": "pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git"
     },
     {
-      "ref": "pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git"
+      "ref": "pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git"
     },
     {
-      "ref": "pkg:npm/readable-stream@3.6.2?vcs_url=git%3A//github.com/nodejs/readable-stream.git",
+      "ref": "pkg:npm/readable-stream@3.6.2?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Freadable-stream.git",
       "dependsOn": [
-        "pkg:npm/buffer@6.0.3?vcs_url=git%3A//github.com/feross/buffer.git",
-        "pkg:npm/events@3.3.0?vcs_url=git%3A//github.com/Gozala/events.git",
-        "pkg:npm/inherits@2.0.4?vcs_url=git%3A//github.com/isaacs/inherits.git",
-        "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A//github.com/nodejs/string_decoder.git",
-        "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A//github.com/TooTallNate/util-deprecate.git"
+        "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git",
+        "pkg:npm/events@3.3.0?vcs_url=git%3A%2F%2Fgithub.com%2FGozala%2Fevents.git",
+        "pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git",
+        "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git",
+        "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git"
       ]
     },
     {
-      "ref": "pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A//github.com/feross/safe-buffer.git",
+      "ref": "pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fsafe-buffer.git",
       "dependsOn": [
-        "pkg:npm/buffer@6.0.3?vcs_url=git%3A//github.com/feross/buffer.git"
+        "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git"
       ]
     },
     {
-      "ref": "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A//github.com/browserify/stream-browserify.git",
+      "ref": "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git",
       "dependsOn": [
-        "pkg:npm/events@3.3.0?vcs_url=git%3A//github.com/Gozala/events.git",
-        "pkg:npm/inherits@2.0.4?vcs_url=git%3A//github.com/isaacs/inherits.git",
-        "pkg:npm/readable-stream@3.6.2?vcs_url=git%3A//github.com/nodejs/readable-stream.git"
+        "pkg:npm/events@3.3.0?vcs_url=git%3A%2F%2Fgithub.com%2FGozala%2Fevents.git",
+        "pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git",
+        "pkg:npm/readable-stream@3.6.2?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Freadable-stream.git"
       ]
     },
     {
-      "ref": "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A//github.com/nodejs/string_decoder.git",
+      "ref": "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git",
       "dependsOn": [
-        "pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A//github.com/feross/safe-buffer.git"
+        "pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fsafe-buffer.git"
       ]
     },
     {
-      "ref": "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A//github.com/dominictarr/through.git",
+      "ref": "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git",
       "dependsOn": [
-        "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A//github.com/browserify/stream-browserify.git"
+        "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git"
       ]
     },
     {
-      "ref": "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A//github.com/TooTallNate/util-deprecate.git"
+      "ref": "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git"
     }
   ]
 }"
@@ -6985,7 +7405,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "application",
       "name": "regression-issue1337",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue1337",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue1337",
       "author": "Jan Kowalleck",
       "description": "example setup for issue#1337",
       "licenses": [
@@ -6995,7 +7415,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue1337",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue1337",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -7021,7 +7441,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "base64-js",
       "version": "1.5.1",
-      "bom-ref": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A//github.com/beatgammit/base64-js.git",
+      "bom-ref": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git",
       "author": "T. Jameson Little",
       "description": "Base64 encoding/decoding in pure JS",
       "licenses": [
@@ -7031,7 +7451,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A//github.com/beatgammit/base64-js.git",
+      "purl": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git",
       "externalReferences": [
         {
           "url": "https://github.com/beatgammit/base64-js/issues",
@@ -7068,7 +7488,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "buffer",
       "version": "6.0.3",
-      "bom-ref": "pkg:npm/buffer@6.0.3?vcs_url=git%3A//github.com/feross/buffer.git",
+      "bom-ref": "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git",
       "author": "Feross Aboukhadijeh",
       "description": "Node.js Buffer API, for the browser",
       "licenses": [
@@ -7078,7 +7498,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/buffer@6.0.3?vcs_url=git%3A//github.com/feross/buffer.git",
+      "purl": "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git",
       "externalReferences": [
         {
           "url": "https://github.com/feross/buffer/issues",
@@ -7115,7 +7535,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "esprima",
       "version": "4.0.1",
-      "bom-ref": "pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A//github.com/jquery/esprima.git",
+      "bom-ref": "pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fjquery%2Fesprima.git",
       "author": "Ariya Hidayat",
       "description": "ECMAScript parsing infrastructure for multipurpose analysis",
       "licenses": [
@@ -7125,7 +7545,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A//github.com/jquery/esprima.git",
+      "purl": "pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fjquery%2Fesprima.git",
       "externalReferences": [
         {
           "url": "https://github.com/jquery/esprima/issues",
@@ -7162,7 +7582,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "events",
       "version": "3.3.0",
-      "bom-ref": "pkg:npm/events@3.3.0?vcs_url=git%3A//github.com/Gozala/events.git",
+      "bom-ref": "pkg:npm/events@3.3.0?vcs_url=git%3A%2F%2Fgithub.com%2FGozala%2Fevents.git",
       "author": "Irakli Gozalishvili",
       "description": "Node's event emitter for all engines.",
       "licenses": [
@@ -7172,7 +7592,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/events@3.3.0?vcs_url=git%3A//github.com/Gozala/events.git",
+      "purl": "pkg:npm/events@3.3.0?vcs_url=git%3A%2F%2Fgithub.com%2FGozala%2Fevents.git",
       "externalReferences": [
         {
           "url": "http://github.com/Gozala/events/issues/",
@@ -7209,7 +7629,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "ieee754",
       "version": "1.2.1",
-      "bom-ref": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A//github.com/feross/ieee754.git",
+      "bom-ref": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git",
       "author": "Feross Aboukhadijeh",
       "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
       "licenses": [
@@ -7219,7 +7639,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A//github.com/feross/ieee754.git",
+      "purl": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git",
       "externalReferences": [
         {
           "url": "https://github.com/feross/ieee754/issues",
@@ -7256,7 +7676,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "inherits",
       "version": "2.0.4",
-      "bom-ref": "pkg:npm/inherits@2.0.4?vcs_url=git%3A//github.com/isaacs/inherits.git",
+      "bom-ref": "pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git",
       "description": "Browser-friendly inheritance fully compatible with standard node.js inherits()",
       "licenses": [
         {
@@ -7265,7 +7685,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/inherits@2.0.4?vcs_url=git%3A//github.com/isaacs/inherits.git",
+      "purl": "pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git",
       "externalReferences": [
         {
           "url": "https://github.com/isaacs/inherits/issues",
@@ -7302,7 +7722,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "libphonenumber-js",
       "version": "1.11.16",
-      "bom-ref": "pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
+      "bom-ref": "pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
       "author": "catamphetamine",
       "description": "A simpler (and smaller) rewrite of Google Android's libphonenumber library in javascript",
       "licenses": [
@@ -7312,7 +7732,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
+      "purl": "pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
       "externalReferences": [
         {
           "url": "https://gitlab.com/catamphetamine/libphonenumber-js/issues",
@@ -7359,7 +7779,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "readable-stream",
       "version": "3.6.2",
-      "bom-ref": "pkg:npm/readable-stream@3.6.2?vcs_url=git%3A//github.com/nodejs/readable-stream.git",
+      "bom-ref": "pkg:npm/readable-stream@3.6.2?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Freadable-stream.git",
       "description": "Streams3, a user-land copy of the stream library from Node.js",
       "licenses": [
         {
@@ -7368,7 +7788,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/readable-stream@3.6.2?vcs_url=git%3A//github.com/nodejs/readable-stream.git",
+      "purl": "pkg:npm/readable-stream@3.6.2?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Freadable-stream.git",
       "externalReferences": [
         {
           "url": "https://github.com/nodejs/readable-stream/issues",
@@ -7405,7 +7825,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "safe-buffer",
       "version": "5.2.1",
-      "bom-ref": "pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A//github.com/feross/safe-buffer.git",
+      "bom-ref": "pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fsafe-buffer.git",
       "author": "Feross Aboukhadijeh",
       "description": "Safer Node.js Buffer API",
       "licenses": [
@@ -7415,7 +7835,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A//github.com/feross/safe-buffer.git",
+      "purl": "pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fsafe-buffer.git",
       "externalReferences": [
         {
           "url": "https://github.com/feross/safe-buffer/issues",
@@ -7452,7 +7872,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "stream-browserify",
       "version": "3.0.0",
-      "bom-ref": "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A//github.com/browserify/stream-browserify.git",
+      "bom-ref": "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git",
       "author": "James Halliday",
       "description": "the stream module from node core for browsers",
       "licenses": [
@@ -7462,7 +7882,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A//github.com/browserify/stream-browserify.git",
+      "purl": "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git",
       "externalReferences": [
         {
           "url": "https://github.com/browserify/stream-browserify/issues",
@@ -7499,7 +7919,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "string_decoder",
       "version": "1.3.0",
-      "bom-ref": "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A//github.com/nodejs/string_decoder.git",
+      "bom-ref": "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git",
       "description": "The string_decoder module from Node core",
       "licenses": [
         {
@@ -7508,7 +7928,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A//github.com/nodejs/string_decoder.git",
+      "purl": "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git",
       "externalReferences": [
         {
           "url": "https://github.com/nodejs/string_decoder/issues",
@@ -7545,7 +7965,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "through",
       "version": "2.3.8",
-      "bom-ref": "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A//github.com/dominictarr/through.git",
+      "bom-ref": "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git",
       "author": "Dominic Tarr",
       "description": "simplified stream construction",
       "licenses": [
@@ -7555,7 +7975,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A//github.com/dominictarr/through.git",
+      "purl": "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git",
       "externalReferences": [
         {
           "url": "https://github.com/dominictarr/through/issues",
@@ -7592,7 +8012,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "util-deprecate",
       "version": "1.0.2",
-      "bom-ref": "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A//github.com/TooTallNate/util-deprecate.git",
+      "bom-ref": "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git",
       "author": "Nathan Rajlich",
       "description": "The Node.js \`util.deprecate()\` function with browser support",
       "licenses": [
@@ -7602,7 +8022,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A//github.com/TooTallNate/util-deprecate.git",
+      "purl": "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git",
       "externalReferences": [
         {
           "url": "https://github.com/TooTallNate/util-deprecate/issues",
@@ -7638,76 +8058,76 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue1337",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue1337",
       "dependsOn": [
-        "pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A//github.com/jquery/esprima.git",
-        "pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
-        "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A//github.com/dominictarr/through.git"
+        "pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fjquery%2Fesprima.git",
+        "pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
+        "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git"
       ]
     },
     {
-      "ref": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A//github.com/beatgammit/base64-js.git"
+      "ref": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git"
     },
     {
-      "ref": "pkg:npm/buffer@6.0.3?vcs_url=git%3A//github.com/feross/buffer.git",
+      "ref": "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git",
       "dependsOn": [
-        "pkg:npm/base64-js@1.5.1?vcs_url=git%3A//github.com/beatgammit/base64-js.git",
-        "pkg:npm/ieee754@1.2.1?vcs_url=git%3A//github.com/feross/ieee754.git"
+        "pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git",
+        "pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git"
       ]
     },
     {
-      "ref": "pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A//github.com/jquery/esprima.git"
+      "ref": "pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fjquery%2Fesprima.git"
     },
     {
-      "ref": "pkg:npm/events@3.3.0?vcs_url=git%3A//github.com/Gozala/events.git"
+      "ref": "pkg:npm/events@3.3.0?vcs_url=git%3A%2F%2Fgithub.com%2FGozala%2Fevents.git"
     },
     {
-      "ref": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A//github.com/feross/ieee754.git"
+      "ref": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git"
     },
     {
-      "ref": "pkg:npm/inherits@2.0.4?vcs_url=git%3A//github.com/isaacs/inherits.git"
+      "ref": "pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git"
     },
     {
-      "ref": "pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git"
+      "ref": "pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git"
     },
     {
-      "ref": "pkg:npm/readable-stream@3.6.2?vcs_url=git%3A//github.com/nodejs/readable-stream.git",
+      "ref": "pkg:npm/readable-stream@3.6.2?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Freadable-stream.git",
       "dependsOn": [
-        "pkg:npm/buffer@6.0.3?vcs_url=git%3A//github.com/feross/buffer.git",
-        "pkg:npm/events@3.3.0?vcs_url=git%3A//github.com/Gozala/events.git",
-        "pkg:npm/inherits@2.0.4?vcs_url=git%3A//github.com/isaacs/inherits.git",
-        "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A//github.com/nodejs/string_decoder.git",
-        "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A//github.com/TooTallNate/util-deprecate.git"
+        "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git",
+        "pkg:npm/events@3.3.0?vcs_url=git%3A%2F%2Fgithub.com%2FGozala%2Fevents.git",
+        "pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git",
+        "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git",
+        "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git"
       ]
     },
     {
-      "ref": "pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A//github.com/feross/safe-buffer.git",
+      "ref": "pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fsafe-buffer.git",
       "dependsOn": [
-        "pkg:npm/buffer@6.0.3?vcs_url=git%3A//github.com/feross/buffer.git"
+        "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git"
       ]
     },
     {
-      "ref": "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A//github.com/browserify/stream-browserify.git",
+      "ref": "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git",
       "dependsOn": [
-        "pkg:npm/events@3.3.0?vcs_url=git%3A//github.com/Gozala/events.git",
-        "pkg:npm/inherits@2.0.4?vcs_url=git%3A//github.com/isaacs/inherits.git",
-        "pkg:npm/readable-stream@3.6.2?vcs_url=git%3A//github.com/nodejs/readable-stream.git"
+        "pkg:npm/events@3.3.0?vcs_url=git%3A%2F%2Fgithub.com%2FGozala%2Fevents.git",
+        "pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git",
+        "pkg:npm/readable-stream@3.6.2?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Freadable-stream.git"
       ]
     },
     {
-      "ref": "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A//github.com/nodejs/string_decoder.git",
+      "ref": "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git",
       "dependsOn": [
-        "pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A//github.com/feross/safe-buffer.git"
+        "pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fsafe-buffer.git"
       ]
     },
     {
-      "ref": "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A//github.com/dominictarr/through.git",
+      "ref": "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git",
       "dependsOn": [
-        "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A//github.com/browserify/stream-browserify.git"
+        "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git"
       ]
     },
     {
-      "ref": "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A//github.com/TooTallNate/util-deprecate.git"
+      "ref": "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git"
     }
   ]
 }"
@@ -7757,7 +8177,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </externalReferences>
       </tool>
     </tools>
-    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue1337">
+    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue1337">
       <author>Jan Kowalleck</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>regression-issue1337</name>
@@ -7767,7 +8187,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           <id>Apache-2.0</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue1337</purl>
+      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue1337</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
@@ -7786,7 +8206,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pkg:npm/base64-js@1.5.1?vcs_url=git%3A//github.com/beatgammit/base64-js.git">
+    <component type="library" bom-ref="pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git">
       <author>T. Jameson Little</author>
       <name>base64-js</name>
       <version>1.5.1</version>
@@ -7796,7 +8216,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/base64-js@1.5.1?vcs_url=git%3A//github.com/beatgammit/base64-js.git</purl>
+      <purl>pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/beatgammit/base64-js/issues</url>
@@ -7820,7 +8240,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/buffer@6.0.3?vcs_url=git%3A//github.com/feross/buffer.git">
+    <component type="library" bom-ref="pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git">
       <author>Feross Aboukhadijeh</author>
       <name>buffer</name>
       <version>6.0.3</version>
@@ -7830,7 +8250,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/buffer@6.0.3?vcs_url=git%3A//github.com/feross/buffer.git</purl>
+      <purl>pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/feross/buffer/issues</url>
@@ -7854,7 +8274,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A//github.com/jquery/esprima.git">
+    <component type="library" bom-ref="pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fjquery%2Fesprima.git">
       <author>Ariya Hidayat</author>
       <name>esprima</name>
       <version>4.0.1</version>
@@ -7864,7 +8284,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           <id>BSD-2-Clause</id>
         </license>
       </licenses>
-      <purl>pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A//github.com/jquery/esprima.git</purl>
+      <purl>pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fjquery%2Fesprima.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/jquery/esprima/issues</url>
@@ -7888,7 +8308,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/events@3.3.0?vcs_url=git%3A//github.com/Gozala/events.git">
+    <component type="library" bom-ref="pkg:npm/events@3.3.0?vcs_url=git%3A%2F%2Fgithub.com%2FGozala%2Fevents.git">
       <author>Irakli Gozalishvili</author>
       <name>events</name>
       <version>3.3.0</version>
@@ -7898,7 +8318,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/events@3.3.0?vcs_url=git%3A//github.com/Gozala/events.git</purl>
+      <purl>pkg:npm/events@3.3.0?vcs_url=git%3A%2F%2Fgithub.com%2FGozala%2Fevents.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>http://github.com/Gozala/events/issues/</url>
@@ -7922,7 +8342,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/ieee754@1.2.1?vcs_url=git%3A//github.com/feross/ieee754.git">
+    <component type="library" bom-ref="pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git">
       <author>Feross Aboukhadijeh</author>
       <name>ieee754</name>
       <version>1.2.1</version>
@@ -7932,7 +8352,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           <id>BSD-3-Clause</id>
         </license>
       </licenses>
-      <purl>pkg:npm/ieee754@1.2.1?vcs_url=git%3A//github.com/feross/ieee754.git</purl>
+      <purl>pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/feross/ieee754/issues</url>
@@ -7956,7 +8376,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/inherits@2.0.4?vcs_url=git%3A//github.com/isaacs/inherits.git">
+    <component type="library" bom-ref="pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git">
       <name>inherits</name>
       <version>2.0.4</version>
       <description>Browser-friendly inheritance fully compatible with standard node.js inherits()</description>
@@ -7965,7 +8385,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           <id>ISC</id>
         </license>
       </licenses>
-      <purl>pkg:npm/inherits@2.0.4?vcs_url=git%3A//github.com/isaacs/inherits.git</purl>
+      <purl>pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/isaacs/inherits/issues</url>
@@ -7989,7 +8409,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git">
+    <component type="library" bom-ref="pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git">
       <author>catamphetamine</author>
       <name>libphonenumber-js</name>
       <version>1.11.16</version>
@@ -7999,7 +8419,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git</purl>
+      <purl>pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://gitlab.com/catamphetamine/libphonenumber-js/issues</url>
@@ -8027,7 +8447,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/readable-stream@3.6.2?vcs_url=git%3A//github.com/nodejs/readable-stream.git">
+    <component type="library" bom-ref="pkg:npm/readable-stream@3.6.2?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Freadable-stream.git">
       <name>readable-stream</name>
       <version>3.6.2</version>
       <description>Streams3, a user-land copy of the stream library from Node.js</description>
@@ -8036,7 +8456,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/readable-stream@3.6.2?vcs_url=git%3A//github.com/nodejs/readable-stream.git</purl>
+      <purl>pkg:npm/readable-stream@3.6.2?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Freadable-stream.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/nodejs/readable-stream/issues</url>
@@ -8060,7 +8480,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A//github.com/feross/safe-buffer.git">
+    <component type="library" bom-ref="pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fsafe-buffer.git">
       <author>Feross Aboukhadijeh</author>
       <name>safe-buffer</name>
       <version>5.2.1</version>
@@ -8070,7 +8490,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A//github.com/feross/safe-buffer.git</purl>
+      <purl>pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fsafe-buffer.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/feross/safe-buffer/issues</url>
@@ -8094,7 +8514,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A//github.com/browserify/stream-browserify.git">
+    <component type="library" bom-ref="pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git">
       <author>James Halliday</author>
       <name>stream-browserify</name>
       <version>3.0.0</version>
@@ -8104,7 +8524,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A//github.com/browserify/stream-browserify.git</purl>
+      <purl>pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/browserify/stream-browserify/issues</url>
@@ -8128,7 +8548,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/string_decoder@1.3.0?vcs_url=git%3A//github.com/nodejs/string_decoder.git">
+    <component type="library" bom-ref="pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git">
       <name>string_decoder</name>
       <version>1.3.0</version>
       <description>The string_decoder module from Node core</description>
@@ -8137,7 +8557,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/string_decoder@1.3.0?vcs_url=git%3A//github.com/nodejs/string_decoder.git</purl>
+      <purl>pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/nodejs/string_decoder/issues</url>
@@ -8161,7 +8581,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A//github.com/dominictarr/through.git">
+    <component type="library" bom-ref="pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git">
       <author>Dominic Tarr</author>
       <name>through</name>
       <version>2.3.8</version>
@@ -8171,7 +8591,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A//github.com/dominictarr/through.git</purl>
+      <purl>pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/dominictarr/through/issues</url>
@@ -8195,7 +8615,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A//github.com/TooTallNate/util-deprecate.git">
+    <component type="library" bom-ref="pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git">
       <author>Nathan Rajlich</author>
       <name>util-deprecate</name>
       <version>1.0.2</version>
@@ -8205,7 +8625,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A//github.com/TooTallNate/util-deprecate.git</purl>
+      <purl>pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/TooTallNate/util-deprecate/issues</url>
@@ -8231,43 +8651,43 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
     </component>
   </components>
   <dependencies>
-    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue1337">
-      <dependency ref="pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A//github.com/jquery/esprima.git"/>
-      <dependency ref="pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git"/>
-      <dependency ref="pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A//github.com/dominictarr/through.git"/>
+    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1337?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue1337">
+      <dependency ref="pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fjquery%2Fesprima.git"/>
+      <dependency ref="pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git"/>
+      <dependency ref="pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git"/>
     </dependency>
-    <dependency ref="pkg:npm/base64-js@1.5.1?vcs_url=git%3A//github.com/beatgammit/base64-js.git"/>
-    <dependency ref="pkg:npm/buffer@6.0.3?vcs_url=git%3A//github.com/feross/buffer.git">
-      <dependency ref="pkg:npm/base64-js@1.5.1?vcs_url=git%3A//github.com/beatgammit/base64-js.git"/>
-      <dependency ref="pkg:npm/ieee754@1.2.1?vcs_url=git%3A//github.com/feross/ieee754.git"/>
+    <dependency ref="pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git"/>
+    <dependency ref="pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git">
+      <dependency ref="pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git"/>
+      <dependency ref="pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git"/>
     </dependency>
-    <dependency ref="pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A//github.com/jquery/esprima.git"/>
-    <dependency ref="pkg:npm/events@3.3.0?vcs_url=git%3A//github.com/Gozala/events.git"/>
-    <dependency ref="pkg:npm/ieee754@1.2.1?vcs_url=git%3A//github.com/feross/ieee754.git"/>
-    <dependency ref="pkg:npm/inherits@2.0.4?vcs_url=git%3A//github.com/isaacs/inherits.git"/>
-    <dependency ref="pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git"/>
-    <dependency ref="pkg:npm/readable-stream@3.6.2?vcs_url=git%3A//github.com/nodejs/readable-stream.git">
-      <dependency ref="pkg:npm/buffer@6.0.3?vcs_url=git%3A//github.com/feross/buffer.git"/>
-      <dependency ref="pkg:npm/events@3.3.0?vcs_url=git%3A//github.com/Gozala/events.git"/>
-      <dependency ref="pkg:npm/inherits@2.0.4?vcs_url=git%3A//github.com/isaacs/inherits.git"/>
-      <dependency ref="pkg:npm/string_decoder@1.3.0?vcs_url=git%3A//github.com/nodejs/string_decoder.git"/>
-      <dependency ref="pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A//github.com/TooTallNate/util-deprecate.git"/>
+    <dependency ref="pkg:npm/esprima@4.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fjquery%2Fesprima.git"/>
+    <dependency ref="pkg:npm/events@3.3.0?vcs_url=git%3A%2F%2Fgithub.com%2FGozala%2Fevents.git"/>
+    <dependency ref="pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git"/>
+    <dependency ref="pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git"/>
+    <dependency ref="pkg:npm/libphonenumber-js@1.11.16?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git"/>
+    <dependency ref="pkg:npm/readable-stream@3.6.2?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Freadable-stream.git">
+      <dependency ref="pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git"/>
+      <dependency ref="pkg:npm/events@3.3.0?vcs_url=git%3A%2F%2Fgithub.com%2FGozala%2Fevents.git"/>
+      <dependency ref="pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git"/>
+      <dependency ref="pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git"/>
+      <dependency ref="pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git"/>
     </dependency>
-    <dependency ref="pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A//github.com/feross/safe-buffer.git">
-      <dependency ref="pkg:npm/buffer@6.0.3?vcs_url=git%3A//github.com/feross/buffer.git"/>
+    <dependency ref="pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fsafe-buffer.git">
+      <dependency ref="pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git"/>
     </dependency>
-    <dependency ref="pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A//github.com/browserify/stream-browserify.git">
-      <dependency ref="pkg:npm/events@3.3.0?vcs_url=git%3A//github.com/Gozala/events.git"/>
-      <dependency ref="pkg:npm/inherits@2.0.4?vcs_url=git%3A//github.com/isaacs/inherits.git"/>
-      <dependency ref="pkg:npm/readable-stream@3.6.2?vcs_url=git%3A//github.com/nodejs/readable-stream.git"/>
+    <dependency ref="pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git">
+      <dependency ref="pkg:npm/events@3.3.0?vcs_url=git%3A%2F%2Fgithub.com%2FGozala%2Fevents.git"/>
+      <dependency ref="pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git"/>
+      <dependency ref="pkg:npm/readable-stream@3.6.2?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Freadable-stream.git"/>
     </dependency>
-    <dependency ref="pkg:npm/string_decoder@1.3.0?vcs_url=git%3A//github.com/nodejs/string_decoder.git">
-      <dependency ref="pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A//github.com/feross/safe-buffer.git"/>
+    <dependency ref="pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git">
+      <dependency ref="pkg:npm/safe-buffer@5.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fsafe-buffer.git"/>
     </dependency>
-    <dependency ref="pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A//github.com/dominictarr/through.git">
-      <dependency ref="pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A//github.com/browserify/stream-browserify.git"/>
+    <dependency ref="pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git">
+      <dependency ref="pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git"/>
     </dependency>
-    <dependency ref="pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A//github.com/TooTallNate/util-deprecate.git"/>
+    <dependency ref="pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git"/>
   </dependencies>
 </bom>"
 `;
@@ -8329,7 +8749,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       "type": "application",
       "name": "regression-issue745",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
       "author": "Jan Kowalleck",
       "description": "example setup for issue#745",
       "licenses": [
@@ -8339,7 +8759,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -8365,7 +8785,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       "name": "client",
       "group": "@apollo",
       "version": "3.7.10",
-      "bom-ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+      "bom-ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fapollo-client.git",
       "author": "packages@apollographql.com",
       "description": "A fully-featured caching GraphQL client.",
       "licenses": [
@@ -8375,7 +8795,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+      "purl": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fapollo-client.git",
       "externalReferences": [
         {
           "url": "https://github.com/apollographql/apollo-client/issues",
@@ -8399,7 +8819,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       "name": "context",
       "group": "@wry",
       "version": "0.7.0",
-      "bom-ref": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "bom-ref": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
       "author": "Ben Newman",
       "description": "Manage contextual information needed by (a)synchronous tasks without explicitly passing objects around",
       "licenses": [
@@ -8409,7 +8829,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "purl": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
       "externalReferences": [
         {
           "url": "https://github.com/benjamn/wryware/issues",
@@ -8433,7 +8853,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       "name": "equality",
       "group": "@wry",
       "version": "0.5.3",
-      "bom-ref": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "bom-ref": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
       "author": "Ben Newman",
       "description": "Structural equality checking for JavaScript values",
       "licenses": [
@@ -8443,7 +8863,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "purl": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
       "externalReferences": [
         {
           "url": "https://github.com/benjamn/wryware/issues",
@@ -8467,7 +8887,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       "name": "trie",
       "group": "@wry",
       "version": "0.3.2",
-      "bom-ref": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "bom-ref": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
       "author": "Ben Newman",
       "description": "https://en.wikipedia.org/wiki/Trie",
       "licenses": [
@@ -8477,7 +8897,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "purl": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
       "externalReferences": [
         {
           "url": "https://github.com/benjamn/wryware/issues",
@@ -8500,7 +8920,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       "type": "library",
       "name": "graphql-tag",
       "version": "2.12.6",
-      "bom-ref": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
+      "bom-ref": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git",
       "description": "A JavaScript template literal tag that parses GraphQL queries",
       "licenses": [
         {
@@ -8509,7 +8929,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
+      "purl": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git",
       "externalReferences": [
         {
           "url": "https://github.com/apollographql/graphql-tag/issues",
@@ -8532,7 +8952,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       "type": "library",
       "name": "graphql",
       "version": "16.6.0",
-      "bom-ref": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+      "bom-ref": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git",
       "description": "A Query Language and Runtime which can target any service.",
       "licenses": [
         {
@@ -8541,7 +8961,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+      "purl": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git",
       "externalReferences": [
         {
           "url": "https://github.com/graphql/graphql-js/issues",
@@ -8564,7 +8984,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       "type": "library",
       "name": "optimism",
       "version": "0.16.2",
-      "bom-ref": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
+      "bom-ref": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Foptimism.git",
       "author": "Ben Newman",
       "description": "Composable reactive caching with efficient invalidation.",
       "licenses": [
@@ -8574,7 +8994,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
+      "purl": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Foptimism.git",
       "externalReferences": [
         {
           "url": "https://github.com/benjamn/optimism/issues",
@@ -8597,7 +9017,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       "type": "library",
       "name": "react",
       "version": "18.2.0",
-      "bom-ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+      "bom-ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react",
       "description": "React is a JavaScript library for building user interfaces.",
       "licenses": [
         {
@@ -8606,7 +9026,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+      "purl": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react",
       "externalReferences": [
         {
           "url": "https://github.com/facebook/react/issues",
@@ -8629,7 +9049,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       "type": "library",
       "name": "symbol-observable",
       "version": "4.0.0",
-      "bom-ref": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
+      "bom-ref": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git",
       "author": "Ben Lesh",
       "description": "Symbol.observable ponyfill",
       "licenses": [
@@ -8639,7 +9059,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
+      "purl": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git",
       "externalReferences": [
         {
           "url": "https://github.com/blesh/symbol-observable/issues",
@@ -8662,7 +9082,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       "type": "library",
       "name": "ts-invariant",
       "version": "0.10.3",
-      "bom-ref": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+      "bom-ref": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git",
       "author": "Ben Newman",
       "description": "TypeScript implementation of invariant(condition, message)",
       "licenses": [
@@ -8672,7 +9092,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+      "purl": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git",
       "externalReferences": [
         {
           "url": "https://github.com/apollographql/invariant-packages/issues",
@@ -8695,7 +9115,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       "type": "library",
       "name": "tslib",
       "version": "2.5.0",
-      "bom-ref": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "bom-ref": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
       "author": "Microsoft Corp.",
       "description": "Runtime library for TypeScript helper functions",
       "licenses": [
@@ -8705,7 +9125,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "purl": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
       "externalReferences": [
         {
           "url": "https://github.com/Microsoft/TypeScript/issues",
@@ -8728,7 +9148,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       "type": "library",
       "name": "zen-observable-ts",
       "version": "1.2.5",
-      "bom-ref": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git",
+      "bom-ref": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git",
       "description": "Thin wrapper around zen-observable and @types/zen-observable, to support ESM exports as well as CommonJS exports",
       "licenses": [
         {
@@ -8737,7 +9157,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git",
+      "purl": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git",
       "externalReferences": [
         {
           "url": "https://github.com/apollographql/zen-observable-ts/issues",
@@ -8759,70 +9179,70 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+      "ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fapollo-client.git",
       "dependsOn": [
-        "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
-        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
-        "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
-        "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+        "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
+        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
+        "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
+        "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git",
+        "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Foptimism.git",
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react",
+        "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git",
+        "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
       "dependsOn": [
-        "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git"
+        "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fapollo-client.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"
+      "ref": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git"
     },
     {
-      "ref": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"
+      "ref": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git"
     },
     {
-      "ref": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"
+      "ref": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git"
     },
     {
-      "ref": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
+      "ref": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git",
       "dependsOn": [
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
       ]
     },
     {
-      "ref": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"
+      "ref": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git"
     },
     {
-      "ref": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
+      "ref": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Foptimism.git",
       "dependsOn": [
-        "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"
+        "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
+        "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git"
       ]
     },
     {
-      "ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
+      "ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react"
     },
     {
-      "ref": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git"
+      "ref": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git"
     },
     {
-      "ref": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+      "ref": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git",
       "dependsOn": [
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
       ]
     },
     {
-      "ref": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      "ref": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
     },
     {
-      "ref": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      "ref": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git"
     }
   ]
 }"
@@ -8885,7 +9305,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       "type": "application",
       "name": "regression-issue745",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "bom-ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
       "author": "Jan Kowalleck",
       "description": "example setup for issue#745",
       "licenses": [
@@ -8895,7 +9315,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           }
         }
       ],
-      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
       "externalReferences": [
         {
           "url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues",
@@ -8921,7 +9341,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       "name": "client",
       "group": "@apollo",
       "version": "3.7.10",
-      "bom-ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+      "bom-ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fapollo-client.git",
       "author": "packages@apollographql.com",
       "description": "A fully-featured caching GraphQL client.",
       "licenses": [
@@ -8931,7 +9351,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           }
         }
       ],
-      "purl": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+      "purl": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fapollo-client.git",
       "externalReferences": [
         {
           "url": "https://github.com/apollographql/apollo-client/issues",
@@ -8955,7 +9375,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       "name": "context",
       "group": "@wry",
       "version": "0.7.0",
-      "bom-ref": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "bom-ref": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
       "author": "Ben Newman",
       "description": "Manage contextual information needed by (a)synchronous tasks without explicitly passing objects around",
       "licenses": [
@@ -8965,7 +9385,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           }
         }
       ],
-      "purl": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "purl": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
       "externalReferences": [
         {
           "url": "https://github.com/benjamn/wryware/issues",
@@ -8989,7 +9409,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       "name": "equality",
       "group": "@wry",
       "version": "0.5.3",
-      "bom-ref": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "bom-ref": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
       "author": "Ben Newman",
       "description": "Structural equality checking for JavaScript values",
       "licenses": [
@@ -8999,7 +9419,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           }
         }
       ],
-      "purl": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "purl": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
       "externalReferences": [
         {
           "url": "https://github.com/benjamn/wryware/issues",
@@ -9023,7 +9443,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       "name": "trie",
       "group": "@wry",
       "version": "0.3.2",
-      "bom-ref": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "bom-ref": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
       "author": "Ben Newman",
       "description": "https://en.wikipedia.org/wiki/Trie",
       "licenses": [
@@ -9033,7 +9453,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           }
         }
       ],
-      "purl": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
+      "purl": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
       "externalReferences": [
         {
           "url": "https://github.com/benjamn/wryware/issues",
@@ -9056,7 +9476,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       "type": "library",
       "name": "graphql-tag",
       "version": "2.12.6",
-      "bom-ref": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
+      "bom-ref": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git",
       "description": "A JavaScript template literal tag that parses GraphQL queries",
       "licenses": [
         {
@@ -9065,7 +9485,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           }
         }
       ],
-      "purl": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
+      "purl": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git",
       "externalReferences": [
         {
           "url": "https://github.com/apollographql/graphql-tag/issues",
@@ -9088,7 +9508,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       "type": "library",
       "name": "graphql",
       "version": "16.6.0",
-      "bom-ref": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+      "bom-ref": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git",
       "description": "A Query Language and Runtime which can target any service.",
       "licenses": [
         {
@@ -9097,7 +9517,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           }
         }
       ],
-      "purl": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
+      "purl": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git",
       "externalReferences": [
         {
           "url": "https://github.com/graphql/graphql-js/issues",
@@ -9120,7 +9540,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       "type": "library",
       "name": "optimism",
       "version": "0.16.2",
-      "bom-ref": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
+      "bom-ref": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Foptimism.git",
       "author": "Ben Newman",
       "description": "Composable reactive caching with efficient invalidation.",
       "licenses": [
@@ -9130,7 +9550,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           }
         }
       ],
-      "purl": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
+      "purl": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Foptimism.git",
       "externalReferences": [
         {
           "url": "https://github.com/benjamn/optimism/issues",
@@ -9153,7 +9573,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       "type": "library",
       "name": "react",
       "version": "18.2.0",
-      "bom-ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+      "bom-ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react",
       "description": "React is a JavaScript library for building user interfaces.",
       "licenses": [
         {
@@ -9162,7 +9582,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           }
         }
       ],
-      "purl": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
+      "purl": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react",
       "externalReferences": [
         {
           "url": "https://github.com/facebook/react/issues",
@@ -9185,7 +9605,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       "type": "library",
       "name": "symbol-observable",
       "version": "4.0.0",
-      "bom-ref": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
+      "bom-ref": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git",
       "author": "Ben Lesh",
       "description": "Symbol.observable ponyfill",
       "licenses": [
@@ -9195,7 +9615,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           }
         }
       ],
-      "purl": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
+      "purl": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git",
       "externalReferences": [
         {
           "url": "https://github.com/blesh/symbol-observable/issues",
@@ -9218,7 +9638,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       "type": "library",
       "name": "ts-invariant",
       "version": "0.10.3",
-      "bom-ref": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+      "bom-ref": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git",
       "author": "Ben Newman",
       "description": "TypeScript implementation of invariant(condition, message)",
       "licenses": [
@@ -9228,7 +9648,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           }
         }
       ],
-      "purl": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+      "purl": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git",
       "externalReferences": [
         {
           "url": "https://github.com/apollographql/invariant-packages/issues",
@@ -9251,7 +9671,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       "type": "library",
       "name": "tslib",
       "version": "2.5.0",
-      "bom-ref": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "bom-ref": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
       "author": "Microsoft Corp.",
       "description": "Runtime library for TypeScript helper functions",
       "licenses": [
@@ -9261,7 +9681,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           }
         }
       ],
-      "purl": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
+      "purl": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
       "externalReferences": [
         {
           "url": "https://github.com/Microsoft/TypeScript/issues",
@@ -9284,7 +9704,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       "type": "library",
       "name": "zen-observable-ts",
       "version": "1.2.5",
-      "bom-ref": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git",
+      "bom-ref": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git",
       "description": "Thin wrapper around zen-observable and @types/zen-observable, to support ESM exports as well as CommonJS exports",
       "licenses": [
         {
@@ -9293,7 +9713,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           }
         }
       ],
-      "purl": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git",
+      "purl": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git",
       "externalReferences": [
         {
           "url": "https://github.com/apollographql/zen-observable-ts/issues",
@@ -9315,70 +9735,70 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git",
+      "ref": "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fapollo-client.git",
       "dependsOn": [
-        "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
-        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react",
-        "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git",
-        "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git",
-        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+        "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
+        "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
+        "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
+        "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git",
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git",
+        "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Foptimism.git",
+        "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react",
+        "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git",
+        "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
+        "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
+      "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue745",
       "dependsOn": [
-        "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git"
+        "pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fapollo-client.git"
       ]
     },
     {
-      "ref": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"
+      "ref": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git"
     },
     {
-      "ref": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"
+      "ref": "pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git"
     },
     {
-      "ref": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"
+      "ref": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git"
     },
     {
-      "ref": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git",
+      "ref": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git",
       "dependsOn": [
-        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git",
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+        "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git",
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
       ]
     },
     {
-      "ref": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"
+      "ref": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git"
     },
     {
-      "ref": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git",
+      "ref": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Foptimism.git",
       "dependsOn": [
-        "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git",
-        "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"
+        "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
+        "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git"
       ]
     },
     {
-      "ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"
+      "ref": "pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react"
     },
     {
-      "ref": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git"
+      "ref": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git"
     },
     {
-      "ref": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git",
+      "ref": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git",
       "dependsOn": [
-        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+        "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
       ]
     },
     {
-      "ref": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"
+      "ref": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"
     },
     {
-      "ref": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"
+      "ref": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git"
     }
   ]
 }"
@@ -9428,7 +9848,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </externalReferences>
       </tool>
     </tools>
-    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745">
+    <component type="application" bom-ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue745">
       <author>Jan Kowalleck</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>regression-issue745</name>
@@ -9438,7 +9858,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
           <id>Apache-2.0</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745</purl>
+      <purl>pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue745</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues</url>
@@ -9456,7 +9876,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git">
+    <component type="library" bom-ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fapollo-client.git">
       <author>packages@apollographql.com</author>
       <group>@apollo</group>
       <name>client</name>
@@ -9467,7 +9887,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git</purl>
+      <purl>pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fapollo-client.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/apollographql/apollo-client/issues</url>
@@ -9483,7 +9903,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git">
+    <component type="library" bom-ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git">
       <author>Ben Newman</author>
       <group>@wry</group>
       <name>context</name>
@@ -9494,7 +9914,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git</purl>
+      <purl>pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/benjamn/wryware/issues</url>
@@ -9510,7 +9930,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git">
+    <component type="library" bom-ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git">
       <author>Ben Newman</author>
       <group>@wry</group>
       <name>equality</name>
@@ -9521,7 +9941,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git</purl>
+      <purl>pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/benjamn/wryware/issues</url>
@@ -9537,7 +9957,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git">
+    <component type="library" bom-ref="pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git">
       <author>Ben Newman</author>
       <group>@wry</group>
       <name>trie</name>
@@ -9548,7 +9968,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git</purl>
+      <purl>pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/benjamn/wryware/issues</url>
@@ -9564,7 +9984,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git">
+    <component type="library" bom-ref="pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git">
       <name>graphql-tag</name>
       <version>2.12.6</version>
       <description>A JavaScript template literal tag that parses GraphQL queries</description>
@@ -9573,7 +9993,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git</purl>
+      <purl>pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/apollographql/graphql-tag/issues</url>
@@ -9589,7 +10009,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git">
+    <component type="library" bom-ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git">
       <name>graphql</name>
       <version>16.6.0</version>
       <description>A Query Language and Runtime which can target any service.</description>
@@ -9598,7 +10018,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git</purl>
+      <purl>pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/graphql/graphql-js/issues</url>
@@ -9614,7 +10034,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git">
+    <component type="library" bom-ref="pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Foptimism.git">
       <author>Ben Newman</author>
       <name>optimism</name>
       <version>0.16.2</version>
@@ -9624,7 +10044,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git</purl>
+      <purl>pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Foptimism.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/benjamn/optimism/issues</url>
@@ -9640,7 +10060,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react">
+    <component type="library" bom-ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react">
       <name>react</name>
       <version>18.2.0</version>
       <description>React is a JavaScript library for building user interfaces.</description>
@@ -9649,7 +10069,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react</purl>
+      <purl>pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/facebook/react/issues</url>
@@ -9665,7 +10085,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git">
+    <component type="library" bom-ref="pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git">
       <author>Ben Lesh</author>
       <name>symbol-observable</name>
       <version>4.0.0</version>
@@ -9675,7 +10095,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git</purl>
+      <purl>pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/blesh/symbol-observable/issues</url>
@@ -9691,7 +10111,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git">
+    <component type="library" bom-ref="pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git">
       <author>Ben Newman</author>
       <name>ts-invariant</name>
       <version>0.10.3</version>
@@ -9701,7 +10121,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git</purl>
+      <purl>pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/apollographql/invariant-packages/issues</url>
@@ -9717,7 +10137,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git">
+    <component type="library" bom-ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git">
       <author>Microsoft Corp.</author>
       <name>tslib</name>
       <version>2.5.0</version>
@@ -9727,7 +10147,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
           <id>0BSD</id>
         </license>
       </licenses>
-      <purl>pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git</purl>
+      <purl>pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/Microsoft/TypeScript/issues</url>
@@ -9743,7 +10163,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git">
+    <component type="library" bom-ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git">
       <name>zen-observable-ts</name>
       <version>1.2.5</version>
       <description>Thin wrapper around zen-observable and @types/zen-observable, to support ESM exports as well as CommonJS exports</description>
@@ -9752,7 +10172,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git</purl>
+      <purl>pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/apollographql/zen-observable-ts/issues</url>
@@ -9770,41 +10190,41 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
     </component>
   </components>
   <dependencies>
-    <dependency ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git">
-      <dependency ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
-      <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
-      <dependency ref="pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
-      <dependency ref="pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git"/>
-      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
-      <dependency ref="pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git"/>
-      <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"/>
-      <dependency ref="pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git"/>
-      <dependency ref="pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git"/>
-      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
+    <dependency ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fapollo-client.git">
+      <dependency ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git"/>
+      <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git"/>
+      <dependency ref="pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git"/>
+      <dependency ref="pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git"/>
+      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git"/>
+      <dependency ref="pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Foptimism.git"/>
+      <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react"/>
+      <dependency ref="pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git"/>
+      <dependency ref="pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"/>
+      <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git"/>
     </dependency>
-    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A//github.com/CycloneDX/cyclonedx-webpack-plugin.git#tests/integration/regression-issue745">
-      <dependency ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A//github.com/apollographql/apollo-client.git"/>
+    <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue745?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FCycloneDX%2Fcyclonedx-webpack-plugin.git#tests/integration/regression-issue745">
+      <dependency ref="pkg:npm/%40apollo/client@3.7.10?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fapollo-client.git"/>
     </dependency>
-    <dependency ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
-    <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
-    <dependency ref="pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
-    <dependency ref="pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A//github.com/apollographql/graphql-tag.git">
-      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
-      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+    <dependency ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git"/>
+    <dependency ref="pkg:npm/%40wry/equality@0.5.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git"/>
+    <dependency ref="pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git"/>
+    <dependency ref="pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git">
+      <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git"/>
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"/>
     </dependency>
-    <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A//github.com/graphql/graphql-js.git"/>
-    <dependency ref="pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/optimism.git">
-      <dependency ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
-      <dependency ref="pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A//github.com/benjamn/wryware.git"/>
+    <dependency ref="pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git"/>
+    <dependency ref="pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Foptimism.git">
+      <dependency ref="pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git"/>
+      <dependency ref="pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git"/>
     </dependency>
-    <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A//github.com/facebook/react.git#packages/react"/>
-    <dependency ref="pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A//github.com/blesh/symbol-observable.git"/>
-    <dependency ref="pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A//github.com/apollographql/invariant-packages.git">
-      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
+    <dependency ref="pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git#packages/react"/>
+    <dependency ref="pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git"/>
+    <dependency ref="pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git">
+      <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"/>
     </dependency>
-    <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A//github.com/Microsoft/tslib.git"/>
-    <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A//github.com/apollographql/zen-observable-ts.git"/>
+    <dependency ref="pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git"/>
+    <dependency ref="pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git"/>
   </dependencies>
 </bom>"
 `;
@@ -9876,7 +10296,7 @@ exports[`integration regression: verify enhanced package.json finder generated j
       "type": "library",
       "name": "libphonenumber-js",
       "version": "1.11.3",
-      "bom-ref": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
+      "bom-ref": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
       "author": "catamphetamine",
       "description": "A simpler (and smaller) rewrite of Google Android's libphonenumber library in javascript",
       "licenses": [
@@ -9886,7 +10306,7 @@ exports[`integration regression: verify enhanced package.json finder generated j
           }
         }
       ],
-      "purl": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
+      "purl": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
       "externalReferences": [
         {
           "url": "https://gitlab.com/catamphetamine/libphonenumber-js/issues",
@@ -9909,7 +10329,7 @@ exports[`integration regression: verify enhanced package.json finder generated j
       "type": "library",
       "name": "luxon",
       "version": "3.4.4",
-      "bom-ref": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git",
+      "bom-ref": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git",
       "author": "Isaac Cambron",
       "description": "Immutable date wrapper",
       "licenses": [
@@ -9919,7 +10339,7 @@ exports[`integration regression: verify enhanced package.json finder generated j
           }
         }
       ],
-      "purl": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git",
+      "purl": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git",
       "externalReferences": [
         {
           "url": "https://github.com/moment/luxon/issues",
@@ -9943,15 +10363,15 @@ exports[`integration regression: verify enhanced package.json finder generated j
     {
       "ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue1284",
       "dependsOn": [
-        "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
-        "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git"
+        "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
+        "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git"
       ]
     },
     {
-      "ref": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git"
+      "ref": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git"
     },
     {
-      "ref": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git"
+      "ref": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git"
     }
   ]
 }"
@@ -10024,7 +10444,7 @@ exports[`integration regression: verify enhanced package.json finder generated j
       "type": "library",
       "name": "libphonenumber-js",
       "version": "1.11.3",
-      "bom-ref": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
+      "bom-ref": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
       "author": "catamphetamine",
       "description": "A simpler (and smaller) rewrite of Google Android's libphonenumber library in javascript",
       "licenses": [
@@ -10034,7 +10454,7 @@ exports[`integration regression: verify enhanced package.json finder generated j
           }
         }
       ],
-      "purl": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
+      "purl": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
       "externalReferences": [
         {
           "url": "https://gitlab.com/catamphetamine/libphonenumber-js/issues",
@@ -10057,7 +10477,7 @@ exports[`integration regression: verify enhanced package.json finder generated j
       "type": "library",
       "name": "luxon",
       "version": "3.4.4",
-      "bom-ref": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git",
+      "bom-ref": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git",
       "author": "Isaac Cambron",
       "description": "Immutable date wrapper",
       "licenses": [
@@ -10067,7 +10487,7 @@ exports[`integration regression: verify enhanced package.json finder generated j
           }
         }
       ],
-      "purl": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git",
+      "purl": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git",
       "externalReferences": [
         {
           "url": "https://github.com/moment/luxon/issues",
@@ -10091,15 +10511,15 @@ exports[`integration regression: verify enhanced package.json finder generated j
     {
       "ref": "pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue1284",
       "dependsOn": [
-        "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
-        "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git"
+        "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
+        "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git"
       ]
     },
     {
-      "ref": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git"
+      "ref": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git"
     },
     {
-      "ref": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git"
+      "ref": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git"
     }
   ]
 }"
@@ -10157,7 +10577,7 @@ exports[`integration regression: verify enhanced package.json finder generated x
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git">
+    <component type="library" bom-ref="pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git">
       <author>catamphetamine</author>
       <name>libphonenumber-js</name>
       <version>1.11.3</version>
@@ -10167,7 +10587,7 @@ exports[`integration regression: verify enhanced package.json finder generated x
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git</purl>
+      <purl>pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://gitlab.com/catamphetamine/libphonenumber-js/issues</url>
@@ -10183,7 +10603,7 @@ exports[`integration regression: verify enhanced package.json finder generated x
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git">
+    <component type="library" bom-ref="pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git">
       <author>Isaac Cambron</author>
       <name>luxon</name>
       <version>3.4.4</version>
@@ -10193,7 +10613,7 @@ exports[`integration regression: verify enhanced package.json finder generated x
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git</purl>
+      <purl>pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/moment/luxon/issues</url>
@@ -10212,11 +10632,11 @@ exports[`integration regression: verify enhanced package.json finder generated x
   </components>
   <dependencies>
     <dependency ref="pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue1284">
-      <dependency ref="pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git"/>
-      <dependency ref="pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git"/>
+      <dependency ref="pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git"/>
+      <dependency ref="pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git"/>
     </dependency>
-    <dependency ref="pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git"/>
-    <dependency ref="pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git"/>
+    <dependency ref="pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git"/>
+    <dependency ref="pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git"/>
   </dependencies>
 </bom>"
 `;
@@ -10288,7 +10708,7 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
       "type": "library",
       "name": "libphonenumber-js",
       "version": "1.11.3",
-      "bom-ref": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
+      "bom-ref": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
       "author": "catamphetamine",
       "description": "A simpler (and smaller) rewrite of Google Android's libphonenumber library in javascript",
       "licenses": [
@@ -10298,7 +10718,7 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
           }
         }
       ],
-      "purl": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
+      "purl": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
       "externalReferences": [
         {
           "url": "https://gitlab.com/catamphetamine/libphonenumber-js/issues",
@@ -10321,7 +10741,7 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
       "type": "library",
       "name": "luxon",
       "version": "3.4.4",
-      "bom-ref": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git",
+      "bom-ref": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git",
       "author": "Isaac Cambron",
       "description": "Immutable date wrapper",
       "licenses": [
@@ -10331,7 +10751,7 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
           }
         }
       ],
-      "purl": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git",
+      "purl": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git",
       "externalReferences": [
         {
           "url": "https://github.com/moment/luxon/issues",
@@ -10355,15 +10775,15 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
     {
       "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1284-yarn",
       "dependsOn": [
-        "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
-        "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git"
+        "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
+        "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git"
       ]
     },
     {
-      "ref": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git"
+      "ref": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git"
     },
     {
-      "ref": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git"
+      "ref": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git"
     }
   ]
 }"
@@ -10436,7 +10856,7 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
       "type": "library",
       "name": "libphonenumber-js",
       "version": "1.11.3",
-      "bom-ref": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
+      "bom-ref": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
       "author": "catamphetamine",
       "description": "A simpler (and smaller) rewrite of Google Android's libphonenumber library in javascript",
       "licenses": [
@@ -10446,7 +10866,7 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
           }
         }
       ],
-      "purl": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
+      "purl": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
       "externalReferences": [
         {
           "url": "https://gitlab.com/catamphetamine/libphonenumber-js/issues",
@@ -10469,7 +10889,7 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
       "type": "library",
       "name": "luxon",
       "version": "3.4.4",
-      "bom-ref": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git",
+      "bom-ref": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git",
       "author": "Isaac Cambron",
       "description": "Immutable date wrapper",
       "licenses": [
@@ -10479,7 +10899,7 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
           }
         }
       ],
-      "purl": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git",
+      "purl": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git",
       "externalReferences": [
         {
           "url": "https://github.com/moment/luxon/issues",
@@ -10503,15 +10923,15 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
     {
       "ref": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1284-yarn",
       "dependsOn": [
-        "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git",
-        "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git"
+        "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git",
+        "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git"
       ]
     },
     {
-      "ref": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git"
+      "ref": "pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git"
     },
     {
-      "ref": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git"
+      "ref": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git"
     }
   ]
 }"
@@ -10569,7 +10989,7 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git">
+    <component type="library" bom-ref="pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git">
       <author>catamphetamine</author>
       <name>libphonenumber-js</name>
       <version>1.11.3</version>
@@ -10579,7 +10999,7 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git</purl>
+      <purl>pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://gitlab.com/catamphetamine/libphonenumber-js/issues</url>
@@ -10595,7 +11015,7 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git">
+    <component type="library" bom-ref="pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git">
       <author>Isaac Cambron</author>
       <name>luxon</name>
       <version>3.4.4</version>
@@ -10605,7 +11025,7 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git</purl>
+      <purl>pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/moment/luxon/issues</url>
@@ -10624,11 +11044,11 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
   </components>
   <dependencies>
     <dependency ref="pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1284-yarn">
-      <dependency ref="pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git"/>
-      <dependency ref="pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git"/>
+      <dependency ref="pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git"/>
+      <dependency ref="pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git"/>
     </dependency>
-    <dependency ref="pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A//gitlab.com/catamphetamine/libphonenumber-js.git"/>
-    <dependency ref="pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A//github.com/moment/luxon.git"/>
+    <dependency ref="pkg:npm/libphonenumber-js@1.11.3?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fcatamphetamine%2Flibphonenumber-js.git"/>
+    <dependency ref="pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git"/>
   </dependencies>
 </bom>"
 `;


### PR DESCRIPTION
- Update to the latest @cyclonedx/cyclonedx-library - 7.0.0
- If the generating schema is 1.5+ generate the non-deprecated version of the metadata/tools section

fixes #1330
closes #1331