### PR TITLE
feat: emit webpack as `metadata.tools`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
   * Option `specVersion` defaults to `"1.6"`, was `"1.4"` ([#1329] via [#1333])
   * Emit `.metadata.tools` as components ([#1330] via [#1331])  
     This affects only CycloneDX spec-version 1.5 and later.
+* Added
+  * Emit "webpack" as part of `.metadata.tools` (via [#])
 * Build
   * Use _TypeScript_ `v5.7.3` now, was `v5.6.3` (via [#1351])
 
@@ -18,6 +20,7 @@ All notable changes to this project will be documented in this file.
 [#1331]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1331
 [#1333]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1333
 [#1351]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1351
+[#]: 
 
 ## 3.17.0 - 2025-01-10
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
   * Emit `.metadata.tools` as components ([#1330] via [#1331])  
     This affects only CycloneDX spec-version 1.5 and later.
 * Added
-  * Emit "webpack" as part of `.metadata.tools` (via [#])
+  * Emit "webpack" as part of `.metadata.tools` (via [#1354])
 * Build
   * Use _TypeScript_ `v5.7.3` now, was `v5.6.3` (via [#1351])
 
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 [#1331]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1331
 [#1333]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1333
 [#1351]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1351
-[#]: 
+[#1354]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1354
 
 ## 3.17.0 - 2025-01-10
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -132,6 +132,15 @@ class ValidationError extends Error {
   }
 }
 
+const WEBPACK_VERSION = (function () {
+  try {
+    /* eslint-disable-next-line @typescript-eslint/no-var-requires */
+    return require('webpack').webpack.version as string
+  } catch {
+    return undefined
+  }
+})()
+
 /** @public */
 export class CycloneDxWebpackPlugin {
   specVersion: CDX.Spec.Version
@@ -385,6 +394,11 @@ export class CycloneDxWebpackPlugin {
       ? undefined
       : new Date()
 
+    bom.metadata.tools.components.add(new CDX.Models.Component(
+      CDX.Enums.ComponentType.Application,
+      'webpack',
+      { version: WEBPACK_VERSION }
+    ))
     for (const toolC of this.#makeToolCs(cdxComponentBuilder, logger.getChildLogger('ToolMaker'))) {
       bom.metadata.tools.components.add(toolC)
     }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -21,7 +21,7 @@ import * as CDX from '@cyclonedx/cyclonedx-library'
 import { existsSync } from 'fs'
 import * as normalizePackageJson from 'normalize-package-data'
 import { join as joinPath, resolve } from 'path'
-import { Compilation, type Compiler, sources } from 'webpack'
+import { Compilation, type Compiler, sources, version as WEBPACK_VERSION } from 'webpack'
 
 import { getPackageDescription, iterableSome, loadJsonFile } from './_helpers'
 import { Extractor } from './extractor'
@@ -131,15 +131,6 @@ class ValidationError extends Error {
     this.details = details
   }
 }
-
-const WEBPACK_VERSION = (function () {
-  try {
-    /* eslint-disable-next-line @typescript-eslint/no-var-requires */
-    return require('webpack').webpack.version as string
-  } catch {
-    return undefined
-  }
-})()
 
 /** @public */
 export class CycloneDxWebpackPlugin {

--- a/tests/integration/__snapshots__/index.test.js.snap
+++ b/tests/integration/__snapshots__/index.test.js.snap
@@ -15,6 +15,11 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -661,6 +666,11 @@ exports[`integration feature: component evidence generated json file: dist/.well
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -1303,6 +1313,10 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
     </lifecycles>
     <tools>
       <components>
+        <component type="application">
+          <name>webpack</name>
+          <version>webpackVersion-testing</version>
+        </component>
         <component type="library">
           <author>Jan Kowalleck</author>
           <group>@cyclonedx</group>
@@ -1761,6 +1775,11 @@ exports[`integration feature: root component BuildSystem generated json file: di
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -1890,6 +1909,11 @@ exports[`integration feature: root component BuildSystem generated json file: di
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -2015,6 +2039,10 @@ exports[`integration feature: root component BuildSystem generated xml file: dis
     </lifecycles>
     <tools>
       <components>
+        <component type="application">
+          <name>webpack</name>
+          <version>webpackVersion-testing</version>
+        </component>
         <component type="library">
           <author>Jan Kowalleck</author>
           <group>@cyclonedx</group>
@@ -2121,6 +2149,11 @@ exports[`integration feature: root component VCS generated json file: dist/.bom/
     ],
     "tools": {
       "components": [
+        {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
         {
           "type": "library",
           "name": "cyclonedx-library",
@@ -2269,6 +2302,11 @@ exports[`integration feature: root component VCS generated json file: dist/.well
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -2412,6 +2450,10 @@ exports[`integration feature: root component VCS generated xml file: dist/.bom/b
     </lifecycles>
     <tools>
       <components>
+        <component type="application">
+          <name>webpack</name>
+          <version>webpackVersion-testing</version>
+        </component>
         <component type="library">
           <author>Jan Kowalleck</author>
           <group>@cyclonedx</group>
@@ -2531,6 +2573,11 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
     ],
     "tools": {
       "components": [
+        {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
         {
           "type": "library",
           "name": "cyclonedx-library",
@@ -2939,6 +2986,11 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -3342,6 +3394,10 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
     </lifecycles>
     <tools>
       <components>
+        <component type="application">
+          <name>webpack</name>
+          <version>webpackVersion-testing</version>
+        </component>
         <component type="library">
           <author>Jan Kowalleck</author>
           <group>@cyclonedx</group>
@@ -3652,6 +3708,11 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
     ],
     "tools": {
       "components": [
+        {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
         {
           "type": "library",
           "name": "cyclonedx-library",
@@ -4140,6 +4201,11 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -4623,6 +4689,10 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
     </lifecycles>
     <tools>
       <components>
+        <component type="application">
+          <name>webpack</name>
+          <version>webpackVersion-testing</version>
+        </component>
         <component type="library">
           <author>Jan Kowalleck</author>
           <group>@cyclonedx</group>
@@ -4994,6 +5064,11 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -5350,6 +5425,11 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -5702,6 +5782,10 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
     </lifecycles>
     <tools>
       <components>
+        <component type="application">
+          <name>webpack</name>
+          <version>webpackVersion-testing</version>
+        </component>
         <component type="library">
           <author>Jan Kowalleck</author>
           <group>@cyclonedx</group>
@@ -5975,6 +6059,11 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.b
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -6140,6 +6229,11 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.w
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -6301,6 +6395,10 @@ exports[`integration functional: webpack5 with vue2 generated xml file: dist/.bo
     </lifecycles>
     <tools>
       <components>
+        <component type="application">
+          <name>webpack</name>
+          <version>webpackVersion-testing</version>
+        </component>
         <component type="library">
           <author>Jan Kowalleck</author>
           <group>@cyclonedx</group>
@@ -6433,6 +6531,11 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
     ],
     "tools": {
       "components": [
+        {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
         {
           "type": "library",
           "name": "cyclonedx-library",
@@ -6599,6 +6702,11 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -6760,6 +6868,10 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated xml 
     </lifecycles>
     <tools>
       <components>
+        <component type="application">
+          <name>webpack</name>
+          <version>webpackVersion-testing</version>
+        </component>
         <component type="library">
           <author>Jan Kowalleck</author>
           <group>@cyclonedx</group>
@@ -6892,6 +7004,11 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
     ],
     "tools": {
       "components": [
+        {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
         {
           "type": "library",
           "name": "cyclonedx-library",
@@ -7057,6 +7174,11 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -7217,6 +7339,10 @@ exports[`integration functional: webpack5 with vue2-cli-service generated xml fi
     </lifecycles>
     <tools>
       <components>
+        <component type="application">
+          <name>webpack</name>
+          <version>webpackVersion-testing</version>
+        </component>
         <component type="library">
           <author>Jan Kowalleck</author>
           <group>@cyclonedx</group>
@@ -7348,6 +7474,11 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
     ],
     "tools": {
       "components": [
+        {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
         {
           "type": "library",
           "name": "cyclonedx-library",
@@ -8175,6 +8306,11 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -8997,6 +9133,10 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
     </lifecycles>
     <tools>
       <components>
+        <component type="application">
+          <name>webpack</name>
+          <version>webpackVersion-testing</version>
+        </component>
         <component type="library">
           <author>Jan Kowalleck</author>
           <group>@cyclonedx</group>
@@ -9580,6 +9720,11 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
     ],
     "tools": {
       "components": [
+        {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
         {
           "type": "library",
           "name": "cyclonedx-library",
@@ -10177,6 +10322,11 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -10769,6 +10919,10 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
     </lifecycles>
     <tools>
       <components>
+        <component type="application">
+          <name>webpack</name>
+          <version>webpackVersion-testing</version>
+        </component>
         <component type="library">
           <author>Jan Kowalleck</author>
           <group>@cyclonedx</group>
@@ -11219,6 +11373,11 @@ exports[`integration regression: verify enhanced package.json finder generated j
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -11396,6 +11555,11 @@ exports[`integration regression: verify enhanced package.json finder generated j
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -11569,6 +11733,10 @@ exports[`integration regression: verify enhanced package.json finder generated x
     </lifecycles>
     <tools>
       <components>
+        <component type="application">
+          <name>webpack</name>
+          <version>webpackVersion-testing</version>
+        </component>
         <component type="library">
           <author>Jan Kowalleck</author>
           <group>@cyclonedx</group>
@@ -11709,6 +11877,11 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
     ],
     "tools": {
       "components": [
+        {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
         {
           "type": "library",
           "name": "cyclonedx-library",
@@ -11887,6 +12060,11 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
     "tools": {
       "components": [
         {
+          "type": "application",
+          "name": "webpack",
+          "version": "webpackVersion-testing"
+        },
+        {
           "type": "library",
           "name": "cyclonedx-library",
           "group": "@cyclonedx",
@@ -12060,6 +12238,10 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
     </lifecycles>
     <tools>
       <components>
+        <component type="application">
+          <name>webpack</name>
+          <version>webpackVersion-testing</version>
+        </component>
         <component type="library">
           <author>Jan Kowalleck</author>
           <group>@cyclonedx</group>

--- a/tests/integration/index.test.js
+++ b/tests/integration/index.test.js
@@ -354,6 +354,20 @@ function makeReproducible (format, data) {
 function makeJsonReproducible (json) {
   return json
     .replace(
+      // replace metadata.tools[].version
+      new RegExp(
+        '        {\n' +
+        '          "type": "application",\n' +
+        '          "name": "webpack",\n' +
+        '          "version": ".+?"\n' +
+        '        }'),
+      '        {\n' +
+      '          "type": "application",\n' +
+      '          "name": "webpack",\n' +
+      '          "version": "webpackVersion-testing"\n' +
+      '        }'
+    )
+    .replace(
       // replace self metadata.tools[].version
       '        "vendor": "@cyclonedx",\n' +
       '        "name": "webpack-plugin",\n' +
@@ -370,7 +384,7 @@ function makeJsonReproducible (json) {
       '          "group": "@cyclonedx",\n' +
       '          "version": "thisVersion-testing"'
     ).replace(
-      // replace library metadata.tools[].version
+      // replace cdx-lib metadata.tools[].version
       new RegExp(
         '        "vendor": "@cyclonedx",\n' +
         '        "name": "cyclonedx-library",\n' +
@@ -380,7 +394,7 @@ function makeJsonReproducible (json) {
       '        "name": "cyclonedx-library",\n' +
       '        "version": "libVersion-testing"'
     ).replace(
-      // replace library metadata.tools.components[].version
+      // replace cdx-lib metadata.tools.components[].version
       new RegExp(
         '          "name": "cyclonedx-library",\n' +
         '          "group": "@cyclonedx",\n' +
@@ -401,7 +415,19 @@ function makeJsonReproducible (json) {
 function makeXmlReproducible (xml) {
   return xml
     .replace(
-      // replace metadata.tools[].version
+      // replace webpack metadata.tools[].version
+      new RegExp(
+        '        <component type="application">\n' +
+        '          <name>webpack</name>\n' +
+        '          <version>.+?</version>\n' +
+        '        </component>'),
+      '        <component type="application">\n' +
+      '          <name>webpack</name>\n' +
+      '          <version>webpackVersion-testing</version>\n' +
+      '        </component>'
+    )
+    .replace(
+      // replace self metadata.tools[].version
       '        <vendor>@cyclonedx</vendor>\n' +
       '        <name>webpack-plugin</name>\n' +
       `        <version>${thisVersion}</version>`,
@@ -409,7 +435,7 @@ function makeXmlReproducible (xml) {
       '        <name>webpack-plugin</name>\n' +
       '        <version>thisVersion-testing</version>'
     ).replace(
-      // replace metadata.tools.components[].version
+      // replace self metadata.tools.components[].version
       '          <group>@cyclonedx</group>\n' +
       '          <name>webpack-plugin</name>\n' +
       `          <version>${thisVersion}</version>`,
@@ -417,7 +443,7 @@ function makeXmlReproducible (xml) {
       '          <name>webpack-plugin</name>\n' +
       '          <version>thisVersion-testing</version>'
     ).replace(
-      // replace metadata.tools[].version
+      // replace cdx-lib metadata.tools[].version
       new RegExp(
         '        <vendor>@cyclonedx</vendor>\n' +
         '        <name>cyclonedx-library</name>\n' +
@@ -427,7 +453,7 @@ function makeXmlReproducible (xml) {
       '        <name>cyclonedx-library</name>\n' +
       '        <version>libVersion-testing</version>'
     ).replace(
-      // replace metadata.tools.components[].version
+      // replace cdx-lib metadata.tools.components[].version
       '          <group>@cyclonedx</group>\n' +
       '          <name>cyclonedx-library</name>\n' +
       '          <version>.+?</version>',


### PR DESCRIPTION
in preparation for #1019