### PR TITLE
fix: prevent multiple, duplicate build-system entries

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -327,7 +327,11 @@ export class CycloneDxWebpackPlugin {
     if (component === undefined) { return }
     if (
       typeof this.rootComponentBuildSystem === 'string' &&
-      this.rootComponentBuildSystem.length > 0
+      this.rootComponentBuildSystem.length > 0 &&
+      !iterableSome(
+        component.externalReferences,
+        ref => ref.type === CDX.Enums.ExternalReferenceType.BuildSystem
+      )
     ) {
       component.externalReferences.add(
         new CDX.Models.ExternalReference(


### PR DESCRIPTION
PR #1349, for some projects, ends up creating multiple duplicate `build-system` external references. The fix is to ensure we have not already added an external reference of type: `build-system`.

With the current implementation, I've seen the plugin produce records like:

```json
"externalReferences": [
        {
          "url": "https://some.build.system.internal/job/88",
          "type": "build-system",
          "comment": "as declared via cyclonedx-webpack-plugin config \"rootComponentBuildSystem\""
        },
        {
          "url": "https://some.internal.vcs/org/repo",
          "type": "vcs",
          "comment": "as declared via cyclonedx-webpack-plugin config \"rootComponentVCS\""
        },
        {
          "url": "https://some.build.system.internal/job/88",
          "type": "build-system",
          "comment": "as declared via cyclonedx-webpack-plugin config \"rootComponentBuildSystem\""
        },
        {
          "url": "https://some.build.system.internal/job/88",
          "type": "build-system",
          "comment": "as declared via cyclonedx-webpack-plugin config \"rootComponentBuildSystem\""
        },
        {
          "url": "https://some.build.system.internal/job/88",
          "type": "build-system",
          "comment": "as declared via cyclonedx-webpack-plugin config \"rootComponentBuildSystem\""
        }
      ]
```


fixes #1356 