### PR TITLE
deps: modernize dependencies

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,10 +10,12 @@ All notable changes to this project will be documented in this file.
   * Dropped support for `node<20.18.0` ([#1362] via [#1365])
 * Dependencies
   * Upgraded runtime-dependency `@cyclonedx/cyclonedx-library@^8.0.0`, was `@^7.0.0` (via [#1367])
+  * Upgraded runtime-dependency `normalize-package-data@^7.0.0`, was `@^3||^4||^5||^6` (via [#1368])
 
 [#1362]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues/1362
 [#1365]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1365
 [#1367]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1367
+[#1368]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1368
 
 ## 4.0.1 - 2025-01-29
 

--- a/package.json
+++ b/package.json
@@ -68,16 +68,16 @@
   },
   "dependencies": {
     "@cyclonedx/cyclonedx-library": "^8.0.0-rc.0",
-    "normalize-package-data": "^3||^4||^5||^6",
+    "normalize-package-data": "^7.0.0",
     "xmlbuilder2": "^3.0.2"
   },
   "peerDependencies": {
     "webpack": "^5"
   },
   "devDependencies": {
-    "@types/node": "ts5.6",
-    "@types/normalize-package-data": "^2.4.1",
-    "c8": "^8||^9",
+    "@types/node": "ts5.7",
+    "@types/normalize-package-data": "^2.4.4",
+    "c8": "^10",
     "eslint": "8.57.1",
     "eslint-config-standard": "17.1.0",
     "eslint-config-standard-with-typescript": "43.0.1",
@@ -85,7 +85,7 @@
     "eslint-plugin-simple-import-sort": "12.1.1",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
-    "npm-run-all2": "^6.2.3",
+    "npm-run-all2": "^7.0.2",
     "typescript": "5.7.3",
     "webpack": "^5"
   },


### PR DESCRIPTION
- `normalize-package-data@^3||^4||^5||^6` -> `normalize-package-data@^7.0.0`
- and some dev-dendencies

this is a result of https://github.com/CycloneDX/cyclonedx-webpack-plugin/issues/1362