### PR TITLE
fix: tool detection in yarn

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 <!-- unreleased changes go here -->
 
+* Fixed
+    * Fix tool detection in yarn envs (via [#1568])
+
+[#1568]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1568
+
 ## 5.3.2 - 2026-03-19
 
 * Docs

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 <!-- unreleased changes go here -->
 
 * Fixed
-    * Fix tool detection in yarn envs (via [#1568])
+  * Fix tool detection in yarn envs (via [#1568])
 
 [#1568]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1568
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -34,11 +34,13 @@ import type { Compiler } from 'webpack'
 import { Compilation, sources, version as WEBPACK_VERSION } from 'webpack'
 
 import type { PackageDescription} from './_helpers';
-import {  getPackageConfig,
+import {
+  getPackageConfig,
   iterableSome,
   loadJsonFile,
   mkRelativePathReproducibleHash,
-  normalizePackageManifest} from './_helpers'
+  normalizePackageManifest
+} from './_helpers'
 import { Extractor } from './extractor'
 import { PackageUrlFactory } from './factories'
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -17,7 +17,6 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) OWASP Foundation. All Rights Reserved.
 */
 
-import { existsSync } from 'node:fs'
 import { join as joinPath, resolve } from 'node:path'
 
 import { Utils as BomUtils } from '@cyclonedx/cyclonedx-library/Contrib/Bom'
@@ -442,33 +441,33 @@ export class CycloneDxWebpackPlugin {
   * #makeToolCs (builder: FromNodePackageJsonBuilders.ComponentBuilder, logger: WebpackLogger): Generator<Component> {
     const packageJsonPaths: Array<[string, ComponentType]> = [
       // this plugin is an optional enhancement, not a standalone application -- use as `Library`
-      [resolve(module.path, '..', 'package.json'), ComponentType.Library]
+      [resolve(module.path, '..', 'package.json'), ComponentType.Library],
     ]
 
     const libs = [
-      '@cyclonedx/cyclonedx-library'
-    ].map(s => s.split('/', 2))
-    const nodeModulePaths = require.resolve.paths('__some_none-native_package__') ?? []
-    /* eslint-disable no-labels -- technically needed */
-    libsLoop:
+      '@cyclonedx/cyclonedx-library',
+    ]
     for (const lib of libs) {
-      for (const nodeModulePath of nodeModulePaths) {
-        const packageJsonPath = resolve(nodeModulePath, ...lib, 'package.json')
-        if (existsSync(packageJsonPath)) {
-          packageJsonPaths.push([packageJsonPath, ComponentType.Library])
-          continue libsLoop
-        }
+      logger.debug('try resolving manifest path for tool/lib', lib)
+      try {
+        packageJsonPaths.push([
+          require.resolve(`${lib}/package.json`),
+          ComponentType.Library
+        ])
+      } catch (err) {
+        logger.debug('failed resolving manifest for', lib, 'with error:', err)
       }
     }
-    /* eslint-enable no-labels */
 
     for (const [packageJsonPath, cType] of packageJsonPaths) {
-      logger.log('try to build new Tool from PkgPath', packageJsonPath)
+      logger.info('try building new Tool from PkgPath', packageJsonPath)
       /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expected */
       const packageJson: PackageDescription['packageJson'] = loadJsonFile(packageJsonPath) ?? {}
       normalizePackageManifest(
         packageJson,
-        w => { logger.debug('normalizePackageJson from PkgPath', packageJsonPath, 'caused:', w) }
+        w => {
+          logger.debug('normalizePackageJson from PkgPath', packageJsonPath, 'caused:', w)
+        }
       )
       const tool = builder.makeComponent(packageJson, cType)
       if (tool !== undefined) {


### PR DESCRIPTION


### Description

when run in a node24 env and in a yarn4.14.1 PnP env - not unplugged -
we see an error: `TypeError: require.resolve.paths is not a function`

this issue seams to be fixed in a later yarn version.

Anyway, here is a fix: lets use native file resolution.

Resolves or fixes issue: <!-- ✍️ Add GitHub issue number in format `#0000` - if there is none fitting, create one -->

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX/cyclonedx-webpack-plugin/blob/main/CONTRIBUTING.md) guidelines
