### PR TITLE
fix: reproducuble bomrefs component based

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,8 +8,10 @@ All notable changes to this project will be documented in this file.
 
 * Fixed
   * Fix tool detection in yarn envs (via [#1568])
+  * Reproducible BomRef values (via [#])
 
 [#1568]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1568
+[#]: 
 
 ## 5.3.2 - 2026-03-19
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,10 +8,10 @@ All notable changes to this project will be documented in this file.
 
 * Fixed
   * Fix tool detection in yarn envs (via [#1568])
-  * Reproducible BomRef values (via [#])
+  * Reproducible BomRef values (via [#1583])
 
 [#1568]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1568
-[#]: 
+[#1583]: https://github.com/CycloneDX/cyclonedx-webpack-plugin/pull/1583
 
 ## 5.3.2 - 2026-03-19
 

--- a/package.json
+++ b/package.json
@@ -127,6 +127,5 @@
   },
   "allowScripts": {
     "libxmljs2@0.37.0": true
-  },
-  "packageManager": "yarn@4.17.0+sha512.c2957de2f9025ab14d63b24d0d8be1f1655810e22c341042c27f7ecd017b180ec12db73d69ac366d71b304ef9f069349ce462de96f04f8f1da317f4f762c95ae"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -124,5 +124,6 @@
     "suiteName": "jest tests",
     "outputDirectory": "reports/jest",
     "outputName": "tests.junit.xml"
-  }
+  },
+  "packageManager": "yarn@4.17.0+sha512.c2957de2f9025ab14d63b24d0d8be1f1655810e22c341042c27f7ecd017b180ec12db73d69ac366d71b304ef9f069349ce462de96f04f8f1da317f4f762c95ae"
 }

--- a/package.json
+++ b/package.json
@@ -127,5 +127,6 @@
   },
   "allowScripts": {
     "libxmljs2@0.37.0": true
-  }
+  },
+  "packageManager": "yarn@4.17.0+sha512.c2957de2f9025ab14d63b24d0d8be1f1655810e22c341042c27f7ecd017b180ec12db73d69ac366d71b304ef9f069349ce462de96f04f8f1da317f4f762c95ae"
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -277,7 +277,7 @@ export class CycloneDxWebpackPlugin {
         if ( this.reproducibleResults ) {
           components.forEach((component, pkgPath) => {
             /* eslint-disable-next-line no-param-reassign -- ack */
-            component.bomRef.value = mkRelativePathReproducibleHash(compilerContext, pkgPath)
+            component.bomRef.value += `#${mkRelativePathReproducibleHash(compilerContext, pkgPath)}`
           })
         }
 

--- a/tests/integration/__snapshots__/index.test.js.snap
+++ b/tests/integration/__snapshots__/index.test.js.snap
@@ -90,7 +90,7 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
       "name": "feature-issue676",
       "group": "@cyclonedx-webpack-plugin-tests",
       "version": "0.0.0",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jan Kowalleck",
       "description": "example setup for testing evidence collection",
       "licenses": [
@@ -153,204 +153,10 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
   "components": [
     {
       "type": "library",
-      "name": "platform-browser",
-      "group": "@angular",
-      "version": "18.2.7",
-      "bom-ref": "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-      "author": "angular",
-      "description": "Angular - library for using Angular in a web browser",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/angular/angular.git#packages/platform-browser",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuZGV2L2xpY2Vuc2UKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "zone.js",
-      "version": "0.14.10",
-      "bom-ref": "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
-      "author": "Brian Ford",
-      "description": "Zones for JavaScript",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/zone.js@0.14.10?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/angular/angular.git#packages/zone.js",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuaW8vbGljZW5zZQoKUGVybWlzc2lvbiBpcyBoZXJlYnkgZ3JhbnRlZCwgZnJlZSBvZiBjaGFyZ2UsIHRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weQpvZiB0aGlzIHNvZnR3YXJlIGFuZCBhc3NvY2lhdGVkIGRvY3VtZW50YXRpb24gZmlsZXMgKHRoZSAiU29mdHdhcmUiKSwgdG8gZGVhbAppbiB0aGUgU29mdHdhcmUgd2l0aG91dCByZXN0cmljdGlvbiwgaW5jbHVkaW5nIHdpdGhvdXQgbGltaXRhdGlvbiB0aGUgcmlnaHRzCnRvIHVzZSwgY29weSwgbW9kaWZ5LCBtZXJnZSwgcHVibGlzaCwgZGlzdHJpYnV0ZSwgc3VibGljZW5zZSwgYW5kL29yIHNlbGwKY29waWVzIG9mIHRoZSBTb2Z0d2FyZSwgYW5kIHRvIHBlcm1pdCBwZXJzb25zIHRvIHdob20gdGhlIFNvZnR3YXJlIGlzCmZ1cm5pc2hlZCB0byBkbyBzbywgc3ViamVjdCB0byB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnM6CgpUaGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBzaGFsbCBiZSBpbmNsdWRlZCBpbgphbGwgY29waWVzIG9yIHN1YnN0YW50aWFsIHBvcnRpb25zIG9mIHRoZSBTb2Z0d2FyZS4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiLCBXSVRIT1VUIFdBUlJBTlRZIE9GIEFOWSBLSU5ELCBFWFBSRVNTIE9SCklNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZLApGSVRORVNTIEZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRSBBTkQgTk9OSU5GUklOR0VNRU5ULiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUKQVVUSE9SUyBPUiBDT1BZUklHSFQgSE9MREVSUyBCRSBMSUFCTEUgRk9SIEFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUgpMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBUT1JUIE9SIE9USEVSV0lTRSwgQVJJU0lORyBGUk9NLApPVVQgT0YgT1IgSU4gQ09OTkVDVElPTiBXSVRIIFRIRSBTT0ZUV0FSRSBPUiBUSEUgVVNFIE9SIE9USEVSIERFQUxJTkdTIElOClRIRSBTT0ZUV0FSRS4K",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "rxjs",
-      "version": "7.8.1",
-      "bom-ref": "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-      "author": "Ben Lesh",
-      "description": "Reactive Extensions for modern JavaScript",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ReactiveX/RxJS/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/reactivex/rxjs.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://rxjs.dev",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE.txt",
-              "text": {
-                "content": "ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEFwYWNoZSBMaWNlbnNlCiAgICAgICAgICAgICAgICAgICAgICAgICBWZXJzaW9uIDIuMCwgSmFudWFyeSAyMDA0CiAgICAgICAgICAgICAgICAgICAgICBodHRwOi8vd3d3LmFwYWNoZS5vcmcvbGljZW5zZXMvCgogVEVSTVMgQU5EIENPTkRJVElPTlMgRk9SIFVTRSwgUkVQUk9EVUNUSU9OLCBBTkQgRElTVFJJQlVUSU9OCgogMS4gRGVmaW5pdGlvbnMuCgogICAgIkxpY2Vuc2UiIHNoYWxsIG1lYW4gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIGZvciB1c2UsIHJlcHJvZHVjdGlvbiwKICAgIGFuZCBkaXN0cmlidXRpb24gYXMgZGVmaW5lZCBieSBTZWN0aW9ucyAxIHRocm91Z2ggOSBvZiB0aGlzIGRvY3VtZW50LgoKICAgICJMaWNlbnNvciIgc2hhbGwgbWVhbiB0aGUgY29weXJpZ2h0IG93bmVyIG9yIGVudGl0eSBhdXRob3JpemVkIGJ5CiAgICB0aGUgY29weXJpZ2h0IG93bmVyIHRoYXQgaXMgZ3JhbnRpbmcgdGhlIExpY2Vuc2UuCgogICAgIkxlZ2FsIEVudGl0eSIgc2hhbGwgbWVhbiB0aGUgdW5pb24gb2YgdGhlIGFjdGluZyBlbnRpdHkgYW5kIGFsbAogICAgb3RoZXIgZW50aXRpZXMgdGhhdCBjb250cm9sLCBhcmUgY29udHJvbGxlZCBieSwgb3IgYXJlIHVuZGVyIGNvbW1vbgogICAgY29udHJvbCB3aXRoIHRoYXQgZW50aXR5LiBGb3IgdGhlIHB1cnBvc2VzIG9mIHRoaXMgZGVmaW5pdGlvbiwKICAgICJjb250cm9sIiBtZWFucyAoaSkgdGhlIHBvd2VyLCBkaXJlY3Qgb3IgaW5kaXJlY3QsIHRvIGNhdXNlIHRoZQogICAgZGlyZWN0aW9uIG9yIG1hbmFnZW1lbnQgb2Ygc3VjaCBlbnRpdHksIHdoZXRoZXIgYnkgY29udHJhY3Qgb3IKICAgIG90aGVyd2lzZSwgb3IgKGlpKSBvd25lcnNoaXAgb2YgZmlmdHkgcGVyY2VudCAoNTAlKSBvciBtb3JlIG9mIHRoZQogICAgb3V0c3RhbmRpbmcgc2hhcmVzLCBvciAoaWlpKSBiZW5lZmljaWFsIG93bmVyc2hpcCBvZiBzdWNoIGVudGl0eS4KCiAgICAiWW91IiAob3IgIllvdXIiKSBzaGFsbCBtZWFuIGFuIGluZGl2aWR1YWwgb3IgTGVnYWwgRW50aXR5CiAgICBleGVyY2lzaW5nIHBlcm1pc3Npb25zIGdyYW50ZWQgYnkgdGhpcyBMaWNlbnNlLgoKICAgICJTb3VyY2UiIGZvcm0gc2hhbGwgbWVhbiB0aGUgcHJlZmVycmVkIGZvcm0gZm9yIG1ha2luZyBtb2RpZmljYXRpb25zLAogICAgaW5jbHVkaW5nIGJ1dCBub3QgbGltaXRlZCB0byBzb2Z0d2FyZSBzb3VyY2UgY29kZSwgZG9jdW1lbnRhdGlvbgogICAgc291cmNlLCBhbmQgY29uZmlndXJhdGlvbiBmaWxlcy4KCiAgICAiT2JqZWN0IiBmb3JtIHNoYWxsIG1lYW4gYW55IGZvcm0gcmVzdWx0aW5nIGZyb20gbWVjaGFuaWNhbAogICAgdHJhbnNmb3JtYXRpb24gb3IgdHJhbnNsYXRpb24gb2YgYSBTb3VyY2UgZm9ybSwgaW5jbHVkaW5nIGJ1dAogICAgbm90IGxpbWl0ZWQgdG8gY29tcGlsZWQgb2JqZWN0IGNvZGUsIGdlbmVyYXRlZCBkb2N1bWVudGF0aW9uLAogICAgYW5kIGNvbnZlcnNpb25zIHRvIG90aGVyIG1lZGlhIHR5cGVzLgoKICAgICJXb3JrIiBzaGFsbCBtZWFuIHRoZSB3b3JrIG9mIGF1dGhvcnNoaXAsIHdoZXRoZXIgaW4gU291cmNlIG9yCiAgICBPYmplY3QgZm9ybSwgbWFkZSBhdmFpbGFibGUgdW5kZXIgdGhlIExpY2Vuc2UsIGFzIGluZGljYXRlZCBieSBhCiAgICBjb3B5cmlnaHQgbm90aWNlIHRoYXQgaXMgaW5jbHVkZWQgaW4gb3IgYXR0YWNoZWQgdG8gdGhlIHdvcmsKICAgIChhbiBleGFtcGxlIGlzIHByb3ZpZGVkIGluIHRoZSBBcHBlbmRpeCBiZWxvdykuCgogICAgIkRlcml2YXRpdmUgV29ya3MiIHNoYWxsIG1lYW4gYW55IHdvcmssIHdoZXRoZXIgaW4gU291cmNlIG9yIE9iamVjdAogICAgZm9ybSwgdGhhdCBpcyBiYXNlZCBvbiAob3IgZGVyaXZlZCBmcm9tKSB0aGUgV29yayBhbmQgZm9yIHdoaWNoIHRoZQogICAgZWRpdG9yaWFsIHJldmlzaW9ucywgYW5ub3RhdGlvbnMsIGVsYWJvcmF0aW9ucywgb3Igb3RoZXIgbW9kaWZpY2F0aW9ucwogICAgcmVwcmVzZW50LCBhcyBhIHdob2xlLCBhbiBvcmlnaW5hbCB3b3JrIG9mIGF1dGhvcnNoaXAuIEZvciB0aGUgcHVycG9zZXMKICAgIG9mIHRoaXMgTGljZW5zZSwgRGVyaXZhdGl2ZSBXb3JrcyBzaGFsbCBub3QgaW5jbHVkZSB3b3JrcyB0aGF0IHJlbWFpbgogICAgc2VwYXJhYmxlIGZyb20sIG9yIG1lcmVseSBsaW5rIChvciBiaW5kIGJ5IG5hbWUpIHRvIHRoZSBpbnRlcmZhY2VzIG9mLAogICAgdGhlIFdvcmsgYW5kIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZi4KCiAgICAiQ29udHJpYnV0aW9uIiBzaGFsbCBtZWFuIGFueSB3b3JrIG9mIGF1dGhvcnNoaXAsIGluY2x1ZGluZwogICAgdGhlIG9yaWdpbmFsIHZlcnNpb24gb2YgdGhlIFdvcmsgYW5kIGFueSBtb2RpZmljYXRpb25zIG9yIGFkZGl0aW9ucwogICAgdG8gdGhhdCBXb3JrIG9yIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZiwgdGhhdCBpcyBpbnRlbnRpb25hbGx5CiAgICBzdWJtaXR0ZWQgdG8gTGljZW5zb3IgZm9yIGluY2x1c2lvbiBpbiB0aGUgV29yayBieSB0aGUgY29weXJpZ2h0IG93bmVyCiAgICBvciBieSBhbiBpbmRpdmlkdWFsIG9yIExlZ2FsIEVudGl0eSBhdXRob3JpemVkIHRvIHN1Ym1pdCBvbiBiZWhhbGYgb2YKICAgIHRoZSBjb3B5cmlnaHQgb3duZXIuIEZvciB0aGUgcHVycG9zZXMgb2YgdGhpcyBkZWZpbml0aW9uLCAic3VibWl0dGVkIgogICAgbWVhbnMgYW55IGZvcm0gb2YgZWxlY3Ryb25pYywgdmVyYmFsLCBvciB3cml0dGVuIGNvbW11bmljYXRpb24gc2VudAogICAgdG8gdGhlIExpY2Vuc29yIG9yIGl0cyByZXByZXNlbnRhdGl2ZXMsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQgdG8KICAgIGNvbW11bmljYXRpb24gb24gZWxlY3Ryb25pYyBtYWlsaW5nIGxpc3RzLCBzb3VyY2UgY29kZSBjb250cm9sIHN5c3RlbXMsCiAgICBhbmQgaXNzdWUgdHJhY2tpbmcgc3lzdGVtcyB0aGF0IGFyZSBtYW5hZ2VkIGJ5LCBvciBvbiBiZWhhbGYgb2YsIHRoZQogICAgTGljZW5zb3IgZm9yIHRoZSBwdXJwb3NlIG9mIGRpc2N1c3NpbmcgYW5kIGltcHJvdmluZyB0aGUgV29yaywgYnV0CiAgICBleGNsdWRpbmcgY29tbXVuaWNhdGlvbiB0aGF0IGlzIGNvbnNwaWN1b3VzbHkgbWFya2VkIG9yIG90aGVyd2lzZQogICAgZGVzaWduYXRlZCBpbiB3cml0aW5nIGJ5IHRoZSBjb3B5cmlnaHQgb3duZXIgYXMgIk5vdCBhIENvbnRyaWJ1dGlvbi4iCgogICAgIkNvbnRyaWJ1dG9yIiBzaGFsbCBtZWFuIExpY2Vuc29yIGFuZCBhbnkgaW5kaXZpZHVhbCBvciBMZWdhbCBFbnRpdHkKICAgIG9uIGJlaGFsZiBvZiB3aG9tIGEgQ29udHJpYnV0aW9uIGhhcyBiZWVuIHJlY2VpdmVkIGJ5IExpY2Vuc29yIGFuZAogICAgc3Vic2VxdWVudGx5IGluY29ycG9yYXRlZCB3aXRoaW4gdGhlIFdvcmsuCgogMi4gR3JhbnQgb2YgQ29weXJpZ2h0IExpY2Vuc2UuIFN1YmplY3QgdG8gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mCiAgICB0aGlzIExpY2Vuc2UsIGVhY2ggQ29udHJpYnV0b3IgaGVyZWJ5IGdyYW50cyB0byBZb3UgYSBwZXJwZXR1YWwsCiAgICB3b3JsZHdpZGUsIG5vbi1leGNsdXNpdmUsIG5vLWNoYXJnZSwgcm95YWx0eS1mcmVlLCBpcnJldm9jYWJsZQogICAgY29weXJpZ2h0IGxpY2Vuc2UgdG8gcmVwcm9kdWNlLCBwcmVwYXJlIERlcml2YXRpdmUgV29ya3Mgb2YsCiAgICBwdWJsaWNseSBkaXNwbGF5LCBwdWJsaWNseSBwZXJmb3JtLCBzdWJsaWNlbnNlLCBhbmQgZGlzdHJpYnV0ZSB0aGUKICAgIFdvcmsgYW5kIHN1Y2ggRGVyaXZhdGl2ZSBXb3JrcyBpbiBTb3VyY2Ugb3IgT2JqZWN0IGZvcm0uCgogMy4gR3JhbnQgb2YgUGF0ZW50IExpY2Vuc2UuIFN1YmplY3QgdG8gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mCiAgICB0aGlzIExpY2Vuc2UsIGVhY2ggQ29udHJpYnV0b3IgaGVyZWJ5IGdyYW50cyB0byBZb3UgYSBwZXJwZXR1YWwsCiAgICB3b3JsZHdpZGUsIG5vbi1leGNsdXNpdmUsIG5vLWNoYXJnZSwgcm95YWx0eS1mcmVlLCBpcnJldm9jYWJsZQogICAgKGV4Y2VwdCBhcyBzdGF0ZWQgaW4gdGhpcyBzZWN0aW9uKSBwYXRlbnQgbGljZW5zZSB0byBtYWtlLCBoYXZlIG1hZGUsCiAgICB1c2UsIG9mZmVyIHRvIHNlbGwsIHNlbGwsIGltcG9ydCwgYW5kIG90aGVyd2lzZSB0cmFuc2ZlciB0aGUgV29yaywKICAgIHdoZXJlIHN1Y2ggbGljZW5zZSBhcHBsaWVzIG9ubHkgdG8gdGhvc2UgcGF0ZW50IGNsYWltcyBsaWNlbnNhYmxlCiAgICBieSBzdWNoIENvbnRyaWJ1dG9yIHRoYXQgYXJlIG5lY2Vzc2FyaWx5IGluZnJpbmdlZCBieSB0aGVpcgogICAgQ29udHJpYnV0aW9uKHMpIGFsb25lIG9yIGJ5IGNvbWJpbmF0aW9uIG9mIHRoZWlyIENvbnRyaWJ1dGlvbihzKQogICAgd2l0aCB0aGUgV29yayB0byB3aGljaCBzdWNoIENvbnRyaWJ1dGlvbihzKSB3YXMgc3VibWl0dGVkLiBJZiBZb3UKICAgIGluc3RpdHV0ZSBwYXRlbnQgbGl0aWdhdGlvbiBhZ2FpbnN0IGFueSBlbnRpdHkgKGluY2x1ZGluZyBhCiAgICBjcm9zcy1jbGFpbSBvciBjb3VudGVyY2xhaW0gaW4gYSBsYXdzdWl0KSBhbGxlZ2luZyB0aGF0IHRoZSBXb3JrCiAgICBvciBhIENvbnRyaWJ1dGlvbiBpbmNvcnBvcmF0ZWQgd2l0aGluIHRoZSBXb3JrIGNvbnN0aXR1dGVzIGRpcmVjdAogICAgb3IgY29udHJpYnV0b3J5IHBhdGVudCBpbmZyaW5nZW1lbnQsIHRoZW4gYW55IHBhdGVudCBsaWNlbnNlcwogICAgZ3JhbnRlZCB0byBZb3UgdW5kZXIgdGhpcyBMaWNlbnNlIGZvciB0aGF0IFdvcmsgc2hhbGwgdGVybWluYXRlCiAgICBhcyBvZiB0aGUgZGF0ZSBzdWNoIGxpdGlnYXRpb24gaXMgZmlsZWQuCgogNC4gUmVkaXN0cmlidXRpb24uIFlvdSBtYXkgcmVwcm9kdWNlIGFuZCBkaXN0cmlidXRlIGNvcGllcyBvZiB0aGUKICAgIFdvcmsgb3IgRGVyaXZhdGl2ZSBXb3JrcyB0aGVyZW9mIGluIGFueSBtZWRpdW0sIHdpdGggb3Igd2l0aG91dAogICAgbW9kaWZpY2F0aW9ucywgYW5kIGluIFNvdXJjZSBvciBPYmplY3QgZm9ybSwgcHJvdmlkZWQgdGhhdCBZb3UKICAgIG1lZXQgdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKICAgIChhKSBZb3UgbXVzdCBnaXZlIGFueSBvdGhlciByZWNpcGllbnRzIG9mIHRoZSBXb3JrIG9yCiAgICAgICAgRGVyaXZhdGl2ZSBXb3JrcyBhIGNvcHkgb2YgdGhpcyBMaWNlbnNlOyBhbmQKCiAgICAoYikgWW91IG11c3QgY2F1c2UgYW55IG1vZGlmaWVkIGZpbGVzIHRvIGNhcnJ5IHByb21pbmVudCBub3RpY2VzCiAgICAgICAgc3RhdGluZyB0aGF0IFlvdSBjaGFuZ2VkIHRoZSBmaWxlczsgYW5kCgogICAgKGMpIFlvdSBtdXN0IHJldGFpbiwgaW4gdGhlIFNvdXJjZSBmb3JtIG9mIGFueSBEZXJpdmF0aXZlIFdvcmtzCiAgICAgICAgdGhhdCBZb3UgZGlzdHJpYnV0ZSwgYWxsIGNvcHlyaWdodCwgcGF0ZW50LCB0cmFkZW1hcmssIGFuZAogICAgICAgIGF0dHJpYnV0aW9uIG5vdGljZXMgZnJvbSB0aGUgU291cmNlIGZvcm0gb2YgdGhlIFdvcmssCiAgICAgICAgZXhjbHVkaW5nIHRob3NlIG5vdGljZXMgdGhhdCBkbyBub3QgcGVydGFpbiB0byBhbnkgcGFydCBvZgogICAgICAgIHRoZSBEZXJpdmF0aXZlIFdvcmtzOyBhbmQKCiAgICAoZCkgSWYgdGhlIFdvcmsgaW5jbHVkZXMgYSAiTk9USUNFIiB0ZXh0IGZpbGUgYXMgcGFydCBvZiBpdHMKICAgICAgICBkaXN0cmlidXRpb24sIHRoZW4gYW55IERlcml2YXRpdmUgV29ya3MgdGhhdCBZb3UgZGlzdHJpYnV0ZSBtdXN0CiAgICAgICAgaW5jbHVkZSBhIHJlYWRhYmxlIGNvcHkgb2YgdGhlIGF0dHJpYnV0aW9uIG5vdGljZXMgY29udGFpbmVkCiAgICAgICAgd2l0aGluIHN1Y2ggTk9USUNFIGZpbGUsIGV4Y2x1ZGluZyB0aG9zZSBub3RpY2VzIHRoYXQgZG8gbm90CiAgICAgICAgcGVydGFpbiB0byBhbnkgcGFydCBvZiB0aGUgRGVyaXZhdGl2ZSBXb3JrcywgaW4gYXQgbGVhc3Qgb25lCiAgICAgICAgb2YgdGhlIGZvbGxvd2luZyBwbGFjZXM6IHdpdGhpbiBhIE5PVElDRSB0ZXh0IGZpbGUgZGlzdHJpYnV0ZWQKICAgICAgICBhcyBwYXJ0IG9mIHRoZSBEZXJpdmF0aXZlIFdvcmtzOyB3aXRoaW4gdGhlIFNvdXJjZSBmb3JtIG9yCiAgICAgICAgZG9jdW1lbnRhdGlvbiwgaWYgcHJvdmlkZWQgYWxvbmcgd2l0aCB0aGUgRGVyaXZhdGl2ZSBXb3Jrczsgb3IsCiAgICAgICAgd2l0aGluIGEgZGlzcGxheSBnZW5lcmF0ZWQgYnkgdGhlIERlcml2YXRpdmUgV29ya3MsIGlmIGFuZAogICAgICAgIHdoZXJldmVyIHN1Y2ggdGhpcmQtcGFydHkgbm90aWNlcyBub3JtYWxseSBhcHBlYXIuIFRoZSBjb250ZW50cwogICAgICAgIG9mIHRoZSBOT1RJQ0UgZmlsZSBhcmUgZm9yIGluZm9ybWF0aW9uYWwgcHVycG9zZXMgb25seSBhbmQKICAgICAgICBkbyBub3QgbW9kaWZ5IHRoZSBMaWNlbnNlLiBZb3UgbWF5IGFkZCBZb3VyIG93biBhdHRyaWJ1dGlvbgogICAgICAgIG5vdGljZXMgd2l0aGluIERlcml2YXRpdmUgV29ya3MgdGhhdCBZb3UgZGlzdHJpYnV0ZSwgYWxvbmdzaWRlCiAgICAgICAgb3IgYXMgYW4gYWRkZW5kdW0gdG8gdGhlIE5PVElDRSB0ZXh0IGZyb20gdGhlIFdvcmssIHByb3ZpZGVkCiAgICAgICAgdGhhdCBzdWNoIGFkZGl0aW9uYWwgYXR0cmlidXRpb24gbm90aWNlcyBjYW5ub3QgYmUgY29uc3RydWVkCiAgICAgICAgYXMgbW9kaWZ5aW5nIHRoZSBMaWNlbnNlLgoKICAgIFlvdSBtYXkgYWRkIFlvdXIgb3duIGNvcHlyaWdodCBzdGF0ZW1lbnQgdG8gWW91ciBtb2RpZmljYXRpb25zIGFuZAogICAgbWF5IHByb3ZpZGUgYWRkaXRpb25hbCBvciBkaWZmZXJlbnQgbGljZW5zZSB0ZXJtcyBhbmQgY29uZGl0aW9ucwogICAgZm9yIHVzZSwgcmVwcm9kdWN0aW9uLCBvciBkaXN0cmlidXRpb24gb2YgWW91ciBtb2RpZmljYXRpb25zLCBvcgogICAgZm9yIGFueSBzdWNoIERlcml2YXRpdmUgV29ya3MgYXMgYSB3aG9sZSwgcHJvdmlkZWQgWW91ciB1c2UsCiAgICByZXByb2R1Y3Rpb24sIGFuZCBkaXN0cmlidXRpb24gb2YgdGhlIFdvcmsgb3RoZXJ3aXNlIGNvbXBsaWVzIHdpdGgKICAgIHRoZSBjb25kaXRpb25zIHN0YXRlZCBpbiB0aGlzIExpY2Vuc2UuCgogNS4gU3VibWlzc2lvbiBvZiBDb250cmlidXRpb25zLiBVbmxlc3MgWW91IGV4cGxpY2l0bHkgc3RhdGUgb3RoZXJ3aXNlLAogICAgYW55IENvbnRyaWJ1dGlvbiBpbnRlbnRpb25hbGx5IHN1Ym1pdHRlZCBmb3IgaW5jbHVzaW9uIGluIHRoZSBXb3JrCiAgICBieSBZb3UgdG8gdGhlIExpY2Vuc29yIHNoYWxsIGJlIHVuZGVyIHRoZSB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZgogICAgdGhpcyBMaWNlbnNlLCB3aXRob3V0IGFueSBhZGRpdGlvbmFsIHRlcm1zIG9yIGNvbmRpdGlvbnMuCiAgICBOb3R3aXRoc3RhbmRpbmcgdGhlIGFib3ZlLCBub3RoaW5nIGhlcmVpbiBzaGFsbCBzdXBlcnNlZGUgb3IgbW9kaWZ5CiAgICB0aGUgdGVybXMgb2YgYW55IHNlcGFyYXRlIGxpY2Vuc2UgYWdyZWVtZW50IHlvdSBtYXkgaGF2ZSBleGVjdXRlZAogICAgd2l0aCBMaWNlbnNvciByZWdhcmRpbmcgc3VjaCBDb250cmlidXRpb25zLgoKIDYuIFRyYWRlbWFya3MuIFRoaXMgTGljZW5zZSBkb2VzIG5vdCBncmFudCBwZXJtaXNzaW9uIHRvIHVzZSB0aGUgdHJhZGUKICAgIG5hbWVzLCB0cmFkZW1hcmtzLCBzZXJ2aWNlIG1hcmtzLCBvciBwcm9kdWN0IG5hbWVzIG9mIHRoZSBMaWNlbnNvciwKICAgIGV4Y2VwdCBhcyByZXF1aXJlZCBmb3IgcmVhc29uYWJsZSBhbmQgY3VzdG9tYXJ5IHVzZSBpbiBkZXNjcmliaW5nIHRoZQogICAgb3JpZ2luIG9mIHRoZSBXb3JrIGFuZCByZXByb2R1Y2luZyB0aGUgY29udGVudCBvZiB0aGUgTk9USUNFIGZpbGUuCgogNy4gRGlzY2xhaW1lciBvZiBXYXJyYW50eS4gVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yCiAgICBhZ3JlZWQgdG8gaW4gd3JpdGluZywgTGljZW5zb3IgcHJvdmlkZXMgdGhlIFdvcmsgKGFuZCBlYWNoCiAgICBDb250cmlidXRvciBwcm92aWRlcyBpdHMgQ29udHJpYnV0aW9ucykgb24gYW4gIkFTIElTIiBCQVNJUywKICAgIFdJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvcgogICAgaW1wbGllZCwgaW5jbHVkaW5nLCB3aXRob3V0IGxpbWl0YXRpb24sIGFueSB3YXJyYW50aWVzIG9yIGNvbmRpdGlvbnMKICAgIG9mIFRJVExFLCBOT04tSU5GUklOR0VNRU5ULCBNRVJDSEFOVEFCSUxJVFksIG9yIEZJVE5FU1MgRk9SIEEKICAgIFBBUlRJQ1VMQVIgUFVSUE9TRS4gWW91IGFyZSBzb2xlbHkgcmVzcG9uc2libGUgZm9yIGRldGVybWluaW5nIHRoZQogICAgYXBwcm9wcmlhdGVuZXNzIG9mIHVzaW5nIG9yIHJlZGlzdHJpYnV0aW5nIHRoZSBXb3JrIGFuZCBhc3N1bWUgYW55CiAgICByaXNrcyBhc3NvY2lhdGVkIHdpdGggWW91ciBleGVyY2lzZSBvZiBwZXJtaXNzaW9ucyB1bmRlciB0aGlzIExpY2Vuc2UuCgogOC4gTGltaXRhdGlvbiBvZiBMaWFiaWxpdHkuIEluIG5vIGV2ZW50IGFuZCB1bmRlciBubyBsZWdhbCB0aGVvcnksCiAgICB3aGV0aGVyIGluIHRvcnQgKGluY2x1ZGluZyBuZWdsaWdlbmNlKSwgY29udHJhY3QsIG9yIG90aGVyd2lzZSwKICAgIHVubGVzcyByZXF1aXJlZCBieSBhcHBsaWNhYmxlIGxhdyAoc3VjaCBhcyBkZWxpYmVyYXRlIGFuZCBncm9zc2x5CiAgICBuZWdsaWdlbnQgYWN0cykgb3IgYWdyZWVkIHRvIGluIHdyaXRpbmcsIHNoYWxsIGFueSBDb250cmlidXRvciBiZQogICAgbGlhYmxlIHRvIFlvdSBmb3IgZGFtYWdlcywgaW5jbHVkaW5nIGFueSBkaXJlY3QsIGluZGlyZWN0LCBzcGVjaWFsLAogICAgaW5jaWRlbnRhbCwgb3IgY29uc2VxdWVudGlhbCBkYW1hZ2VzIG9mIGFueSBjaGFyYWN0ZXIgYXJpc2luZyBhcyBhCiAgICByZXN1bHQgb2YgdGhpcyBMaWNlbnNlIG9yIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0byB1c2UgdGhlCiAgICBXb3JrIChpbmNsdWRpbmcgYnV0IG5vdCBsaW1pdGVkIHRvIGRhbWFnZXMgZm9yIGxvc3Mgb2YgZ29vZHdpbGwsCiAgICB3b3JrIHN0b3BwYWdlLCBjb21wdXRlciBmYWlsdXJlIG9yIG1hbGZ1bmN0aW9uLCBvciBhbnkgYW5kIGFsbAogICAgb3RoZXIgY29tbWVyY2lhbCBkYW1hZ2VzIG9yIGxvc3NlcyksIGV2ZW4gaWYgc3VjaCBDb250cmlidXRvcgogICAgaGFzIGJlZW4gYWR2aXNlZCBvZiB0aGUgcG9zc2liaWxpdHkgb2Ygc3VjaCBkYW1hZ2VzLgoKIDkuIEFjY2VwdGluZyBXYXJyYW50eSBvciBBZGRpdGlvbmFsIExpYWJpbGl0eS4gV2hpbGUgcmVkaXN0cmlidXRpbmcKICAgIHRoZSBXb3JrIG9yIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZiwgWW91IG1heSBjaG9vc2UgdG8gb2ZmZXIsCiAgICBhbmQgY2hhcmdlIGEgZmVlIGZvciwgYWNjZXB0YW5jZSBvZiBzdXBwb3J0LCB3YXJyYW50eSwgaW5kZW1uaXR5LAogICAgb3Igb3RoZXIgbGlhYmlsaXR5IG9ibGlnYXRpb25zIGFuZC9vciByaWdodHMgY29uc2lzdGVudCB3aXRoIHRoaXMKICAgIExpY2Vuc2UuIEhvd2V2ZXIsIGluIGFjY2VwdGluZyBzdWNoIG9ibGlnYXRpb25zLCBZb3UgbWF5IGFjdCBvbmx5CiAgICBvbiBZb3VyIG93biBiZWhhbGYgYW5kIG9uIFlvdXIgc29sZSByZXNwb25zaWJpbGl0eSwgbm90IG9uIGJlaGFsZgogICAgb2YgYW55IG90aGVyIENvbnRyaWJ1dG9yLCBhbmQgb25seSBpZiBZb3UgYWdyZWUgdG8gaW5kZW1uaWZ5LAogICAgZGVmZW5kLCBhbmQgaG9sZCBlYWNoIENvbnRyaWJ1dG9yIGhhcm1sZXNzIGZvciBhbnkgbGlhYmlsaXR5CiAgICBpbmN1cnJlZCBieSwgb3IgY2xhaW1zIGFzc2VydGVkIGFnYWluc3QsIHN1Y2ggQ29udHJpYnV0b3IgYnkgcmVhc29uCiAgICBvZiB5b3VyIGFjY2VwdGluZyBhbnkgc3VjaCB3YXJyYW50eSBvciBhZGRpdGlvbmFsIGxpYWJpbGl0eS4KCiBFTkQgT0YgVEVSTVMgQU5EIENPTkRJVElPTlMKCiBBUFBFTkRJWDogSG93IHRvIGFwcGx5IHRoZSBBcGFjaGUgTGljZW5zZSB0byB5b3VyIHdvcmsuCgogICAgVG8gYXBwbHkgdGhlIEFwYWNoZSBMaWNlbnNlIHRvIHlvdXIgd29yaywgYXR0YWNoIHRoZSBmb2xsb3dpbmcKICAgIGJvaWxlcnBsYXRlIG5vdGljZSwgd2l0aCB0aGUgZmllbGRzIGVuY2xvc2VkIGJ5IGJyYWNrZXRzICJbXSIKICAgIHJlcGxhY2VkIHdpdGggeW91ciBvd24gaWRlbnRpZnlpbmcgaW5mb3JtYXRpb24uIChEb24ndCBpbmNsdWRlCiAgICB0aGUgYnJhY2tldHMhKSAgVGhlIHRleHQgc2hvdWxkIGJlIGVuY2xvc2VkIGluIHRoZSBhcHByb3ByaWF0ZQogICAgY29tbWVudCBzeW50YXggZm9yIHRoZSBmaWxlIGZvcm1hdC4gV2UgYWxzbyByZWNvbW1lbmQgdGhhdCBhCiAgICBmaWxlIG9yIGNsYXNzIG5hbWUgYW5kIGRlc2NyaXB0aW9uIG9mIHB1cnBvc2UgYmUgaW5jbHVkZWQgb24gdGhlCiAgICBzYW1lICJwcmludGVkIHBhZ2UiIGFzIHRoZSBjb3B5cmlnaHQgbm90aWNlIGZvciBlYXNpZXIKICAgIGlkZW50aWZpY2F0aW9uIHdpdGhpbiB0aGlyZC1wYXJ0eSBhcmNoaXZlcy4KCiBDb3B5cmlnaHQgKGMpIDIwMTUtMjAxOCBHb29nbGUsIEluYy4sIE5ldGZsaXgsIEluYy4sIE1pY3Jvc29mdCBDb3JwLiBhbmQgY29udHJpYnV0b3JzCgogTGljZW5zZWQgdW5kZXIgdGhlIEFwYWNoZSBMaWNlbnNlLCBWZXJzaW9uIDIuMCAodGhlICJMaWNlbnNlIik7CiB5b3UgbWF5IG5vdCB1c2UgdGhpcyBmaWxlIGV4Y2VwdCBpbiBjb21wbGlhbmNlIHdpdGggdGhlIExpY2Vuc2UuCiBZb3UgbWF5IG9idGFpbiBhIGNvcHkgb2YgdGhlIExpY2Vuc2UgYXQKCiAgICAgaHR0cDovL3d3dy5hcGFjaGUub3JnL2xpY2Vuc2VzL0xJQ0VOU0UtMi4wCgogVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yIGFncmVlZCB0byBpbiB3cml0aW5nLCBzb2Z0d2FyZQogZGlzdHJpYnV0ZWQgdW5kZXIgdGhlIExpY2Vuc2UgaXMgZGlzdHJpYnV0ZWQgb24gYW4gIkFTIElTIiBCQVNJUywKIFdJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvciBpbXBsaWVkLgogU2VlIHRoZSBMaWNlbnNlIGZvciB0aGUgc3BlY2lmaWMgbGFuZ3VhZ2UgZ292ZXJuaW5nIHBlcm1pc3Npb25zIGFuZAogbGltaXRhdGlvbnMgdW5kZXIgdGhlIExpY2Vuc2UuCiAK",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "runtime",
-      "group": "@babel",
-      "version": "7.25.0",
-      "bom-ref": "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
-      "author": "The Babel Team",
-      "description": "babel's modular runtime helpers",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git%23packages%2Fbabel-runtime",
-      "externalReferences": [
-        {
-          "url": "https://github.com/babel/babel/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/babel/babel.git#packages/babel-runtime",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://babel.dev/docs/en/next/babel-runtime",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "TUlUIExpY2Vuc2UKCkNvcHlyaWdodCAoYykgMjAxNC1wcmVzZW50IFNlYmFzdGlhbiBNY0tlbnppZSBhbmQgb3RoZXIgY29udHJpYnV0b3JzCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcKYSBjb3B5IG9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlCiJTb2Z0d2FyZSIpLCB0byBkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcKd2l0aG91dCBsaW1pdGF0aW9uIHRoZSByaWdodHMgdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLApkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3Igc2VsbCBjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8KcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMgZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvCnRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlCmluY2x1ZGVkIGluIGFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsCkVYUFJFU1MgT1IgSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRgpNRVJDSEFOVEFCSUxJVFksIEZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORApOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRSBBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFCkxJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSIExJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04KT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HIEZST00sIE9VVCBPRiBPUiBJTiBDT05ORUNUSU9OCldJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4gVEhFIFNPRlRXQVJFLgo=",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
       "name": "common",
       "group": "@angular",
       "version": "18.2.7",
-      "bom-ref": "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+      "bom-ref": "@angular/common@18.2.7#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
       "author": "angular",
       "description": "Angular - commonly needed directives and services",
       "licenses": [
@@ -396,107 +202,10 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
     },
     {
       "type": "library",
-      "name": "router",
-      "group": "@angular",
-      "version": "18.2.7",
-      "bom-ref": "a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
-      "author": "angular",
-      "description": "Angular - the routing library",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Frouter",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/angular/angular.git#packages/router",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular/tree/main/packages/router",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuZGV2L2xpY2Vuc2UKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "tslib",
-      "version": "2.6.3",
-      "bom-ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
-      "author": "Microsoft Corp.",
-      "description": "Runtime library for TypeScript helper functions",
-      "licenses": [
-        {
-          "license": {
-            "id": "0BSD",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/Microsoft/TypeScript/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/Microsoft/tslib.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://www.typescriptlang.org/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE.txt",
-              "text": {
-                "content": "Q29weXJpZ2h0IChjKSBNaWNyb3NvZnQgQ29ycG9yYXRpb24uDQoNClBlcm1pc3Npb24gdG8gdXNlLCBjb3B5LCBtb2RpZnksIGFuZC9vciBkaXN0cmlidXRlIHRoaXMgc29mdHdhcmUgZm9yIGFueQ0KcHVycG9zZSB3aXRoIG9yIHdpdGhvdXQgZmVlIGlzIGhlcmVieSBncmFudGVkLg0KDQpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiBBTkQgVEhFIEFVVEhPUiBESVNDTEFJTVMgQUxMIFdBUlJBTlRJRVMgV0lUSA0KUkVHQVJEIFRPIFRISVMgU09GVFdBUkUgSU5DTFVESU5HIEFMTCBJTVBMSUVEIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZDQpBTkQgRklUTkVTUy4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUiBCRSBMSUFCTEUgRk9SIEFOWSBTUEVDSUFMLCBESVJFQ1QsDQpJTkRJUkVDVCwgT1IgQ09OU0VRVUVOVElBTCBEQU1BR0VTIE9SIEFOWSBEQU1BR0VTIFdIQVRTT0VWRVIgUkVTVUxUSU5HIEZST00NCkxPU1MgT0YgVVNFLCBEQVRBIE9SIFBST0ZJVFMsIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBORUdMSUdFTkNFIE9SDQpPVEhFUiBUT1JUSU9VUyBBQ1RJT04sIEFSSVNJTkcgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgVVNFIE9SDQpQRVJGT1JNQU5DRSBPRiBUSElTIFNPRlRXQVJFLg==",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
       "name": "core",
       "group": "@angular",
       "version": "18.2.7",
-      "bom-ref": "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+      "bom-ref": "@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
       "author": "angular",
       "description": "Angular - the core framework",
       "licenses": [
@@ -542,9 +251,156 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
     },
     {
       "type": "library",
+      "name": "platform-browser",
+      "group": "@angular",
+      "version": "18.2.7",
+      "bom-ref": "@angular/platform-browser@18.2.7#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "author": "angular",
+      "description": "Angular - library for using Angular in a web browser",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/angular/angular.git#packages/platform-browser",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuZGV2L2xpY2Vuc2UKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "router",
+      "group": "@angular",
+      "version": "18.2.7",
+      "bom-ref": "@angular/router@18.2.7#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
+      "author": "angular",
+      "description": "Angular - the routing library",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Frouter",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/angular/angular.git#packages/router",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular/tree/main/packages/router",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuZGV2L2xpY2Vuc2UKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "runtime",
+      "group": "@babel",
+      "version": "7.25.0",
+      "bom-ref": "@babel/runtime@7.25.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
+      "author": "The Babel Team",
+      "description": "babel's modular runtime helpers",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git%23packages%2Fbabel-runtime",
+      "externalReferences": [
+        {
+          "url": "https://github.com/babel/babel/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/babel/babel.git#packages/babel-runtime",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://babel.dev/docs/en/next/babel-runtime",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "TUlUIExpY2Vuc2UKCkNvcHlyaWdodCAoYykgMjAxNC1wcmVzZW50IFNlYmFzdGlhbiBNY0tlbnppZSBhbmQgb3RoZXIgY29udHJpYnV0b3JzCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcKYSBjb3B5IG9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlCiJTb2Z0d2FyZSIpLCB0byBkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcKd2l0aG91dCBsaW1pdGF0aW9uIHRoZSByaWdodHMgdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLApkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3Igc2VsbCBjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8KcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMgZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvCnRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlCmluY2x1ZGVkIGluIGFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsCkVYUFJFU1MgT1IgSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRgpNRVJDSEFOVEFCSUxJVFksIEZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORApOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRSBBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFCkxJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSIExJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04KT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HIEZST00sIE9VVCBPRiBPUiBJTiBDT05ORUNUSU9OCldJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4gVEhFIFNPRlRXQVJFLgo=",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
       "name": "css-loader",
       "version": "7.1.2",
-      "bom-ref": "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
+      "bom-ref": "css-loader@7.1.2#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
       "author": "Tobias Koppers @sokra",
       "description": "css loader module for webpack",
       "licenses": [
@@ -587,65 +443,209 @@ exports[`integration feature: component evidence generated json file: dist/.bom/
           }
         ]
       }
+    },
+    {
+      "type": "library",
+      "name": "rxjs",
+      "version": "7.8.1",
+      "bom-ref": "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+      "author": "Ben Lesh",
+      "description": "Reactive Extensions for modern JavaScript",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ReactiveX/RxJS/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/reactivex/rxjs.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://rxjs.dev",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE.txt",
+              "text": {
+                "content": "ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEFwYWNoZSBMaWNlbnNlCiAgICAgICAgICAgICAgICAgICAgICAgICBWZXJzaW9uIDIuMCwgSmFudWFyeSAyMDA0CiAgICAgICAgICAgICAgICAgICAgICBodHRwOi8vd3d3LmFwYWNoZS5vcmcvbGljZW5zZXMvCgogVEVSTVMgQU5EIENPTkRJVElPTlMgRk9SIFVTRSwgUkVQUk9EVUNUSU9OLCBBTkQgRElTVFJJQlVUSU9OCgogMS4gRGVmaW5pdGlvbnMuCgogICAgIkxpY2Vuc2UiIHNoYWxsIG1lYW4gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIGZvciB1c2UsIHJlcHJvZHVjdGlvbiwKICAgIGFuZCBkaXN0cmlidXRpb24gYXMgZGVmaW5lZCBieSBTZWN0aW9ucyAxIHRocm91Z2ggOSBvZiB0aGlzIGRvY3VtZW50LgoKICAgICJMaWNlbnNvciIgc2hhbGwgbWVhbiB0aGUgY29weXJpZ2h0IG93bmVyIG9yIGVudGl0eSBhdXRob3JpemVkIGJ5CiAgICB0aGUgY29weXJpZ2h0IG93bmVyIHRoYXQgaXMgZ3JhbnRpbmcgdGhlIExpY2Vuc2UuCgogICAgIkxlZ2FsIEVudGl0eSIgc2hhbGwgbWVhbiB0aGUgdW5pb24gb2YgdGhlIGFjdGluZyBlbnRpdHkgYW5kIGFsbAogICAgb3RoZXIgZW50aXRpZXMgdGhhdCBjb250cm9sLCBhcmUgY29udHJvbGxlZCBieSwgb3IgYXJlIHVuZGVyIGNvbW1vbgogICAgY29udHJvbCB3aXRoIHRoYXQgZW50aXR5LiBGb3IgdGhlIHB1cnBvc2VzIG9mIHRoaXMgZGVmaW5pdGlvbiwKICAgICJjb250cm9sIiBtZWFucyAoaSkgdGhlIHBvd2VyLCBkaXJlY3Qgb3IgaW5kaXJlY3QsIHRvIGNhdXNlIHRoZQogICAgZGlyZWN0aW9uIG9yIG1hbmFnZW1lbnQgb2Ygc3VjaCBlbnRpdHksIHdoZXRoZXIgYnkgY29udHJhY3Qgb3IKICAgIG90aGVyd2lzZSwgb3IgKGlpKSBvd25lcnNoaXAgb2YgZmlmdHkgcGVyY2VudCAoNTAlKSBvciBtb3JlIG9mIHRoZQogICAgb3V0c3RhbmRpbmcgc2hhcmVzLCBvciAoaWlpKSBiZW5lZmljaWFsIG93bmVyc2hpcCBvZiBzdWNoIGVudGl0eS4KCiAgICAiWW91IiAob3IgIllvdXIiKSBzaGFsbCBtZWFuIGFuIGluZGl2aWR1YWwgb3IgTGVnYWwgRW50aXR5CiAgICBleGVyY2lzaW5nIHBlcm1pc3Npb25zIGdyYW50ZWQgYnkgdGhpcyBMaWNlbnNlLgoKICAgICJTb3VyY2UiIGZvcm0gc2hhbGwgbWVhbiB0aGUgcHJlZmVycmVkIGZvcm0gZm9yIG1ha2luZyBtb2RpZmljYXRpb25zLAogICAgaW5jbHVkaW5nIGJ1dCBub3QgbGltaXRlZCB0byBzb2Z0d2FyZSBzb3VyY2UgY29kZSwgZG9jdW1lbnRhdGlvbgogICAgc291cmNlLCBhbmQgY29uZmlndXJhdGlvbiBmaWxlcy4KCiAgICAiT2JqZWN0IiBmb3JtIHNoYWxsIG1lYW4gYW55IGZvcm0gcmVzdWx0aW5nIGZyb20gbWVjaGFuaWNhbAogICAgdHJhbnNmb3JtYXRpb24gb3IgdHJhbnNsYXRpb24gb2YgYSBTb3VyY2UgZm9ybSwgaW5jbHVkaW5nIGJ1dAogICAgbm90IGxpbWl0ZWQgdG8gY29tcGlsZWQgb2JqZWN0IGNvZGUsIGdlbmVyYXRlZCBkb2N1bWVudGF0aW9uLAogICAgYW5kIGNvbnZlcnNpb25zIHRvIG90aGVyIG1lZGlhIHR5cGVzLgoKICAgICJXb3JrIiBzaGFsbCBtZWFuIHRoZSB3b3JrIG9mIGF1dGhvcnNoaXAsIHdoZXRoZXIgaW4gU291cmNlIG9yCiAgICBPYmplY3QgZm9ybSwgbWFkZSBhdmFpbGFibGUgdW5kZXIgdGhlIExpY2Vuc2UsIGFzIGluZGljYXRlZCBieSBhCiAgICBjb3B5cmlnaHQgbm90aWNlIHRoYXQgaXMgaW5jbHVkZWQgaW4gb3IgYXR0YWNoZWQgdG8gdGhlIHdvcmsKICAgIChhbiBleGFtcGxlIGlzIHByb3ZpZGVkIGluIHRoZSBBcHBlbmRpeCBiZWxvdykuCgogICAgIkRlcml2YXRpdmUgV29ya3MiIHNoYWxsIG1lYW4gYW55IHdvcmssIHdoZXRoZXIgaW4gU291cmNlIG9yIE9iamVjdAogICAgZm9ybSwgdGhhdCBpcyBiYXNlZCBvbiAob3IgZGVyaXZlZCBmcm9tKSB0aGUgV29yayBhbmQgZm9yIHdoaWNoIHRoZQogICAgZWRpdG9yaWFsIHJldmlzaW9ucywgYW5ub3RhdGlvbnMsIGVsYWJvcmF0aW9ucywgb3Igb3RoZXIgbW9kaWZpY2F0aW9ucwogICAgcmVwcmVzZW50LCBhcyBhIHdob2xlLCBhbiBvcmlnaW5hbCB3b3JrIG9mIGF1dGhvcnNoaXAuIEZvciB0aGUgcHVycG9zZXMKICAgIG9mIHRoaXMgTGljZW5zZSwgRGVyaXZhdGl2ZSBXb3JrcyBzaGFsbCBub3QgaW5jbHVkZSB3b3JrcyB0aGF0IHJlbWFpbgogICAgc2VwYXJhYmxlIGZyb20sIG9yIG1lcmVseSBsaW5rIChvciBiaW5kIGJ5IG5hbWUpIHRvIHRoZSBpbnRlcmZhY2VzIG9mLAogICAgdGhlIFdvcmsgYW5kIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZi4KCiAgICAiQ29udHJpYnV0aW9uIiBzaGFsbCBtZWFuIGFueSB3b3JrIG9mIGF1dGhvcnNoaXAsIGluY2x1ZGluZwogICAgdGhlIG9yaWdpbmFsIHZlcnNpb24gb2YgdGhlIFdvcmsgYW5kIGFueSBtb2RpZmljYXRpb25zIG9yIGFkZGl0aW9ucwogICAgdG8gdGhhdCBXb3JrIG9yIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZiwgdGhhdCBpcyBpbnRlbnRpb25hbGx5CiAgICBzdWJtaXR0ZWQgdG8gTGljZW5zb3IgZm9yIGluY2x1c2lvbiBpbiB0aGUgV29yayBieSB0aGUgY29weXJpZ2h0IG93bmVyCiAgICBvciBieSBhbiBpbmRpdmlkdWFsIG9yIExlZ2FsIEVudGl0eSBhdXRob3JpemVkIHRvIHN1Ym1pdCBvbiBiZWhhbGYgb2YKICAgIHRoZSBjb3B5cmlnaHQgb3duZXIuIEZvciB0aGUgcHVycG9zZXMgb2YgdGhpcyBkZWZpbml0aW9uLCAic3VibWl0dGVkIgogICAgbWVhbnMgYW55IGZvcm0gb2YgZWxlY3Ryb25pYywgdmVyYmFsLCBvciB3cml0dGVuIGNvbW11bmljYXRpb24gc2VudAogICAgdG8gdGhlIExpY2Vuc29yIG9yIGl0cyByZXByZXNlbnRhdGl2ZXMsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQgdG8KICAgIGNvbW11bmljYXRpb24gb24gZWxlY3Ryb25pYyBtYWlsaW5nIGxpc3RzLCBzb3VyY2UgY29kZSBjb250cm9sIHN5c3RlbXMsCiAgICBhbmQgaXNzdWUgdHJhY2tpbmcgc3lzdGVtcyB0aGF0IGFyZSBtYW5hZ2VkIGJ5LCBvciBvbiBiZWhhbGYgb2YsIHRoZQogICAgTGljZW5zb3IgZm9yIHRoZSBwdXJwb3NlIG9mIGRpc2N1c3NpbmcgYW5kIGltcHJvdmluZyB0aGUgV29yaywgYnV0CiAgICBleGNsdWRpbmcgY29tbXVuaWNhdGlvbiB0aGF0IGlzIGNvbnNwaWN1b3VzbHkgbWFya2VkIG9yIG90aGVyd2lzZQogICAgZGVzaWduYXRlZCBpbiB3cml0aW5nIGJ5IHRoZSBjb3B5cmlnaHQgb3duZXIgYXMgIk5vdCBhIENvbnRyaWJ1dGlvbi4iCgogICAgIkNvbnRyaWJ1dG9yIiBzaGFsbCBtZWFuIExpY2Vuc29yIGFuZCBhbnkgaW5kaXZpZHVhbCBvciBMZWdhbCBFbnRpdHkKICAgIG9uIGJlaGFsZiBvZiB3aG9tIGEgQ29udHJpYnV0aW9uIGhhcyBiZWVuIHJlY2VpdmVkIGJ5IExpY2Vuc29yIGFuZAogICAgc3Vic2VxdWVudGx5IGluY29ycG9yYXRlZCB3aXRoaW4gdGhlIFdvcmsuCgogMi4gR3JhbnQgb2YgQ29weXJpZ2h0IExpY2Vuc2UuIFN1YmplY3QgdG8gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mCiAgICB0aGlzIExpY2Vuc2UsIGVhY2ggQ29udHJpYnV0b3IgaGVyZWJ5IGdyYW50cyB0byBZb3UgYSBwZXJwZXR1YWwsCiAgICB3b3JsZHdpZGUsIG5vbi1leGNsdXNpdmUsIG5vLWNoYXJnZSwgcm95YWx0eS1mcmVlLCBpcnJldm9jYWJsZQogICAgY29weXJpZ2h0IGxpY2Vuc2UgdG8gcmVwcm9kdWNlLCBwcmVwYXJlIERlcml2YXRpdmUgV29ya3Mgb2YsCiAgICBwdWJsaWNseSBkaXNwbGF5LCBwdWJsaWNseSBwZXJmb3JtLCBzdWJsaWNlbnNlLCBhbmQgZGlzdHJpYnV0ZSB0aGUKICAgIFdvcmsgYW5kIHN1Y2ggRGVyaXZhdGl2ZSBXb3JrcyBpbiBTb3VyY2Ugb3IgT2JqZWN0IGZvcm0uCgogMy4gR3JhbnQgb2YgUGF0ZW50IExpY2Vuc2UuIFN1YmplY3QgdG8gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mCiAgICB0aGlzIExpY2Vuc2UsIGVhY2ggQ29udHJpYnV0b3IgaGVyZWJ5IGdyYW50cyB0byBZb3UgYSBwZXJwZXR1YWwsCiAgICB3b3JsZHdpZGUsIG5vbi1leGNsdXNpdmUsIG5vLWNoYXJnZSwgcm95YWx0eS1mcmVlLCBpcnJldm9jYWJsZQogICAgKGV4Y2VwdCBhcyBzdGF0ZWQgaW4gdGhpcyBzZWN0aW9uKSBwYXRlbnQgbGljZW5zZSB0byBtYWtlLCBoYXZlIG1hZGUsCiAgICB1c2UsIG9mZmVyIHRvIHNlbGwsIHNlbGwsIGltcG9ydCwgYW5kIG90aGVyd2lzZSB0cmFuc2ZlciB0aGUgV29yaywKICAgIHdoZXJlIHN1Y2ggbGljZW5zZSBhcHBsaWVzIG9ubHkgdG8gdGhvc2UgcGF0ZW50IGNsYWltcyBsaWNlbnNhYmxlCiAgICBieSBzdWNoIENvbnRyaWJ1dG9yIHRoYXQgYXJlIG5lY2Vzc2FyaWx5IGluZnJpbmdlZCBieSB0aGVpcgogICAgQ29udHJpYnV0aW9uKHMpIGFsb25lIG9yIGJ5IGNvbWJpbmF0aW9uIG9mIHRoZWlyIENvbnRyaWJ1dGlvbihzKQogICAgd2l0aCB0aGUgV29yayB0byB3aGljaCBzdWNoIENvbnRyaWJ1dGlvbihzKSB3YXMgc3VibWl0dGVkLiBJZiBZb3UKICAgIGluc3RpdHV0ZSBwYXRlbnQgbGl0aWdhdGlvbiBhZ2FpbnN0IGFueSBlbnRpdHkgKGluY2x1ZGluZyBhCiAgICBjcm9zcy1jbGFpbSBvciBjb3VudGVyY2xhaW0gaW4gYSBsYXdzdWl0KSBhbGxlZ2luZyB0aGF0IHRoZSBXb3JrCiAgICBvciBhIENvbnRyaWJ1dGlvbiBpbmNvcnBvcmF0ZWQgd2l0aGluIHRoZSBXb3JrIGNvbnN0aXR1dGVzIGRpcmVjdAogICAgb3IgY29udHJpYnV0b3J5IHBhdGVudCBpbmZyaW5nZW1lbnQsIHRoZW4gYW55IHBhdGVudCBsaWNlbnNlcwogICAgZ3JhbnRlZCB0byBZb3UgdW5kZXIgdGhpcyBMaWNlbnNlIGZvciB0aGF0IFdvcmsgc2hhbGwgdGVybWluYXRlCiAgICBhcyBvZiB0aGUgZGF0ZSBzdWNoIGxpdGlnYXRpb24gaXMgZmlsZWQuCgogNC4gUmVkaXN0cmlidXRpb24uIFlvdSBtYXkgcmVwcm9kdWNlIGFuZCBkaXN0cmlidXRlIGNvcGllcyBvZiB0aGUKICAgIFdvcmsgb3IgRGVyaXZhdGl2ZSBXb3JrcyB0aGVyZW9mIGluIGFueSBtZWRpdW0sIHdpdGggb3Igd2l0aG91dAogICAgbW9kaWZpY2F0aW9ucywgYW5kIGluIFNvdXJjZSBvciBPYmplY3QgZm9ybSwgcHJvdmlkZWQgdGhhdCBZb3UKICAgIG1lZXQgdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKICAgIChhKSBZb3UgbXVzdCBnaXZlIGFueSBvdGhlciByZWNpcGllbnRzIG9mIHRoZSBXb3JrIG9yCiAgICAgICAgRGVyaXZhdGl2ZSBXb3JrcyBhIGNvcHkgb2YgdGhpcyBMaWNlbnNlOyBhbmQKCiAgICAoYikgWW91IG11c3QgY2F1c2UgYW55IG1vZGlmaWVkIGZpbGVzIHRvIGNhcnJ5IHByb21pbmVudCBub3RpY2VzCiAgICAgICAgc3RhdGluZyB0aGF0IFlvdSBjaGFuZ2VkIHRoZSBmaWxlczsgYW5kCgogICAgKGMpIFlvdSBtdXN0IHJldGFpbiwgaW4gdGhlIFNvdXJjZSBmb3JtIG9mIGFueSBEZXJpdmF0aXZlIFdvcmtzCiAgICAgICAgdGhhdCBZb3UgZGlzdHJpYnV0ZSwgYWxsIGNvcHlyaWdodCwgcGF0ZW50LCB0cmFkZW1hcmssIGFuZAogICAgICAgIGF0dHJpYnV0aW9uIG5vdGljZXMgZnJvbSB0aGUgU291cmNlIGZvcm0gb2YgdGhlIFdvcmssCiAgICAgICAgZXhjbHVkaW5nIHRob3NlIG5vdGljZXMgdGhhdCBkbyBub3QgcGVydGFpbiB0byBhbnkgcGFydCBvZgogICAgICAgIHRoZSBEZXJpdmF0aXZlIFdvcmtzOyBhbmQKCiAgICAoZCkgSWYgdGhlIFdvcmsgaW5jbHVkZXMgYSAiTk9USUNFIiB0ZXh0IGZpbGUgYXMgcGFydCBvZiBpdHMKICAgICAgICBkaXN0cmlidXRpb24sIHRoZW4gYW55IERlcml2YXRpdmUgV29ya3MgdGhhdCBZb3UgZGlzdHJpYnV0ZSBtdXN0CiAgICAgICAgaW5jbHVkZSBhIHJlYWRhYmxlIGNvcHkgb2YgdGhlIGF0dHJpYnV0aW9uIG5vdGljZXMgY29udGFpbmVkCiAgICAgICAgd2l0aGluIHN1Y2ggTk9USUNFIGZpbGUsIGV4Y2x1ZGluZyB0aG9zZSBub3RpY2VzIHRoYXQgZG8gbm90CiAgICAgICAgcGVydGFpbiB0byBhbnkgcGFydCBvZiB0aGUgRGVyaXZhdGl2ZSBXb3JrcywgaW4gYXQgbGVhc3Qgb25lCiAgICAgICAgb2YgdGhlIGZvbGxvd2luZyBwbGFjZXM6IHdpdGhpbiBhIE5PVElDRSB0ZXh0IGZpbGUgZGlzdHJpYnV0ZWQKICAgICAgICBhcyBwYXJ0IG9mIHRoZSBEZXJpdmF0aXZlIFdvcmtzOyB3aXRoaW4gdGhlIFNvdXJjZSBmb3JtIG9yCiAgICAgICAgZG9jdW1lbnRhdGlvbiwgaWYgcHJvdmlkZWQgYWxvbmcgd2l0aCB0aGUgRGVyaXZhdGl2ZSBXb3Jrczsgb3IsCiAgICAgICAgd2l0aGluIGEgZGlzcGxheSBnZW5lcmF0ZWQgYnkgdGhlIERlcml2YXRpdmUgV29ya3MsIGlmIGFuZAogICAgICAgIHdoZXJldmVyIHN1Y2ggdGhpcmQtcGFydHkgbm90aWNlcyBub3JtYWxseSBhcHBlYXIuIFRoZSBjb250ZW50cwogICAgICAgIG9mIHRoZSBOT1RJQ0UgZmlsZSBhcmUgZm9yIGluZm9ybWF0aW9uYWwgcHVycG9zZXMgb25seSBhbmQKICAgICAgICBkbyBub3QgbW9kaWZ5IHRoZSBMaWNlbnNlLiBZb3UgbWF5IGFkZCBZb3VyIG93biBhdHRyaWJ1dGlvbgogICAgICAgIG5vdGljZXMgd2l0aGluIERlcml2YXRpdmUgV29ya3MgdGhhdCBZb3UgZGlzdHJpYnV0ZSwgYWxvbmdzaWRlCiAgICAgICAgb3IgYXMgYW4gYWRkZW5kdW0gdG8gdGhlIE5PVElDRSB0ZXh0IGZyb20gdGhlIFdvcmssIHByb3ZpZGVkCiAgICAgICAgdGhhdCBzdWNoIGFkZGl0aW9uYWwgYXR0cmlidXRpb24gbm90aWNlcyBjYW5ub3QgYmUgY29uc3RydWVkCiAgICAgICAgYXMgbW9kaWZ5aW5nIHRoZSBMaWNlbnNlLgoKICAgIFlvdSBtYXkgYWRkIFlvdXIgb3duIGNvcHlyaWdodCBzdGF0ZW1lbnQgdG8gWW91ciBtb2RpZmljYXRpb25zIGFuZAogICAgbWF5IHByb3ZpZGUgYWRkaXRpb25hbCBvciBkaWZmZXJlbnQgbGljZW5zZSB0ZXJtcyBhbmQgY29uZGl0aW9ucwogICAgZm9yIHVzZSwgcmVwcm9kdWN0aW9uLCBvciBkaXN0cmlidXRpb24gb2YgWW91ciBtb2RpZmljYXRpb25zLCBvcgogICAgZm9yIGFueSBzdWNoIERlcml2YXRpdmUgV29ya3MgYXMgYSB3aG9sZSwgcHJvdmlkZWQgWW91ciB1c2UsCiAgICByZXByb2R1Y3Rpb24sIGFuZCBkaXN0cmlidXRpb24gb2YgdGhlIFdvcmsgb3RoZXJ3aXNlIGNvbXBsaWVzIHdpdGgKICAgIHRoZSBjb25kaXRpb25zIHN0YXRlZCBpbiB0aGlzIExpY2Vuc2UuCgogNS4gU3VibWlzc2lvbiBvZiBDb250cmlidXRpb25zLiBVbmxlc3MgWW91IGV4cGxpY2l0bHkgc3RhdGUgb3RoZXJ3aXNlLAogICAgYW55IENvbnRyaWJ1dGlvbiBpbnRlbnRpb25hbGx5IHN1Ym1pdHRlZCBmb3IgaW5jbHVzaW9uIGluIHRoZSBXb3JrCiAgICBieSBZb3UgdG8gdGhlIExpY2Vuc29yIHNoYWxsIGJlIHVuZGVyIHRoZSB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZgogICAgdGhpcyBMaWNlbnNlLCB3aXRob3V0IGFueSBhZGRpdGlvbmFsIHRlcm1zIG9yIGNvbmRpdGlvbnMuCiAgICBOb3R3aXRoc3RhbmRpbmcgdGhlIGFib3ZlLCBub3RoaW5nIGhlcmVpbiBzaGFsbCBzdXBlcnNlZGUgb3IgbW9kaWZ5CiAgICB0aGUgdGVybXMgb2YgYW55IHNlcGFyYXRlIGxpY2Vuc2UgYWdyZWVtZW50IHlvdSBtYXkgaGF2ZSBleGVjdXRlZAogICAgd2l0aCBMaWNlbnNvciByZWdhcmRpbmcgc3VjaCBDb250cmlidXRpb25zLgoKIDYuIFRyYWRlbWFya3MuIFRoaXMgTGljZW5zZSBkb2VzIG5vdCBncmFudCBwZXJtaXNzaW9uIHRvIHVzZSB0aGUgdHJhZGUKICAgIG5hbWVzLCB0cmFkZW1hcmtzLCBzZXJ2aWNlIG1hcmtzLCBvciBwcm9kdWN0IG5hbWVzIG9mIHRoZSBMaWNlbnNvciwKICAgIGV4Y2VwdCBhcyByZXF1aXJlZCBmb3IgcmVhc29uYWJsZSBhbmQgY3VzdG9tYXJ5IHVzZSBpbiBkZXNjcmliaW5nIHRoZQogICAgb3JpZ2luIG9mIHRoZSBXb3JrIGFuZCByZXByb2R1Y2luZyB0aGUgY29udGVudCBvZiB0aGUgTk9USUNFIGZpbGUuCgogNy4gRGlzY2xhaW1lciBvZiBXYXJyYW50eS4gVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yCiAgICBhZ3JlZWQgdG8gaW4gd3JpdGluZywgTGljZW5zb3IgcHJvdmlkZXMgdGhlIFdvcmsgKGFuZCBlYWNoCiAgICBDb250cmlidXRvciBwcm92aWRlcyBpdHMgQ29udHJpYnV0aW9ucykgb24gYW4gIkFTIElTIiBCQVNJUywKICAgIFdJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvcgogICAgaW1wbGllZCwgaW5jbHVkaW5nLCB3aXRob3V0IGxpbWl0YXRpb24sIGFueSB3YXJyYW50aWVzIG9yIGNvbmRpdGlvbnMKICAgIG9mIFRJVExFLCBOT04tSU5GUklOR0VNRU5ULCBNRVJDSEFOVEFCSUxJVFksIG9yIEZJVE5FU1MgRk9SIEEKICAgIFBBUlRJQ1VMQVIgUFVSUE9TRS4gWW91IGFyZSBzb2xlbHkgcmVzcG9uc2libGUgZm9yIGRldGVybWluaW5nIHRoZQogICAgYXBwcm9wcmlhdGVuZXNzIG9mIHVzaW5nIG9yIHJlZGlzdHJpYnV0aW5nIHRoZSBXb3JrIGFuZCBhc3N1bWUgYW55CiAgICByaXNrcyBhc3NvY2lhdGVkIHdpdGggWW91ciBleGVyY2lzZSBvZiBwZXJtaXNzaW9ucyB1bmRlciB0aGlzIExpY2Vuc2UuCgogOC4gTGltaXRhdGlvbiBvZiBMaWFiaWxpdHkuIEluIG5vIGV2ZW50IGFuZCB1bmRlciBubyBsZWdhbCB0aGVvcnksCiAgICB3aGV0aGVyIGluIHRvcnQgKGluY2x1ZGluZyBuZWdsaWdlbmNlKSwgY29udHJhY3QsIG9yIG90aGVyd2lzZSwKICAgIHVubGVzcyByZXF1aXJlZCBieSBhcHBsaWNhYmxlIGxhdyAoc3VjaCBhcyBkZWxpYmVyYXRlIGFuZCBncm9zc2x5CiAgICBuZWdsaWdlbnQgYWN0cykgb3IgYWdyZWVkIHRvIGluIHdyaXRpbmcsIHNoYWxsIGFueSBDb250cmlidXRvciBiZQogICAgbGlhYmxlIHRvIFlvdSBmb3IgZGFtYWdlcywgaW5jbHVkaW5nIGFueSBkaXJlY3QsIGluZGlyZWN0LCBzcGVjaWFsLAogICAgaW5jaWRlbnRhbCwgb3IgY29uc2VxdWVudGlhbCBkYW1hZ2VzIG9mIGFueSBjaGFyYWN0ZXIgYXJpc2luZyBhcyBhCiAgICByZXN1bHQgb2YgdGhpcyBMaWNlbnNlIG9yIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0byB1c2UgdGhlCiAgICBXb3JrIChpbmNsdWRpbmcgYnV0IG5vdCBsaW1pdGVkIHRvIGRhbWFnZXMgZm9yIGxvc3Mgb2YgZ29vZHdpbGwsCiAgICB3b3JrIHN0b3BwYWdlLCBjb21wdXRlciBmYWlsdXJlIG9yIG1hbGZ1bmN0aW9uLCBvciBhbnkgYW5kIGFsbAogICAgb3RoZXIgY29tbWVyY2lhbCBkYW1hZ2VzIG9yIGxvc3NlcyksIGV2ZW4gaWYgc3VjaCBDb250cmlidXRvcgogICAgaGFzIGJlZW4gYWR2aXNlZCBvZiB0aGUgcG9zc2liaWxpdHkgb2Ygc3VjaCBkYW1hZ2VzLgoKIDkuIEFjY2VwdGluZyBXYXJyYW50eSBvciBBZGRpdGlvbmFsIExpYWJpbGl0eS4gV2hpbGUgcmVkaXN0cmlidXRpbmcKICAgIHRoZSBXb3JrIG9yIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZiwgWW91IG1heSBjaG9vc2UgdG8gb2ZmZXIsCiAgICBhbmQgY2hhcmdlIGEgZmVlIGZvciwgYWNjZXB0YW5jZSBvZiBzdXBwb3J0LCB3YXJyYW50eSwgaW5kZW1uaXR5LAogICAgb3Igb3RoZXIgbGlhYmlsaXR5IG9ibGlnYXRpb25zIGFuZC9vciByaWdodHMgY29uc2lzdGVudCB3aXRoIHRoaXMKICAgIExpY2Vuc2UuIEhvd2V2ZXIsIGluIGFjY2VwdGluZyBzdWNoIG9ibGlnYXRpb25zLCBZb3UgbWF5IGFjdCBvbmx5CiAgICBvbiBZb3VyIG93biBiZWhhbGYgYW5kIG9uIFlvdXIgc29sZSByZXNwb25zaWJpbGl0eSwgbm90IG9uIGJlaGFsZgogICAgb2YgYW55IG90aGVyIENvbnRyaWJ1dG9yLCBhbmQgb25seSBpZiBZb3UgYWdyZWUgdG8gaW5kZW1uaWZ5LAogICAgZGVmZW5kLCBhbmQgaG9sZCBlYWNoIENvbnRyaWJ1dG9yIGhhcm1sZXNzIGZvciBhbnkgbGlhYmlsaXR5CiAgICBpbmN1cnJlZCBieSwgb3IgY2xhaW1zIGFzc2VydGVkIGFnYWluc3QsIHN1Y2ggQ29udHJpYnV0b3IgYnkgcmVhc29uCiAgICBvZiB5b3VyIGFjY2VwdGluZyBhbnkgc3VjaCB3YXJyYW50eSBvciBhZGRpdGlvbmFsIGxpYWJpbGl0eS4KCiBFTkQgT0YgVEVSTVMgQU5EIENPTkRJVElPTlMKCiBBUFBFTkRJWDogSG93IHRvIGFwcGx5IHRoZSBBcGFjaGUgTGljZW5zZSB0byB5b3VyIHdvcmsuCgogICAgVG8gYXBwbHkgdGhlIEFwYWNoZSBMaWNlbnNlIHRvIHlvdXIgd29yaywgYXR0YWNoIHRoZSBmb2xsb3dpbmcKICAgIGJvaWxlcnBsYXRlIG5vdGljZSwgd2l0aCB0aGUgZmllbGRzIGVuY2xvc2VkIGJ5IGJyYWNrZXRzICJbXSIKICAgIHJlcGxhY2VkIHdpdGggeW91ciBvd24gaWRlbnRpZnlpbmcgaW5mb3JtYXRpb24uIChEb24ndCBpbmNsdWRlCiAgICB0aGUgYnJhY2tldHMhKSAgVGhlIHRleHQgc2hvdWxkIGJlIGVuY2xvc2VkIGluIHRoZSBhcHByb3ByaWF0ZQogICAgY29tbWVudCBzeW50YXggZm9yIHRoZSBmaWxlIGZvcm1hdC4gV2UgYWxzbyByZWNvbW1lbmQgdGhhdCBhCiAgICBmaWxlIG9yIGNsYXNzIG5hbWUgYW5kIGRlc2NyaXB0aW9uIG9mIHB1cnBvc2UgYmUgaW5jbHVkZWQgb24gdGhlCiAgICBzYW1lICJwcmludGVkIHBhZ2UiIGFzIHRoZSBjb3B5cmlnaHQgbm90aWNlIGZvciBlYXNpZXIKICAgIGlkZW50aWZpY2F0aW9uIHdpdGhpbiB0aGlyZC1wYXJ0eSBhcmNoaXZlcy4KCiBDb3B5cmlnaHQgKGMpIDIwMTUtMjAxOCBHb29nbGUsIEluYy4sIE5ldGZsaXgsIEluYy4sIE1pY3Jvc29mdCBDb3JwLiBhbmQgY29udHJpYnV0b3JzCgogTGljZW5zZWQgdW5kZXIgdGhlIEFwYWNoZSBMaWNlbnNlLCBWZXJzaW9uIDIuMCAodGhlICJMaWNlbnNlIik7CiB5b3UgbWF5IG5vdCB1c2UgdGhpcyBmaWxlIGV4Y2VwdCBpbiBjb21wbGlhbmNlIHdpdGggdGhlIExpY2Vuc2UuCiBZb3UgbWF5IG9idGFpbiBhIGNvcHkgb2YgdGhlIExpY2Vuc2UgYXQKCiAgICAgaHR0cDovL3d3dy5hcGFjaGUub3JnL2xpY2Vuc2VzL0xJQ0VOU0UtMi4wCgogVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yIGFncmVlZCB0byBpbiB3cml0aW5nLCBzb2Z0d2FyZQogZGlzdHJpYnV0ZWQgdW5kZXIgdGhlIExpY2Vuc2UgaXMgZGlzdHJpYnV0ZWQgb24gYW4gIkFTIElTIiBCQVNJUywKIFdJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvciBpbXBsaWVkLgogU2VlIHRoZSBMaWNlbnNlIGZvciB0aGUgc3BlY2lmaWMgbGFuZ3VhZ2UgZ292ZXJuaW5nIHBlcm1pc3Npb25zIGFuZAogbGltaXRhdGlvbnMgdW5kZXIgdGhlIExpY2Vuc2UuCiAK",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "tslib",
+      "version": "2.6.3",
+      "bom-ref": "tslib@2.6.3#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
+      "author": "Microsoft Corp.",
+      "description": "Runtime library for TypeScript helper functions",
+      "licenses": [
+        {
+          "license": {
+            "id": "0BSD",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/Microsoft/TypeScript/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/Microsoft/tslib.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://www.typescriptlang.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE.txt",
+              "text": {
+                "content": "Q29weXJpZ2h0IChjKSBNaWNyb3NvZnQgQ29ycG9yYXRpb24uDQoNClBlcm1pc3Npb24gdG8gdXNlLCBjb3B5LCBtb2RpZnksIGFuZC9vciBkaXN0cmlidXRlIHRoaXMgc29mdHdhcmUgZm9yIGFueQ0KcHVycG9zZSB3aXRoIG9yIHdpdGhvdXQgZmVlIGlzIGhlcmVieSBncmFudGVkLg0KDQpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiBBTkQgVEhFIEFVVEhPUiBESVNDTEFJTVMgQUxMIFdBUlJBTlRJRVMgV0lUSA0KUkVHQVJEIFRPIFRISVMgU09GVFdBUkUgSU5DTFVESU5HIEFMTCBJTVBMSUVEIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZDQpBTkQgRklUTkVTUy4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUiBCRSBMSUFCTEUgRk9SIEFOWSBTUEVDSUFMLCBESVJFQ1QsDQpJTkRJUkVDVCwgT1IgQ09OU0VRVUVOVElBTCBEQU1BR0VTIE9SIEFOWSBEQU1BR0VTIFdIQVRTT0VWRVIgUkVTVUxUSU5HIEZST00NCkxPU1MgT0YgVVNFLCBEQVRBIE9SIFBST0ZJVFMsIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBORUdMSUdFTkNFIE9SDQpPVEhFUiBUT1JUSU9VUyBBQ1RJT04sIEFSSVNJTkcgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgVVNFIE9SDQpQRVJGT1JNQU5DRSBPRiBUSElTIFNPRlRXQVJFLg==",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "zone.js",
+      "version": "0.14.10",
+      "bom-ref": "zone.js@0.14.10#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
+      "author": "Brian Ford",
+      "description": "Zones for JavaScript",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/zone.js@0.14.10?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/angular/angular.git#packages/zone.js",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuaW8vbGljZW5zZQoKUGVybWlzc2lvbiBpcyBoZXJlYnkgZ3JhbnRlZCwgZnJlZSBvZiBjaGFyZ2UsIHRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weQpvZiB0aGlzIHNvZnR3YXJlIGFuZCBhc3NvY2lhdGVkIGRvY3VtZW50YXRpb24gZmlsZXMgKHRoZSAiU29mdHdhcmUiKSwgdG8gZGVhbAppbiB0aGUgU29mdHdhcmUgd2l0aG91dCByZXN0cmljdGlvbiwgaW5jbHVkaW5nIHdpdGhvdXQgbGltaXRhdGlvbiB0aGUgcmlnaHRzCnRvIHVzZSwgY29weSwgbW9kaWZ5LCBtZXJnZSwgcHVibGlzaCwgZGlzdHJpYnV0ZSwgc3VibGljZW5zZSwgYW5kL29yIHNlbGwKY29waWVzIG9mIHRoZSBTb2Z0d2FyZSwgYW5kIHRvIHBlcm1pdCBwZXJzb25zIHRvIHdob20gdGhlIFNvZnR3YXJlIGlzCmZ1cm5pc2hlZCB0byBkbyBzbywgc3ViamVjdCB0byB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnM6CgpUaGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBzaGFsbCBiZSBpbmNsdWRlZCBpbgphbGwgY29waWVzIG9yIHN1YnN0YW50aWFsIHBvcnRpb25zIG9mIHRoZSBTb2Z0d2FyZS4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiLCBXSVRIT1VUIFdBUlJBTlRZIE9GIEFOWSBLSU5ELCBFWFBSRVNTIE9SCklNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZLApGSVRORVNTIEZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRSBBTkQgTk9OSU5GUklOR0VNRU5ULiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUKQVVUSE9SUyBPUiBDT1BZUklHSFQgSE9MREVSUyBCRSBMSUFCTEUgRk9SIEFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUgpMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBUT1JUIE9SIE9USEVSV0lTRSwgQVJJU0lORyBGUk9NLApPVVQgT0YgT1IgSU4gQ09OTkVDVElPTiBXSVRIIFRIRSBTT0ZUV0FSRSBPUiBUSEUgVVNFIE9SIE9USEVSIERFQUxJTkdTIElOClRIRSBTT0ZUV0FSRS4K",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
     }
   ],
   "dependencies": [
     {
-      "ref": "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "ref": "@angular/common@18.2.7#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
       "dependsOn": [
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@babel/runtime@7.25.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
+        "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
-    },
-    {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
       "dependsOn": [
-        "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-        "a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
-        "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
+        "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+      "ref": "@angular/platform-browser@18.2.7#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
       "dependsOn": [
-        "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+        "@angular/common@18.2.7#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
       ]
     },
     {
-      "ref": "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"
-    },
-    {
-      "ref": "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+      "ref": "@angular/router@18.2.7#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
       "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/common@18.2.7#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/platform-browser@18.2.7#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+        "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
+      "ref": "@babel/runtime@7.25.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"
+    },
+    {
+      "ref": "@cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/platform-browser@18.2.7#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+        "@angular/router@18.2.7#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
+        "css-loader@7.1.2#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
       ]
     },
     {
-      "ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+      "ref": "css-loader@7.1.2#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
     },
     {
-      "ref": "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+      "ref": "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
       "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
+        "tslib@2.6.3#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
       ]
     },
     {
-      "ref": "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
+      "ref": "tslib@2.6.3#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+    },
+    {
+      "ref": "zone.js@0.14.10#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
     }
   ]
 }"
@@ -741,7 +741,7 @@ exports[`integration feature: component evidence generated json file: dist/.well
       "name": "feature-issue676",
       "group": "@cyclonedx-webpack-plugin-tests",
       "version": "0.0.0",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jan Kowalleck",
       "description": "example setup for testing evidence collection",
       "licenses": [
@@ -804,204 +804,10 @@ exports[`integration feature: component evidence generated json file: dist/.well
   "components": [
     {
       "type": "library",
-      "name": "platform-browser",
-      "group": "@angular",
-      "version": "18.2.7",
-      "bom-ref": "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-      "author": "angular",
-      "description": "Angular - library for using Angular in a web browser",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/angular/angular.git#packages/platform-browser",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuZGV2L2xpY2Vuc2UKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "zone.js",
-      "version": "0.14.10",
-      "bom-ref": "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
-      "author": "Brian Ford",
-      "description": "Zones for JavaScript",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/zone.js@0.14.10?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/angular/angular.git#packages/zone.js",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuaW8vbGljZW5zZQoKUGVybWlzc2lvbiBpcyBoZXJlYnkgZ3JhbnRlZCwgZnJlZSBvZiBjaGFyZ2UsIHRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weQpvZiB0aGlzIHNvZnR3YXJlIGFuZCBhc3NvY2lhdGVkIGRvY3VtZW50YXRpb24gZmlsZXMgKHRoZSAiU29mdHdhcmUiKSwgdG8gZGVhbAppbiB0aGUgU29mdHdhcmUgd2l0aG91dCByZXN0cmljdGlvbiwgaW5jbHVkaW5nIHdpdGhvdXQgbGltaXRhdGlvbiB0aGUgcmlnaHRzCnRvIHVzZSwgY29weSwgbW9kaWZ5LCBtZXJnZSwgcHVibGlzaCwgZGlzdHJpYnV0ZSwgc3VibGljZW5zZSwgYW5kL29yIHNlbGwKY29waWVzIG9mIHRoZSBTb2Z0d2FyZSwgYW5kIHRvIHBlcm1pdCBwZXJzb25zIHRvIHdob20gdGhlIFNvZnR3YXJlIGlzCmZ1cm5pc2hlZCB0byBkbyBzbywgc3ViamVjdCB0byB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnM6CgpUaGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBzaGFsbCBiZSBpbmNsdWRlZCBpbgphbGwgY29waWVzIG9yIHN1YnN0YW50aWFsIHBvcnRpb25zIG9mIHRoZSBTb2Z0d2FyZS4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiLCBXSVRIT1VUIFdBUlJBTlRZIE9GIEFOWSBLSU5ELCBFWFBSRVNTIE9SCklNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZLApGSVRORVNTIEZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRSBBTkQgTk9OSU5GUklOR0VNRU5ULiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUKQVVUSE9SUyBPUiBDT1BZUklHSFQgSE9MREVSUyBCRSBMSUFCTEUgRk9SIEFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUgpMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBUT1JUIE9SIE9USEVSV0lTRSwgQVJJU0lORyBGUk9NLApPVVQgT0YgT1IgSU4gQ09OTkVDVElPTiBXSVRIIFRIRSBTT0ZUV0FSRSBPUiBUSEUgVVNFIE9SIE9USEVSIERFQUxJTkdTIElOClRIRSBTT0ZUV0FSRS4K",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "rxjs",
-      "version": "7.8.1",
-      "bom-ref": "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-      "author": "Ben Lesh",
-      "description": "Reactive Extensions for modern JavaScript",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ReactiveX/RxJS/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/reactivex/rxjs.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://rxjs.dev",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE.txt",
-              "text": {
-                "content": "ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEFwYWNoZSBMaWNlbnNlCiAgICAgICAgICAgICAgICAgICAgICAgICBWZXJzaW9uIDIuMCwgSmFudWFyeSAyMDA0CiAgICAgICAgICAgICAgICAgICAgICBodHRwOi8vd3d3LmFwYWNoZS5vcmcvbGljZW5zZXMvCgogVEVSTVMgQU5EIENPTkRJVElPTlMgRk9SIFVTRSwgUkVQUk9EVUNUSU9OLCBBTkQgRElTVFJJQlVUSU9OCgogMS4gRGVmaW5pdGlvbnMuCgogICAgIkxpY2Vuc2UiIHNoYWxsIG1lYW4gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIGZvciB1c2UsIHJlcHJvZHVjdGlvbiwKICAgIGFuZCBkaXN0cmlidXRpb24gYXMgZGVmaW5lZCBieSBTZWN0aW9ucyAxIHRocm91Z2ggOSBvZiB0aGlzIGRvY3VtZW50LgoKICAgICJMaWNlbnNvciIgc2hhbGwgbWVhbiB0aGUgY29weXJpZ2h0IG93bmVyIG9yIGVudGl0eSBhdXRob3JpemVkIGJ5CiAgICB0aGUgY29weXJpZ2h0IG93bmVyIHRoYXQgaXMgZ3JhbnRpbmcgdGhlIExpY2Vuc2UuCgogICAgIkxlZ2FsIEVudGl0eSIgc2hhbGwgbWVhbiB0aGUgdW5pb24gb2YgdGhlIGFjdGluZyBlbnRpdHkgYW5kIGFsbAogICAgb3RoZXIgZW50aXRpZXMgdGhhdCBjb250cm9sLCBhcmUgY29udHJvbGxlZCBieSwgb3IgYXJlIHVuZGVyIGNvbW1vbgogICAgY29udHJvbCB3aXRoIHRoYXQgZW50aXR5LiBGb3IgdGhlIHB1cnBvc2VzIG9mIHRoaXMgZGVmaW5pdGlvbiwKICAgICJjb250cm9sIiBtZWFucyAoaSkgdGhlIHBvd2VyLCBkaXJlY3Qgb3IgaW5kaXJlY3QsIHRvIGNhdXNlIHRoZQogICAgZGlyZWN0aW9uIG9yIG1hbmFnZW1lbnQgb2Ygc3VjaCBlbnRpdHksIHdoZXRoZXIgYnkgY29udHJhY3Qgb3IKICAgIG90aGVyd2lzZSwgb3IgKGlpKSBvd25lcnNoaXAgb2YgZmlmdHkgcGVyY2VudCAoNTAlKSBvciBtb3JlIG9mIHRoZQogICAgb3V0c3RhbmRpbmcgc2hhcmVzLCBvciAoaWlpKSBiZW5lZmljaWFsIG93bmVyc2hpcCBvZiBzdWNoIGVudGl0eS4KCiAgICAiWW91IiAob3IgIllvdXIiKSBzaGFsbCBtZWFuIGFuIGluZGl2aWR1YWwgb3IgTGVnYWwgRW50aXR5CiAgICBleGVyY2lzaW5nIHBlcm1pc3Npb25zIGdyYW50ZWQgYnkgdGhpcyBMaWNlbnNlLgoKICAgICJTb3VyY2UiIGZvcm0gc2hhbGwgbWVhbiB0aGUgcHJlZmVycmVkIGZvcm0gZm9yIG1ha2luZyBtb2RpZmljYXRpb25zLAogICAgaW5jbHVkaW5nIGJ1dCBub3QgbGltaXRlZCB0byBzb2Z0d2FyZSBzb3VyY2UgY29kZSwgZG9jdW1lbnRhdGlvbgogICAgc291cmNlLCBhbmQgY29uZmlndXJhdGlvbiBmaWxlcy4KCiAgICAiT2JqZWN0IiBmb3JtIHNoYWxsIG1lYW4gYW55IGZvcm0gcmVzdWx0aW5nIGZyb20gbWVjaGFuaWNhbAogICAgdHJhbnNmb3JtYXRpb24gb3IgdHJhbnNsYXRpb24gb2YgYSBTb3VyY2UgZm9ybSwgaW5jbHVkaW5nIGJ1dAogICAgbm90IGxpbWl0ZWQgdG8gY29tcGlsZWQgb2JqZWN0IGNvZGUsIGdlbmVyYXRlZCBkb2N1bWVudGF0aW9uLAogICAgYW5kIGNvbnZlcnNpb25zIHRvIG90aGVyIG1lZGlhIHR5cGVzLgoKICAgICJXb3JrIiBzaGFsbCBtZWFuIHRoZSB3b3JrIG9mIGF1dGhvcnNoaXAsIHdoZXRoZXIgaW4gU291cmNlIG9yCiAgICBPYmplY3QgZm9ybSwgbWFkZSBhdmFpbGFibGUgdW5kZXIgdGhlIExpY2Vuc2UsIGFzIGluZGljYXRlZCBieSBhCiAgICBjb3B5cmlnaHQgbm90aWNlIHRoYXQgaXMgaW5jbHVkZWQgaW4gb3IgYXR0YWNoZWQgdG8gdGhlIHdvcmsKICAgIChhbiBleGFtcGxlIGlzIHByb3ZpZGVkIGluIHRoZSBBcHBlbmRpeCBiZWxvdykuCgogICAgIkRlcml2YXRpdmUgV29ya3MiIHNoYWxsIG1lYW4gYW55IHdvcmssIHdoZXRoZXIgaW4gU291cmNlIG9yIE9iamVjdAogICAgZm9ybSwgdGhhdCBpcyBiYXNlZCBvbiAob3IgZGVyaXZlZCBmcm9tKSB0aGUgV29yayBhbmQgZm9yIHdoaWNoIHRoZQogICAgZWRpdG9yaWFsIHJldmlzaW9ucywgYW5ub3RhdGlvbnMsIGVsYWJvcmF0aW9ucywgb3Igb3RoZXIgbW9kaWZpY2F0aW9ucwogICAgcmVwcmVzZW50LCBhcyBhIHdob2xlLCBhbiBvcmlnaW5hbCB3b3JrIG9mIGF1dGhvcnNoaXAuIEZvciB0aGUgcHVycG9zZXMKICAgIG9mIHRoaXMgTGljZW5zZSwgRGVyaXZhdGl2ZSBXb3JrcyBzaGFsbCBub3QgaW5jbHVkZSB3b3JrcyB0aGF0IHJlbWFpbgogICAgc2VwYXJhYmxlIGZyb20sIG9yIG1lcmVseSBsaW5rIChvciBiaW5kIGJ5IG5hbWUpIHRvIHRoZSBpbnRlcmZhY2VzIG9mLAogICAgdGhlIFdvcmsgYW5kIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZi4KCiAgICAiQ29udHJpYnV0aW9uIiBzaGFsbCBtZWFuIGFueSB3b3JrIG9mIGF1dGhvcnNoaXAsIGluY2x1ZGluZwogICAgdGhlIG9yaWdpbmFsIHZlcnNpb24gb2YgdGhlIFdvcmsgYW5kIGFueSBtb2RpZmljYXRpb25zIG9yIGFkZGl0aW9ucwogICAgdG8gdGhhdCBXb3JrIG9yIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZiwgdGhhdCBpcyBpbnRlbnRpb25hbGx5CiAgICBzdWJtaXR0ZWQgdG8gTGljZW5zb3IgZm9yIGluY2x1c2lvbiBpbiB0aGUgV29yayBieSB0aGUgY29weXJpZ2h0IG93bmVyCiAgICBvciBieSBhbiBpbmRpdmlkdWFsIG9yIExlZ2FsIEVudGl0eSBhdXRob3JpemVkIHRvIHN1Ym1pdCBvbiBiZWhhbGYgb2YKICAgIHRoZSBjb3B5cmlnaHQgb3duZXIuIEZvciB0aGUgcHVycG9zZXMgb2YgdGhpcyBkZWZpbml0aW9uLCAic3VibWl0dGVkIgogICAgbWVhbnMgYW55IGZvcm0gb2YgZWxlY3Ryb25pYywgdmVyYmFsLCBvciB3cml0dGVuIGNvbW11bmljYXRpb24gc2VudAogICAgdG8gdGhlIExpY2Vuc29yIG9yIGl0cyByZXByZXNlbnRhdGl2ZXMsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQgdG8KICAgIGNvbW11bmljYXRpb24gb24gZWxlY3Ryb25pYyBtYWlsaW5nIGxpc3RzLCBzb3VyY2UgY29kZSBjb250cm9sIHN5c3RlbXMsCiAgICBhbmQgaXNzdWUgdHJhY2tpbmcgc3lzdGVtcyB0aGF0IGFyZSBtYW5hZ2VkIGJ5LCBvciBvbiBiZWhhbGYgb2YsIHRoZQogICAgTGljZW5zb3IgZm9yIHRoZSBwdXJwb3NlIG9mIGRpc2N1c3NpbmcgYW5kIGltcHJvdmluZyB0aGUgV29yaywgYnV0CiAgICBleGNsdWRpbmcgY29tbXVuaWNhdGlvbiB0aGF0IGlzIGNvbnNwaWN1b3VzbHkgbWFya2VkIG9yIG90aGVyd2lzZQogICAgZGVzaWduYXRlZCBpbiB3cml0aW5nIGJ5IHRoZSBjb3B5cmlnaHQgb3duZXIgYXMgIk5vdCBhIENvbnRyaWJ1dGlvbi4iCgogICAgIkNvbnRyaWJ1dG9yIiBzaGFsbCBtZWFuIExpY2Vuc29yIGFuZCBhbnkgaW5kaXZpZHVhbCBvciBMZWdhbCBFbnRpdHkKICAgIG9uIGJlaGFsZiBvZiB3aG9tIGEgQ29udHJpYnV0aW9uIGhhcyBiZWVuIHJlY2VpdmVkIGJ5IExpY2Vuc29yIGFuZAogICAgc3Vic2VxdWVudGx5IGluY29ycG9yYXRlZCB3aXRoaW4gdGhlIFdvcmsuCgogMi4gR3JhbnQgb2YgQ29weXJpZ2h0IExpY2Vuc2UuIFN1YmplY3QgdG8gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mCiAgICB0aGlzIExpY2Vuc2UsIGVhY2ggQ29udHJpYnV0b3IgaGVyZWJ5IGdyYW50cyB0byBZb3UgYSBwZXJwZXR1YWwsCiAgICB3b3JsZHdpZGUsIG5vbi1leGNsdXNpdmUsIG5vLWNoYXJnZSwgcm95YWx0eS1mcmVlLCBpcnJldm9jYWJsZQogICAgY29weXJpZ2h0IGxpY2Vuc2UgdG8gcmVwcm9kdWNlLCBwcmVwYXJlIERlcml2YXRpdmUgV29ya3Mgb2YsCiAgICBwdWJsaWNseSBkaXNwbGF5LCBwdWJsaWNseSBwZXJmb3JtLCBzdWJsaWNlbnNlLCBhbmQgZGlzdHJpYnV0ZSB0aGUKICAgIFdvcmsgYW5kIHN1Y2ggRGVyaXZhdGl2ZSBXb3JrcyBpbiBTb3VyY2Ugb3IgT2JqZWN0IGZvcm0uCgogMy4gR3JhbnQgb2YgUGF0ZW50IExpY2Vuc2UuIFN1YmplY3QgdG8gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mCiAgICB0aGlzIExpY2Vuc2UsIGVhY2ggQ29udHJpYnV0b3IgaGVyZWJ5IGdyYW50cyB0byBZb3UgYSBwZXJwZXR1YWwsCiAgICB3b3JsZHdpZGUsIG5vbi1leGNsdXNpdmUsIG5vLWNoYXJnZSwgcm95YWx0eS1mcmVlLCBpcnJldm9jYWJsZQogICAgKGV4Y2VwdCBhcyBzdGF0ZWQgaW4gdGhpcyBzZWN0aW9uKSBwYXRlbnQgbGljZW5zZSB0byBtYWtlLCBoYXZlIG1hZGUsCiAgICB1c2UsIG9mZmVyIHRvIHNlbGwsIHNlbGwsIGltcG9ydCwgYW5kIG90aGVyd2lzZSB0cmFuc2ZlciB0aGUgV29yaywKICAgIHdoZXJlIHN1Y2ggbGljZW5zZSBhcHBsaWVzIG9ubHkgdG8gdGhvc2UgcGF0ZW50IGNsYWltcyBsaWNlbnNhYmxlCiAgICBieSBzdWNoIENvbnRyaWJ1dG9yIHRoYXQgYXJlIG5lY2Vzc2FyaWx5IGluZnJpbmdlZCBieSB0aGVpcgogICAgQ29udHJpYnV0aW9uKHMpIGFsb25lIG9yIGJ5IGNvbWJpbmF0aW9uIG9mIHRoZWlyIENvbnRyaWJ1dGlvbihzKQogICAgd2l0aCB0aGUgV29yayB0byB3aGljaCBzdWNoIENvbnRyaWJ1dGlvbihzKSB3YXMgc3VibWl0dGVkLiBJZiBZb3UKICAgIGluc3RpdHV0ZSBwYXRlbnQgbGl0aWdhdGlvbiBhZ2FpbnN0IGFueSBlbnRpdHkgKGluY2x1ZGluZyBhCiAgICBjcm9zcy1jbGFpbSBvciBjb3VudGVyY2xhaW0gaW4gYSBsYXdzdWl0KSBhbGxlZ2luZyB0aGF0IHRoZSBXb3JrCiAgICBvciBhIENvbnRyaWJ1dGlvbiBpbmNvcnBvcmF0ZWQgd2l0aGluIHRoZSBXb3JrIGNvbnN0aXR1dGVzIGRpcmVjdAogICAgb3IgY29udHJpYnV0b3J5IHBhdGVudCBpbmZyaW5nZW1lbnQsIHRoZW4gYW55IHBhdGVudCBsaWNlbnNlcwogICAgZ3JhbnRlZCB0byBZb3UgdW5kZXIgdGhpcyBMaWNlbnNlIGZvciB0aGF0IFdvcmsgc2hhbGwgdGVybWluYXRlCiAgICBhcyBvZiB0aGUgZGF0ZSBzdWNoIGxpdGlnYXRpb24gaXMgZmlsZWQuCgogNC4gUmVkaXN0cmlidXRpb24uIFlvdSBtYXkgcmVwcm9kdWNlIGFuZCBkaXN0cmlidXRlIGNvcGllcyBvZiB0aGUKICAgIFdvcmsgb3IgRGVyaXZhdGl2ZSBXb3JrcyB0aGVyZW9mIGluIGFueSBtZWRpdW0sIHdpdGggb3Igd2l0aG91dAogICAgbW9kaWZpY2F0aW9ucywgYW5kIGluIFNvdXJjZSBvciBPYmplY3QgZm9ybSwgcHJvdmlkZWQgdGhhdCBZb3UKICAgIG1lZXQgdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKICAgIChhKSBZb3UgbXVzdCBnaXZlIGFueSBvdGhlciByZWNpcGllbnRzIG9mIHRoZSBXb3JrIG9yCiAgICAgICAgRGVyaXZhdGl2ZSBXb3JrcyBhIGNvcHkgb2YgdGhpcyBMaWNlbnNlOyBhbmQKCiAgICAoYikgWW91IG11c3QgY2F1c2UgYW55IG1vZGlmaWVkIGZpbGVzIHRvIGNhcnJ5IHByb21pbmVudCBub3RpY2VzCiAgICAgICAgc3RhdGluZyB0aGF0IFlvdSBjaGFuZ2VkIHRoZSBmaWxlczsgYW5kCgogICAgKGMpIFlvdSBtdXN0IHJldGFpbiwgaW4gdGhlIFNvdXJjZSBmb3JtIG9mIGFueSBEZXJpdmF0aXZlIFdvcmtzCiAgICAgICAgdGhhdCBZb3UgZGlzdHJpYnV0ZSwgYWxsIGNvcHlyaWdodCwgcGF0ZW50LCB0cmFkZW1hcmssIGFuZAogICAgICAgIGF0dHJpYnV0aW9uIG5vdGljZXMgZnJvbSB0aGUgU291cmNlIGZvcm0gb2YgdGhlIFdvcmssCiAgICAgICAgZXhjbHVkaW5nIHRob3NlIG5vdGljZXMgdGhhdCBkbyBub3QgcGVydGFpbiB0byBhbnkgcGFydCBvZgogICAgICAgIHRoZSBEZXJpdmF0aXZlIFdvcmtzOyBhbmQKCiAgICAoZCkgSWYgdGhlIFdvcmsgaW5jbHVkZXMgYSAiTk9USUNFIiB0ZXh0IGZpbGUgYXMgcGFydCBvZiBpdHMKICAgICAgICBkaXN0cmlidXRpb24sIHRoZW4gYW55IERlcml2YXRpdmUgV29ya3MgdGhhdCBZb3UgZGlzdHJpYnV0ZSBtdXN0CiAgICAgICAgaW5jbHVkZSBhIHJlYWRhYmxlIGNvcHkgb2YgdGhlIGF0dHJpYnV0aW9uIG5vdGljZXMgY29udGFpbmVkCiAgICAgICAgd2l0aGluIHN1Y2ggTk9USUNFIGZpbGUsIGV4Y2x1ZGluZyB0aG9zZSBub3RpY2VzIHRoYXQgZG8gbm90CiAgICAgICAgcGVydGFpbiB0byBhbnkgcGFydCBvZiB0aGUgRGVyaXZhdGl2ZSBXb3JrcywgaW4gYXQgbGVhc3Qgb25lCiAgICAgICAgb2YgdGhlIGZvbGxvd2luZyBwbGFjZXM6IHdpdGhpbiBhIE5PVElDRSB0ZXh0IGZpbGUgZGlzdHJpYnV0ZWQKICAgICAgICBhcyBwYXJ0IG9mIHRoZSBEZXJpdmF0aXZlIFdvcmtzOyB3aXRoaW4gdGhlIFNvdXJjZSBmb3JtIG9yCiAgICAgICAgZG9jdW1lbnRhdGlvbiwgaWYgcHJvdmlkZWQgYWxvbmcgd2l0aCB0aGUgRGVyaXZhdGl2ZSBXb3Jrczsgb3IsCiAgICAgICAgd2l0aGluIGEgZGlzcGxheSBnZW5lcmF0ZWQgYnkgdGhlIERlcml2YXRpdmUgV29ya3MsIGlmIGFuZAogICAgICAgIHdoZXJldmVyIHN1Y2ggdGhpcmQtcGFydHkgbm90aWNlcyBub3JtYWxseSBhcHBlYXIuIFRoZSBjb250ZW50cwogICAgICAgIG9mIHRoZSBOT1RJQ0UgZmlsZSBhcmUgZm9yIGluZm9ybWF0aW9uYWwgcHVycG9zZXMgb25seSBhbmQKICAgICAgICBkbyBub3QgbW9kaWZ5IHRoZSBMaWNlbnNlLiBZb3UgbWF5IGFkZCBZb3VyIG93biBhdHRyaWJ1dGlvbgogICAgICAgIG5vdGljZXMgd2l0aGluIERlcml2YXRpdmUgV29ya3MgdGhhdCBZb3UgZGlzdHJpYnV0ZSwgYWxvbmdzaWRlCiAgICAgICAgb3IgYXMgYW4gYWRkZW5kdW0gdG8gdGhlIE5PVElDRSB0ZXh0IGZyb20gdGhlIFdvcmssIHByb3ZpZGVkCiAgICAgICAgdGhhdCBzdWNoIGFkZGl0aW9uYWwgYXR0cmlidXRpb24gbm90aWNlcyBjYW5ub3QgYmUgY29uc3RydWVkCiAgICAgICAgYXMgbW9kaWZ5aW5nIHRoZSBMaWNlbnNlLgoKICAgIFlvdSBtYXkgYWRkIFlvdXIgb3duIGNvcHlyaWdodCBzdGF0ZW1lbnQgdG8gWW91ciBtb2RpZmljYXRpb25zIGFuZAogICAgbWF5IHByb3ZpZGUgYWRkaXRpb25hbCBvciBkaWZmZXJlbnQgbGljZW5zZSB0ZXJtcyBhbmQgY29uZGl0aW9ucwogICAgZm9yIHVzZSwgcmVwcm9kdWN0aW9uLCBvciBkaXN0cmlidXRpb24gb2YgWW91ciBtb2RpZmljYXRpb25zLCBvcgogICAgZm9yIGFueSBzdWNoIERlcml2YXRpdmUgV29ya3MgYXMgYSB3aG9sZSwgcHJvdmlkZWQgWW91ciB1c2UsCiAgICByZXByb2R1Y3Rpb24sIGFuZCBkaXN0cmlidXRpb24gb2YgdGhlIFdvcmsgb3RoZXJ3aXNlIGNvbXBsaWVzIHdpdGgKICAgIHRoZSBjb25kaXRpb25zIHN0YXRlZCBpbiB0aGlzIExpY2Vuc2UuCgogNS4gU3VibWlzc2lvbiBvZiBDb250cmlidXRpb25zLiBVbmxlc3MgWW91IGV4cGxpY2l0bHkgc3RhdGUgb3RoZXJ3aXNlLAogICAgYW55IENvbnRyaWJ1dGlvbiBpbnRlbnRpb25hbGx5IHN1Ym1pdHRlZCBmb3IgaW5jbHVzaW9uIGluIHRoZSBXb3JrCiAgICBieSBZb3UgdG8gdGhlIExpY2Vuc29yIHNoYWxsIGJlIHVuZGVyIHRoZSB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZgogICAgdGhpcyBMaWNlbnNlLCB3aXRob3V0IGFueSBhZGRpdGlvbmFsIHRlcm1zIG9yIGNvbmRpdGlvbnMuCiAgICBOb3R3aXRoc3RhbmRpbmcgdGhlIGFib3ZlLCBub3RoaW5nIGhlcmVpbiBzaGFsbCBzdXBlcnNlZGUgb3IgbW9kaWZ5CiAgICB0aGUgdGVybXMgb2YgYW55IHNlcGFyYXRlIGxpY2Vuc2UgYWdyZWVtZW50IHlvdSBtYXkgaGF2ZSBleGVjdXRlZAogICAgd2l0aCBMaWNlbnNvciByZWdhcmRpbmcgc3VjaCBDb250cmlidXRpb25zLgoKIDYuIFRyYWRlbWFya3MuIFRoaXMgTGljZW5zZSBkb2VzIG5vdCBncmFudCBwZXJtaXNzaW9uIHRvIHVzZSB0aGUgdHJhZGUKICAgIG5hbWVzLCB0cmFkZW1hcmtzLCBzZXJ2aWNlIG1hcmtzLCBvciBwcm9kdWN0IG5hbWVzIG9mIHRoZSBMaWNlbnNvciwKICAgIGV4Y2VwdCBhcyByZXF1aXJlZCBmb3IgcmVhc29uYWJsZSBhbmQgY3VzdG9tYXJ5IHVzZSBpbiBkZXNjcmliaW5nIHRoZQogICAgb3JpZ2luIG9mIHRoZSBXb3JrIGFuZCByZXByb2R1Y2luZyB0aGUgY29udGVudCBvZiB0aGUgTk9USUNFIGZpbGUuCgogNy4gRGlzY2xhaW1lciBvZiBXYXJyYW50eS4gVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yCiAgICBhZ3JlZWQgdG8gaW4gd3JpdGluZywgTGljZW5zb3IgcHJvdmlkZXMgdGhlIFdvcmsgKGFuZCBlYWNoCiAgICBDb250cmlidXRvciBwcm92aWRlcyBpdHMgQ29udHJpYnV0aW9ucykgb24gYW4gIkFTIElTIiBCQVNJUywKICAgIFdJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvcgogICAgaW1wbGllZCwgaW5jbHVkaW5nLCB3aXRob3V0IGxpbWl0YXRpb24sIGFueSB3YXJyYW50aWVzIG9yIGNvbmRpdGlvbnMKICAgIG9mIFRJVExFLCBOT04tSU5GUklOR0VNRU5ULCBNRVJDSEFOVEFCSUxJVFksIG9yIEZJVE5FU1MgRk9SIEEKICAgIFBBUlRJQ1VMQVIgUFVSUE9TRS4gWW91IGFyZSBzb2xlbHkgcmVzcG9uc2libGUgZm9yIGRldGVybWluaW5nIHRoZQogICAgYXBwcm9wcmlhdGVuZXNzIG9mIHVzaW5nIG9yIHJlZGlzdHJpYnV0aW5nIHRoZSBXb3JrIGFuZCBhc3N1bWUgYW55CiAgICByaXNrcyBhc3NvY2lhdGVkIHdpdGggWW91ciBleGVyY2lzZSBvZiBwZXJtaXNzaW9ucyB1bmRlciB0aGlzIExpY2Vuc2UuCgogOC4gTGltaXRhdGlvbiBvZiBMaWFiaWxpdHkuIEluIG5vIGV2ZW50IGFuZCB1bmRlciBubyBsZWdhbCB0aGVvcnksCiAgICB3aGV0aGVyIGluIHRvcnQgKGluY2x1ZGluZyBuZWdsaWdlbmNlKSwgY29udHJhY3QsIG9yIG90aGVyd2lzZSwKICAgIHVubGVzcyByZXF1aXJlZCBieSBhcHBsaWNhYmxlIGxhdyAoc3VjaCBhcyBkZWxpYmVyYXRlIGFuZCBncm9zc2x5CiAgICBuZWdsaWdlbnQgYWN0cykgb3IgYWdyZWVkIHRvIGluIHdyaXRpbmcsIHNoYWxsIGFueSBDb250cmlidXRvciBiZQogICAgbGlhYmxlIHRvIFlvdSBmb3IgZGFtYWdlcywgaW5jbHVkaW5nIGFueSBkaXJlY3QsIGluZGlyZWN0LCBzcGVjaWFsLAogICAgaW5jaWRlbnRhbCwgb3IgY29uc2VxdWVudGlhbCBkYW1hZ2VzIG9mIGFueSBjaGFyYWN0ZXIgYXJpc2luZyBhcyBhCiAgICByZXN1bHQgb2YgdGhpcyBMaWNlbnNlIG9yIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0byB1c2UgdGhlCiAgICBXb3JrIChpbmNsdWRpbmcgYnV0IG5vdCBsaW1pdGVkIHRvIGRhbWFnZXMgZm9yIGxvc3Mgb2YgZ29vZHdpbGwsCiAgICB3b3JrIHN0b3BwYWdlLCBjb21wdXRlciBmYWlsdXJlIG9yIG1hbGZ1bmN0aW9uLCBvciBhbnkgYW5kIGFsbAogICAgb3RoZXIgY29tbWVyY2lhbCBkYW1hZ2VzIG9yIGxvc3NlcyksIGV2ZW4gaWYgc3VjaCBDb250cmlidXRvcgogICAgaGFzIGJlZW4gYWR2aXNlZCBvZiB0aGUgcG9zc2liaWxpdHkgb2Ygc3VjaCBkYW1hZ2VzLgoKIDkuIEFjY2VwdGluZyBXYXJyYW50eSBvciBBZGRpdGlvbmFsIExpYWJpbGl0eS4gV2hpbGUgcmVkaXN0cmlidXRpbmcKICAgIHRoZSBXb3JrIG9yIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZiwgWW91IG1heSBjaG9vc2UgdG8gb2ZmZXIsCiAgICBhbmQgY2hhcmdlIGEgZmVlIGZvciwgYWNjZXB0YW5jZSBvZiBzdXBwb3J0LCB3YXJyYW50eSwgaW5kZW1uaXR5LAogICAgb3Igb3RoZXIgbGlhYmlsaXR5IG9ibGlnYXRpb25zIGFuZC9vciByaWdodHMgY29uc2lzdGVudCB3aXRoIHRoaXMKICAgIExpY2Vuc2UuIEhvd2V2ZXIsIGluIGFjY2VwdGluZyBzdWNoIG9ibGlnYXRpb25zLCBZb3UgbWF5IGFjdCBvbmx5CiAgICBvbiBZb3VyIG93biBiZWhhbGYgYW5kIG9uIFlvdXIgc29sZSByZXNwb25zaWJpbGl0eSwgbm90IG9uIGJlaGFsZgogICAgb2YgYW55IG90aGVyIENvbnRyaWJ1dG9yLCBhbmQgb25seSBpZiBZb3UgYWdyZWUgdG8gaW5kZW1uaWZ5LAogICAgZGVmZW5kLCBhbmQgaG9sZCBlYWNoIENvbnRyaWJ1dG9yIGhhcm1sZXNzIGZvciBhbnkgbGlhYmlsaXR5CiAgICBpbmN1cnJlZCBieSwgb3IgY2xhaW1zIGFzc2VydGVkIGFnYWluc3QsIHN1Y2ggQ29udHJpYnV0b3IgYnkgcmVhc29uCiAgICBvZiB5b3VyIGFjY2VwdGluZyBhbnkgc3VjaCB3YXJyYW50eSBvciBhZGRpdGlvbmFsIGxpYWJpbGl0eS4KCiBFTkQgT0YgVEVSTVMgQU5EIENPTkRJVElPTlMKCiBBUFBFTkRJWDogSG93IHRvIGFwcGx5IHRoZSBBcGFjaGUgTGljZW5zZSB0byB5b3VyIHdvcmsuCgogICAgVG8gYXBwbHkgdGhlIEFwYWNoZSBMaWNlbnNlIHRvIHlvdXIgd29yaywgYXR0YWNoIHRoZSBmb2xsb3dpbmcKICAgIGJvaWxlcnBsYXRlIG5vdGljZSwgd2l0aCB0aGUgZmllbGRzIGVuY2xvc2VkIGJ5IGJyYWNrZXRzICJbXSIKICAgIHJlcGxhY2VkIHdpdGggeW91ciBvd24gaWRlbnRpZnlpbmcgaW5mb3JtYXRpb24uIChEb24ndCBpbmNsdWRlCiAgICB0aGUgYnJhY2tldHMhKSAgVGhlIHRleHQgc2hvdWxkIGJlIGVuY2xvc2VkIGluIHRoZSBhcHByb3ByaWF0ZQogICAgY29tbWVudCBzeW50YXggZm9yIHRoZSBmaWxlIGZvcm1hdC4gV2UgYWxzbyByZWNvbW1lbmQgdGhhdCBhCiAgICBmaWxlIG9yIGNsYXNzIG5hbWUgYW5kIGRlc2NyaXB0aW9uIG9mIHB1cnBvc2UgYmUgaW5jbHVkZWQgb24gdGhlCiAgICBzYW1lICJwcmludGVkIHBhZ2UiIGFzIHRoZSBjb3B5cmlnaHQgbm90aWNlIGZvciBlYXNpZXIKICAgIGlkZW50aWZpY2F0aW9uIHdpdGhpbiB0aGlyZC1wYXJ0eSBhcmNoaXZlcy4KCiBDb3B5cmlnaHQgKGMpIDIwMTUtMjAxOCBHb29nbGUsIEluYy4sIE5ldGZsaXgsIEluYy4sIE1pY3Jvc29mdCBDb3JwLiBhbmQgY29udHJpYnV0b3JzCgogTGljZW5zZWQgdW5kZXIgdGhlIEFwYWNoZSBMaWNlbnNlLCBWZXJzaW9uIDIuMCAodGhlICJMaWNlbnNlIik7CiB5b3UgbWF5IG5vdCB1c2UgdGhpcyBmaWxlIGV4Y2VwdCBpbiBjb21wbGlhbmNlIHdpdGggdGhlIExpY2Vuc2UuCiBZb3UgbWF5IG9idGFpbiBhIGNvcHkgb2YgdGhlIExpY2Vuc2UgYXQKCiAgICAgaHR0cDovL3d3dy5hcGFjaGUub3JnL2xpY2Vuc2VzL0xJQ0VOU0UtMi4wCgogVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yIGFncmVlZCB0byBpbiB3cml0aW5nLCBzb2Z0d2FyZQogZGlzdHJpYnV0ZWQgdW5kZXIgdGhlIExpY2Vuc2UgaXMgZGlzdHJpYnV0ZWQgb24gYW4gIkFTIElTIiBCQVNJUywKIFdJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvciBpbXBsaWVkLgogU2VlIHRoZSBMaWNlbnNlIGZvciB0aGUgc3BlY2lmaWMgbGFuZ3VhZ2UgZ292ZXJuaW5nIHBlcm1pc3Npb25zIGFuZAogbGltaXRhdGlvbnMgdW5kZXIgdGhlIExpY2Vuc2UuCiAK",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "runtime",
-      "group": "@babel",
-      "version": "7.25.0",
-      "bom-ref": "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
-      "author": "The Babel Team",
-      "description": "babel's modular runtime helpers",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git%23packages%2Fbabel-runtime",
-      "externalReferences": [
-        {
-          "url": "https://github.com/babel/babel/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/babel/babel.git#packages/babel-runtime",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://babel.dev/docs/en/next/babel-runtime",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "TUlUIExpY2Vuc2UKCkNvcHlyaWdodCAoYykgMjAxNC1wcmVzZW50IFNlYmFzdGlhbiBNY0tlbnppZSBhbmQgb3RoZXIgY29udHJpYnV0b3JzCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcKYSBjb3B5IG9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlCiJTb2Z0d2FyZSIpLCB0byBkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcKd2l0aG91dCBsaW1pdGF0aW9uIHRoZSByaWdodHMgdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLApkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3Igc2VsbCBjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8KcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMgZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvCnRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlCmluY2x1ZGVkIGluIGFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsCkVYUFJFU1MgT1IgSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRgpNRVJDSEFOVEFCSUxJVFksIEZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORApOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRSBBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFCkxJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSIExJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04KT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HIEZST00sIE9VVCBPRiBPUiBJTiBDT05ORUNUSU9OCldJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4gVEhFIFNPRlRXQVJFLgo=",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
       "name": "common",
       "group": "@angular",
       "version": "18.2.7",
-      "bom-ref": "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+      "bom-ref": "@angular/common@18.2.7#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
       "author": "angular",
       "description": "Angular - commonly needed directives and services",
       "licenses": [
@@ -1047,107 +853,10 @@ exports[`integration feature: component evidence generated json file: dist/.well
     },
     {
       "type": "library",
-      "name": "router",
-      "group": "@angular",
-      "version": "18.2.7",
-      "bom-ref": "a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
-      "author": "angular",
-      "description": "Angular - the routing library",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Frouter",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/angular/angular.git#packages/router",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular/tree/main/packages/router",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuZGV2L2xpY2Vuc2UKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "tslib",
-      "version": "2.6.3",
-      "bom-ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
-      "author": "Microsoft Corp.",
-      "description": "Runtime library for TypeScript helper functions",
-      "licenses": [
-        {
-          "license": {
-            "id": "0BSD",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/Microsoft/TypeScript/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/Microsoft/tslib.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://www.typescriptlang.org/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE.txt",
-              "text": {
-                "content": "Q29weXJpZ2h0IChjKSBNaWNyb3NvZnQgQ29ycG9yYXRpb24uDQoNClBlcm1pc3Npb24gdG8gdXNlLCBjb3B5LCBtb2RpZnksIGFuZC9vciBkaXN0cmlidXRlIHRoaXMgc29mdHdhcmUgZm9yIGFueQ0KcHVycG9zZSB3aXRoIG9yIHdpdGhvdXQgZmVlIGlzIGhlcmVieSBncmFudGVkLg0KDQpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiBBTkQgVEhFIEFVVEhPUiBESVNDTEFJTVMgQUxMIFdBUlJBTlRJRVMgV0lUSA0KUkVHQVJEIFRPIFRISVMgU09GVFdBUkUgSU5DTFVESU5HIEFMTCBJTVBMSUVEIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZDQpBTkQgRklUTkVTUy4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUiBCRSBMSUFCTEUgRk9SIEFOWSBTUEVDSUFMLCBESVJFQ1QsDQpJTkRJUkVDVCwgT1IgQ09OU0VRVUVOVElBTCBEQU1BR0VTIE9SIEFOWSBEQU1BR0VTIFdIQVRTT0VWRVIgUkVTVUxUSU5HIEZST00NCkxPU1MgT0YgVVNFLCBEQVRBIE9SIFBST0ZJVFMsIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBORUdMSUdFTkNFIE9SDQpPVEhFUiBUT1JUSU9VUyBBQ1RJT04sIEFSSVNJTkcgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgVVNFIE9SDQpQRVJGT1JNQU5DRSBPRiBUSElTIFNPRlRXQVJFLg==",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
       "name": "core",
       "group": "@angular",
       "version": "18.2.7",
-      "bom-ref": "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+      "bom-ref": "@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
       "author": "angular",
       "description": "Angular - the core framework",
       "licenses": [
@@ -1193,9 +902,156 @@ exports[`integration feature: component evidence generated json file: dist/.well
     },
     {
       "type": "library",
+      "name": "platform-browser",
+      "group": "@angular",
+      "version": "18.2.7",
+      "bom-ref": "@angular/platform-browser@18.2.7#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "author": "angular",
+      "description": "Angular - library for using Angular in a web browser",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/angular/angular.git#packages/platform-browser",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuZGV2L2xpY2Vuc2UKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "router",
+      "group": "@angular",
+      "version": "18.2.7",
+      "bom-ref": "@angular/router@18.2.7#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
+      "author": "angular",
+      "description": "Angular - the routing library",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Frouter",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/angular/angular.git#packages/router",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular/tree/main/packages/router",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuZGV2L2xpY2Vuc2UKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "runtime",
+      "group": "@babel",
+      "version": "7.25.0",
+      "bom-ref": "@babel/runtime@7.25.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
+      "author": "The Babel Team",
+      "description": "babel's modular runtime helpers",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git%23packages%2Fbabel-runtime",
+      "externalReferences": [
+        {
+          "url": "https://github.com/babel/babel/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/babel/babel.git#packages/babel-runtime",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://babel.dev/docs/en/next/babel-runtime",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "TUlUIExpY2Vuc2UKCkNvcHlyaWdodCAoYykgMjAxNC1wcmVzZW50IFNlYmFzdGlhbiBNY0tlbnppZSBhbmQgb3RoZXIgY29udHJpYnV0b3JzCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcKYSBjb3B5IG9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlCiJTb2Z0d2FyZSIpLCB0byBkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcKd2l0aG91dCBsaW1pdGF0aW9uIHRoZSByaWdodHMgdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLApkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3Igc2VsbCBjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8KcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMgZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvCnRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlCmluY2x1ZGVkIGluIGFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsCkVYUFJFU1MgT1IgSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRgpNRVJDSEFOVEFCSUxJVFksIEZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORApOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRSBBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFCkxJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSIExJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04KT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HIEZST00sIE9VVCBPRiBPUiBJTiBDT05ORUNUSU9OCldJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4gVEhFIFNPRlRXQVJFLgo=",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
       "name": "css-loader",
       "version": "7.1.2",
-      "bom-ref": "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
+      "bom-ref": "css-loader@7.1.2#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
       "author": "Tobias Koppers @sokra",
       "description": "css loader module for webpack",
       "licenses": [
@@ -1238,65 +1094,209 @@ exports[`integration feature: component evidence generated json file: dist/.well
           }
         ]
       }
+    },
+    {
+      "type": "library",
+      "name": "rxjs",
+      "version": "7.8.1",
+      "bom-ref": "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+      "author": "Ben Lesh",
+      "description": "Reactive Extensions for modern JavaScript",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ReactiveX/RxJS/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/reactivex/rxjs.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://rxjs.dev",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE.txt",
+              "text": {
+                "content": "ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEFwYWNoZSBMaWNlbnNlCiAgICAgICAgICAgICAgICAgICAgICAgICBWZXJzaW9uIDIuMCwgSmFudWFyeSAyMDA0CiAgICAgICAgICAgICAgICAgICAgICBodHRwOi8vd3d3LmFwYWNoZS5vcmcvbGljZW5zZXMvCgogVEVSTVMgQU5EIENPTkRJVElPTlMgRk9SIFVTRSwgUkVQUk9EVUNUSU9OLCBBTkQgRElTVFJJQlVUSU9OCgogMS4gRGVmaW5pdGlvbnMuCgogICAgIkxpY2Vuc2UiIHNoYWxsIG1lYW4gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIGZvciB1c2UsIHJlcHJvZHVjdGlvbiwKICAgIGFuZCBkaXN0cmlidXRpb24gYXMgZGVmaW5lZCBieSBTZWN0aW9ucyAxIHRocm91Z2ggOSBvZiB0aGlzIGRvY3VtZW50LgoKICAgICJMaWNlbnNvciIgc2hhbGwgbWVhbiB0aGUgY29weXJpZ2h0IG93bmVyIG9yIGVudGl0eSBhdXRob3JpemVkIGJ5CiAgICB0aGUgY29weXJpZ2h0IG93bmVyIHRoYXQgaXMgZ3JhbnRpbmcgdGhlIExpY2Vuc2UuCgogICAgIkxlZ2FsIEVudGl0eSIgc2hhbGwgbWVhbiB0aGUgdW5pb24gb2YgdGhlIGFjdGluZyBlbnRpdHkgYW5kIGFsbAogICAgb3RoZXIgZW50aXRpZXMgdGhhdCBjb250cm9sLCBhcmUgY29udHJvbGxlZCBieSwgb3IgYXJlIHVuZGVyIGNvbW1vbgogICAgY29udHJvbCB3aXRoIHRoYXQgZW50aXR5LiBGb3IgdGhlIHB1cnBvc2VzIG9mIHRoaXMgZGVmaW5pdGlvbiwKICAgICJjb250cm9sIiBtZWFucyAoaSkgdGhlIHBvd2VyLCBkaXJlY3Qgb3IgaW5kaXJlY3QsIHRvIGNhdXNlIHRoZQogICAgZGlyZWN0aW9uIG9yIG1hbmFnZW1lbnQgb2Ygc3VjaCBlbnRpdHksIHdoZXRoZXIgYnkgY29udHJhY3Qgb3IKICAgIG90aGVyd2lzZSwgb3IgKGlpKSBvd25lcnNoaXAgb2YgZmlmdHkgcGVyY2VudCAoNTAlKSBvciBtb3JlIG9mIHRoZQogICAgb3V0c3RhbmRpbmcgc2hhcmVzLCBvciAoaWlpKSBiZW5lZmljaWFsIG93bmVyc2hpcCBvZiBzdWNoIGVudGl0eS4KCiAgICAiWW91IiAob3IgIllvdXIiKSBzaGFsbCBtZWFuIGFuIGluZGl2aWR1YWwgb3IgTGVnYWwgRW50aXR5CiAgICBleGVyY2lzaW5nIHBlcm1pc3Npb25zIGdyYW50ZWQgYnkgdGhpcyBMaWNlbnNlLgoKICAgICJTb3VyY2UiIGZvcm0gc2hhbGwgbWVhbiB0aGUgcHJlZmVycmVkIGZvcm0gZm9yIG1ha2luZyBtb2RpZmljYXRpb25zLAogICAgaW5jbHVkaW5nIGJ1dCBub3QgbGltaXRlZCB0byBzb2Z0d2FyZSBzb3VyY2UgY29kZSwgZG9jdW1lbnRhdGlvbgogICAgc291cmNlLCBhbmQgY29uZmlndXJhdGlvbiBmaWxlcy4KCiAgICAiT2JqZWN0IiBmb3JtIHNoYWxsIG1lYW4gYW55IGZvcm0gcmVzdWx0aW5nIGZyb20gbWVjaGFuaWNhbAogICAgdHJhbnNmb3JtYXRpb24gb3IgdHJhbnNsYXRpb24gb2YgYSBTb3VyY2UgZm9ybSwgaW5jbHVkaW5nIGJ1dAogICAgbm90IGxpbWl0ZWQgdG8gY29tcGlsZWQgb2JqZWN0IGNvZGUsIGdlbmVyYXRlZCBkb2N1bWVudGF0aW9uLAogICAgYW5kIGNvbnZlcnNpb25zIHRvIG90aGVyIG1lZGlhIHR5cGVzLgoKICAgICJXb3JrIiBzaGFsbCBtZWFuIHRoZSB3b3JrIG9mIGF1dGhvcnNoaXAsIHdoZXRoZXIgaW4gU291cmNlIG9yCiAgICBPYmplY3QgZm9ybSwgbWFkZSBhdmFpbGFibGUgdW5kZXIgdGhlIExpY2Vuc2UsIGFzIGluZGljYXRlZCBieSBhCiAgICBjb3B5cmlnaHQgbm90aWNlIHRoYXQgaXMgaW5jbHVkZWQgaW4gb3IgYXR0YWNoZWQgdG8gdGhlIHdvcmsKICAgIChhbiBleGFtcGxlIGlzIHByb3ZpZGVkIGluIHRoZSBBcHBlbmRpeCBiZWxvdykuCgogICAgIkRlcml2YXRpdmUgV29ya3MiIHNoYWxsIG1lYW4gYW55IHdvcmssIHdoZXRoZXIgaW4gU291cmNlIG9yIE9iamVjdAogICAgZm9ybSwgdGhhdCBpcyBiYXNlZCBvbiAob3IgZGVyaXZlZCBmcm9tKSB0aGUgV29yayBhbmQgZm9yIHdoaWNoIHRoZQogICAgZWRpdG9yaWFsIHJldmlzaW9ucywgYW5ub3RhdGlvbnMsIGVsYWJvcmF0aW9ucywgb3Igb3RoZXIgbW9kaWZpY2F0aW9ucwogICAgcmVwcmVzZW50LCBhcyBhIHdob2xlLCBhbiBvcmlnaW5hbCB3b3JrIG9mIGF1dGhvcnNoaXAuIEZvciB0aGUgcHVycG9zZXMKICAgIG9mIHRoaXMgTGljZW5zZSwgRGVyaXZhdGl2ZSBXb3JrcyBzaGFsbCBub3QgaW5jbHVkZSB3b3JrcyB0aGF0IHJlbWFpbgogICAgc2VwYXJhYmxlIGZyb20sIG9yIG1lcmVseSBsaW5rIChvciBiaW5kIGJ5IG5hbWUpIHRvIHRoZSBpbnRlcmZhY2VzIG9mLAogICAgdGhlIFdvcmsgYW5kIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZi4KCiAgICAiQ29udHJpYnV0aW9uIiBzaGFsbCBtZWFuIGFueSB3b3JrIG9mIGF1dGhvcnNoaXAsIGluY2x1ZGluZwogICAgdGhlIG9yaWdpbmFsIHZlcnNpb24gb2YgdGhlIFdvcmsgYW5kIGFueSBtb2RpZmljYXRpb25zIG9yIGFkZGl0aW9ucwogICAgdG8gdGhhdCBXb3JrIG9yIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZiwgdGhhdCBpcyBpbnRlbnRpb25hbGx5CiAgICBzdWJtaXR0ZWQgdG8gTGljZW5zb3IgZm9yIGluY2x1c2lvbiBpbiB0aGUgV29yayBieSB0aGUgY29weXJpZ2h0IG93bmVyCiAgICBvciBieSBhbiBpbmRpdmlkdWFsIG9yIExlZ2FsIEVudGl0eSBhdXRob3JpemVkIHRvIHN1Ym1pdCBvbiBiZWhhbGYgb2YKICAgIHRoZSBjb3B5cmlnaHQgb3duZXIuIEZvciB0aGUgcHVycG9zZXMgb2YgdGhpcyBkZWZpbml0aW9uLCAic3VibWl0dGVkIgogICAgbWVhbnMgYW55IGZvcm0gb2YgZWxlY3Ryb25pYywgdmVyYmFsLCBvciB3cml0dGVuIGNvbW11bmljYXRpb24gc2VudAogICAgdG8gdGhlIExpY2Vuc29yIG9yIGl0cyByZXByZXNlbnRhdGl2ZXMsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQgdG8KICAgIGNvbW11bmljYXRpb24gb24gZWxlY3Ryb25pYyBtYWlsaW5nIGxpc3RzLCBzb3VyY2UgY29kZSBjb250cm9sIHN5c3RlbXMsCiAgICBhbmQgaXNzdWUgdHJhY2tpbmcgc3lzdGVtcyB0aGF0IGFyZSBtYW5hZ2VkIGJ5LCBvciBvbiBiZWhhbGYgb2YsIHRoZQogICAgTGljZW5zb3IgZm9yIHRoZSBwdXJwb3NlIG9mIGRpc2N1c3NpbmcgYW5kIGltcHJvdmluZyB0aGUgV29yaywgYnV0CiAgICBleGNsdWRpbmcgY29tbXVuaWNhdGlvbiB0aGF0IGlzIGNvbnNwaWN1b3VzbHkgbWFya2VkIG9yIG90aGVyd2lzZQogICAgZGVzaWduYXRlZCBpbiB3cml0aW5nIGJ5IHRoZSBjb3B5cmlnaHQgb3duZXIgYXMgIk5vdCBhIENvbnRyaWJ1dGlvbi4iCgogICAgIkNvbnRyaWJ1dG9yIiBzaGFsbCBtZWFuIExpY2Vuc29yIGFuZCBhbnkgaW5kaXZpZHVhbCBvciBMZWdhbCBFbnRpdHkKICAgIG9uIGJlaGFsZiBvZiB3aG9tIGEgQ29udHJpYnV0aW9uIGhhcyBiZWVuIHJlY2VpdmVkIGJ5IExpY2Vuc29yIGFuZAogICAgc3Vic2VxdWVudGx5IGluY29ycG9yYXRlZCB3aXRoaW4gdGhlIFdvcmsuCgogMi4gR3JhbnQgb2YgQ29weXJpZ2h0IExpY2Vuc2UuIFN1YmplY3QgdG8gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mCiAgICB0aGlzIExpY2Vuc2UsIGVhY2ggQ29udHJpYnV0b3IgaGVyZWJ5IGdyYW50cyB0byBZb3UgYSBwZXJwZXR1YWwsCiAgICB3b3JsZHdpZGUsIG5vbi1leGNsdXNpdmUsIG5vLWNoYXJnZSwgcm95YWx0eS1mcmVlLCBpcnJldm9jYWJsZQogICAgY29weXJpZ2h0IGxpY2Vuc2UgdG8gcmVwcm9kdWNlLCBwcmVwYXJlIERlcml2YXRpdmUgV29ya3Mgb2YsCiAgICBwdWJsaWNseSBkaXNwbGF5LCBwdWJsaWNseSBwZXJmb3JtLCBzdWJsaWNlbnNlLCBhbmQgZGlzdHJpYnV0ZSB0aGUKICAgIFdvcmsgYW5kIHN1Y2ggRGVyaXZhdGl2ZSBXb3JrcyBpbiBTb3VyY2Ugb3IgT2JqZWN0IGZvcm0uCgogMy4gR3JhbnQgb2YgUGF0ZW50IExpY2Vuc2UuIFN1YmplY3QgdG8gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mCiAgICB0aGlzIExpY2Vuc2UsIGVhY2ggQ29udHJpYnV0b3IgaGVyZWJ5IGdyYW50cyB0byBZb3UgYSBwZXJwZXR1YWwsCiAgICB3b3JsZHdpZGUsIG5vbi1leGNsdXNpdmUsIG5vLWNoYXJnZSwgcm95YWx0eS1mcmVlLCBpcnJldm9jYWJsZQogICAgKGV4Y2VwdCBhcyBzdGF0ZWQgaW4gdGhpcyBzZWN0aW9uKSBwYXRlbnQgbGljZW5zZSB0byBtYWtlLCBoYXZlIG1hZGUsCiAgICB1c2UsIG9mZmVyIHRvIHNlbGwsIHNlbGwsIGltcG9ydCwgYW5kIG90aGVyd2lzZSB0cmFuc2ZlciB0aGUgV29yaywKICAgIHdoZXJlIHN1Y2ggbGljZW5zZSBhcHBsaWVzIG9ubHkgdG8gdGhvc2UgcGF0ZW50IGNsYWltcyBsaWNlbnNhYmxlCiAgICBieSBzdWNoIENvbnRyaWJ1dG9yIHRoYXQgYXJlIG5lY2Vzc2FyaWx5IGluZnJpbmdlZCBieSB0aGVpcgogICAgQ29udHJpYnV0aW9uKHMpIGFsb25lIG9yIGJ5IGNvbWJpbmF0aW9uIG9mIHRoZWlyIENvbnRyaWJ1dGlvbihzKQogICAgd2l0aCB0aGUgV29yayB0byB3aGljaCBzdWNoIENvbnRyaWJ1dGlvbihzKSB3YXMgc3VibWl0dGVkLiBJZiBZb3UKICAgIGluc3RpdHV0ZSBwYXRlbnQgbGl0aWdhdGlvbiBhZ2FpbnN0IGFueSBlbnRpdHkgKGluY2x1ZGluZyBhCiAgICBjcm9zcy1jbGFpbSBvciBjb3VudGVyY2xhaW0gaW4gYSBsYXdzdWl0KSBhbGxlZ2luZyB0aGF0IHRoZSBXb3JrCiAgICBvciBhIENvbnRyaWJ1dGlvbiBpbmNvcnBvcmF0ZWQgd2l0aGluIHRoZSBXb3JrIGNvbnN0aXR1dGVzIGRpcmVjdAogICAgb3IgY29udHJpYnV0b3J5IHBhdGVudCBpbmZyaW5nZW1lbnQsIHRoZW4gYW55IHBhdGVudCBsaWNlbnNlcwogICAgZ3JhbnRlZCB0byBZb3UgdW5kZXIgdGhpcyBMaWNlbnNlIGZvciB0aGF0IFdvcmsgc2hhbGwgdGVybWluYXRlCiAgICBhcyBvZiB0aGUgZGF0ZSBzdWNoIGxpdGlnYXRpb24gaXMgZmlsZWQuCgogNC4gUmVkaXN0cmlidXRpb24uIFlvdSBtYXkgcmVwcm9kdWNlIGFuZCBkaXN0cmlidXRlIGNvcGllcyBvZiB0aGUKICAgIFdvcmsgb3IgRGVyaXZhdGl2ZSBXb3JrcyB0aGVyZW9mIGluIGFueSBtZWRpdW0sIHdpdGggb3Igd2l0aG91dAogICAgbW9kaWZpY2F0aW9ucywgYW5kIGluIFNvdXJjZSBvciBPYmplY3QgZm9ybSwgcHJvdmlkZWQgdGhhdCBZb3UKICAgIG1lZXQgdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKICAgIChhKSBZb3UgbXVzdCBnaXZlIGFueSBvdGhlciByZWNpcGllbnRzIG9mIHRoZSBXb3JrIG9yCiAgICAgICAgRGVyaXZhdGl2ZSBXb3JrcyBhIGNvcHkgb2YgdGhpcyBMaWNlbnNlOyBhbmQKCiAgICAoYikgWW91IG11c3QgY2F1c2UgYW55IG1vZGlmaWVkIGZpbGVzIHRvIGNhcnJ5IHByb21pbmVudCBub3RpY2VzCiAgICAgICAgc3RhdGluZyB0aGF0IFlvdSBjaGFuZ2VkIHRoZSBmaWxlczsgYW5kCgogICAgKGMpIFlvdSBtdXN0IHJldGFpbiwgaW4gdGhlIFNvdXJjZSBmb3JtIG9mIGFueSBEZXJpdmF0aXZlIFdvcmtzCiAgICAgICAgdGhhdCBZb3UgZGlzdHJpYnV0ZSwgYWxsIGNvcHlyaWdodCwgcGF0ZW50LCB0cmFkZW1hcmssIGFuZAogICAgICAgIGF0dHJpYnV0aW9uIG5vdGljZXMgZnJvbSB0aGUgU291cmNlIGZvcm0gb2YgdGhlIFdvcmssCiAgICAgICAgZXhjbHVkaW5nIHRob3NlIG5vdGljZXMgdGhhdCBkbyBub3QgcGVydGFpbiB0byBhbnkgcGFydCBvZgogICAgICAgIHRoZSBEZXJpdmF0aXZlIFdvcmtzOyBhbmQKCiAgICAoZCkgSWYgdGhlIFdvcmsgaW5jbHVkZXMgYSAiTk9USUNFIiB0ZXh0IGZpbGUgYXMgcGFydCBvZiBpdHMKICAgICAgICBkaXN0cmlidXRpb24sIHRoZW4gYW55IERlcml2YXRpdmUgV29ya3MgdGhhdCBZb3UgZGlzdHJpYnV0ZSBtdXN0CiAgICAgICAgaW5jbHVkZSBhIHJlYWRhYmxlIGNvcHkgb2YgdGhlIGF0dHJpYnV0aW9uIG5vdGljZXMgY29udGFpbmVkCiAgICAgICAgd2l0aGluIHN1Y2ggTk9USUNFIGZpbGUsIGV4Y2x1ZGluZyB0aG9zZSBub3RpY2VzIHRoYXQgZG8gbm90CiAgICAgICAgcGVydGFpbiB0byBhbnkgcGFydCBvZiB0aGUgRGVyaXZhdGl2ZSBXb3JrcywgaW4gYXQgbGVhc3Qgb25lCiAgICAgICAgb2YgdGhlIGZvbGxvd2luZyBwbGFjZXM6IHdpdGhpbiBhIE5PVElDRSB0ZXh0IGZpbGUgZGlzdHJpYnV0ZWQKICAgICAgICBhcyBwYXJ0IG9mIHRoZSBEZXJpdmF0aXZlIFdvcmtzOyB3aXRoaW4gdGhlIFNvdXJjZSBmb3JtIG9yCiAgICAgICAgZG9jdW1lbnRhdGlvbiwgaWYgcHJvdmlkZWQgYWxvbmcgd2l0aCB0aGUgRGVyaXZhdGl2ZSBXb3Jrczsgb3IsCiAgICAgICAgd2l0aGluIGEgZGlzcGxheSBnZW5lcmF0ZWQgYnkgdGhlIERlcml2YXRpdmUgV29ya3MsIGlmIGFuZAogICAgICAgIHdoZXJldmVyIHN1Y2ggdGhpcmQtcGFydHkgbm90aWNlcyBub3JtYWxseSBhcHBlYXIuIFRoZSBjb250ZW50cwogICAgICAgIG9mIHRoZSBOT1RJQ0UgZmlsZSBhcmUgZm9yIGluZm9ybWF0aW9uYWwgcHVycG9zZXMgb25seSBhbmQKICAgICAgICBkbyBub3QgbW9kaWZ5IHRoZSBMaWNlbnNlLiBZb3UgbWF5IGFkZCBZb3VyIG93biBhdHRyaWJ1dGlvbgogICAgICAgIG5vdGljZXMgd2l0aGluIERlcml2YXRpdmUgV29ya3MgdGhhdCBZb3UgZGlzdHJpYnV0ZSwgYWxvbmdzaWRlCiAgICAgICAgb3IgYXMgYW4gYWRkZW5kdW0gdG8gdGhlIE5PVElDRSB0ZXh0IGZyb20gdGhlIFdvcmssIHByb3ZpZGVkCiAgICAgICAgdGhhdCBzdWNoIGFkZGl0aW9uYWwgYXR0cmlidXRpb24gbm90aWNlcyBjYW5ub3QgYmUgY29uc3RydWVkCiAgICAgICAgYXMgbW9kaWZ5aW5nIHRoZSBMaWNlbnNlLgoKICAgIFlvdSBtYXkgYWRkIFlvdXIgb3duIGNvcHlyaWdodCBzdGF0ZW1lbnQgdG8gWW91ciBtb2RpZmljYXRpb25zIGFuZAogICAgbWF5IHByb3ZpZGUgYWRkaXRpb25hbCBvciBkaWZmZXJlbnQgbGljZW5zZSB0ZXJtcyBhbmQgY29uZGl0aW9ucwogICAgZm9yIHVzZSwgcmVwcm9kdWN0aW9uLCBvciBkaXN0cmlidXRpb24gb2YgWW91ciBtb2RpZmljYXRpb25zLCBvcgogICAgZm9yIGFueSBzdWNoIERlcml2YXRpdmUgV29ya3MgYXMgYSB3aG9sZSwgcHJvdmlkZWQgWW91ciB1c2UsCiAgICByZXByb2R1Y3Rpb24sIGFuZCBkaXN0cmlidXRpb24gb2YgdGhlIFdvcmsgb3RoZXJ3aXNlIGNvbXBsaWVzIHdpdGgKICAgIHRoZSBjb25kaXRpb25zIHN0YXRlZCBpbiB0aGlzIExpY2Vuc2UuCgogNS4gU3VibWlzc2lvbiBvZiBDb250cmlidXRpb25zLiBVbmxlc3MgWW91IGV4cGxpY2l0bHkgc3RhdGUgb3RoZXJ3aXNlLAogICAgYW55IENvbnRyaWJ1dGlvbiBpbnRlbnRpb25hbGx5IHN1Ym1pdHRlZCBmb3IgaW5jbHVzaW9uIGluIHRoZSBXb3JrCiAgICBieSBZb3UgdG8gdGhlIExpY2Vuc29yIHNoYWxsIGJlIHVuZGVyIHRoZSB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZgogICAgdGhpcyBMaWNlbnNlLCB3aXRob3V0IGFueSBhZGRpdGlvbmFsIHRlcm1zIG9yIGNvbmRpdGlvbnMuCiAgICBOb3R3aXRoc3RhbmRpbmcgdGhlIGFib3ZlLCBub3RoaW5nIGhlcmVpbiBzaGFsbCBzdXBlcnNlZGUgb3IgbW9kaWZ5CiAgICB0aGUgdGVybXMgb2YgYW55IHNlcGFyYXRlIGxpY2Vuc2UgYWdyZWVtZW50IHlvdSBtYXkgaGF2ZSBleGVjdXRlZAogICAgd2l0aCBMaWNlbnNvciByZWdhcmRpbmcgc3VjaCBDb250cmlidXRpb25zLgoKIDYuIFRyYWRlbWFya3MuIFRoaXMgTGljZW5zZSBkb2VzIG5vdCBncmFudCBwZXJtaXNzaW9uIHRvIHVzZSB0aGUgdHJhZGUKICAgIG5hbWVzLCB0cmFkZW1hcmtzLCBzZXJ2aWNlIG1hcmtzLCBvciBwcm9kdWN0IG5hbWVzIG9mIHRoZSBMaWNlbnNvciwKICAgIGV4Y2VwdCBhcyByZXF1aXJlZCBmb3IgcmVhc29uYWJsZSBhbmQgY3VzdG9tYXJ5IHVzZSBpbiBkZXNjcmliaW5nIHRoZQogICAgb3JpZ2luIG9mIHRoZSBXb3JrIGFuZCByZXByb2R1Y2luZyB0aGUgY29udGVudCBvZiB0aGUgTk9USUNFIGZpbGUuCgogNy4gRGlzY2xhaW1lciBvZiBXYXJyYW50eS4gVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yCiAgICBhZ3JlZWQgdG8gaW4gd3JpdGluZywgTGljZW5zb3IgcHJvdmlkZXMgdGhlIFdvcmsgKGFuZCBlYWNoCiAgICBDb250cmlidXRvciBwcm92aWRlcyBpdHMgQ29udHJpYnV0aW9ucykgb24gYW4gIkFTIElTIiBCQVNJUywKICAgIFdJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvcgogICAgaW1wbGllZCwgaW5jbHVkaW5nLCB3aXRob3V0IGxpbWl0YXRpb24sIGFueSB3YXJyYW50aWVzIG9yIGNvbmRpdGlvbnMKICAgIG9mIFRJVExFLCBOT04tSU5GUklOR0VNRU5ULCBNRVJDSEFOVEFCSUxJVFksIG9yIEZJVE5FU1MgRk9SIEEKICAgIFBBUlRJQ1VMQVIgUFVSUE9TRS4gWW91IGFyZSBzb2xlbHkgcmVzcG9uc2libGUgZm9yIGRldGVybWluaW5nIHRoZQogICAgYXBwcm9wcmlhdGVuZXNzIG9mIHVzaW5nIG9yIHJlZGlzdHJpYnV0aW5nIHRoZSBXb3JrIGFuZCBhc3N1bWUgYW55CiAgICByaXNrcyBhc3NvY2lhdGVkIHdpdGggWW91ciBleGVyY2lzZSBvZiBwZXJtaXNzaW9ucyB1bmRlciB0aGlzIExpY2Vuc2UuCgogOC4gTGltaXRhdGlvbiBvZiBMaWFiaWxpdHkuIEluIG5vIGV2ZW50IGFuZCB1bmRlciBubyBsZWdhbCB0aGVvcnksCiAgICB3aGV0aGVyIGluIHRvcnQgKGluY2x1ZGluZyBuZWdsaWdlbmNlKSwgY29udHJhY3QsIG9yIG90aGVyd2lzZSwKICAgIHVubGVzcyByZXF1aXJlZCBieSBhcHBsaWNhYmxlIGxhdyAoc3VjaCBhcyBkZWxpYmVyYXRlIGFuZCBncm9zc2x5CiAgICBuZWdsaWdlbnQgYWN0cykgb3IgYWdyZWVkIHRvIGluIHdyaXRpbmcsIHNoYWxsIGFueSBDb250cmlidXRvciBiZQogICAgbGlhYmxlIHRvIFlvdSBmb3IgZGFtYWdlcywgaW5jbHVkaW5nIGFueSBkaXJlY3QsIGluZGlyZWN0LCBzcGVjaWFsLAogICAgaW5jaWRlbnRhbCwgb3IgY29uc2VxdWVudGlhbCBkYW1hZ2VzIG9mIGFueSBjaGFyYWN0ZXIgYXJpc2luZyBhcyBhCiAgICByZXN1bHQgb2YgdGhpcyBMaWNlbnNlIG9yIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0byB1c2UgdGhlCiAgICBXb3JrIChpbmNsdWRpbmcgYnV0IG5vdCBsaW1pdGVkIHRvIGRhbWFnZXMgZm9yIGxvc3Mgb2YgZ29vZHdpbGwsCiAgICB3b3JrIHN0b3BwYWdlLCBjb21wdXRlciBmYWlsdXJlIG9yIG1hbGZ1bmN0aW9uLCBvciBhbnkgYW5kIGFsbAogICAgb3RoZXIgY29tbWVyY2lhbCBkYW1hZ2VzIG9yIGxvc3NlcyksIGV2ZW4gaWYgc3VjaCBDb250cmlidXRvcgogICAgaGFzIGJlZW4gYWR2aXNlZCBvZiB0aGUgcG9zc2liaWxpdHkgb2Ygc3VjaCBkYW1hZ2VzLgoKIDkuIEFjY2VwdGluZyBXYXJyYW50eSBvciBBZGRpdGlvbmFsIExpYWJpbGl0eS4gV2hpbGUgcmVkaXN0cmlidXRpbmcKICAgIHRoZSBXb3JrIG9yIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZiwgWW91IG1heSBjaG9vc2UgdG8gb2ZmZXIsCiAgICBhbmQgY2hhcmdlIGEgZmVlIGZvciwgYWNjZXB0YW5jZSBvZiBzdXBwb3J0LCB3YXJyYW50eSwgaW5kZW1uaXR5LAogICAgb3Igb3RoZXIgbGlhYmlsaXR5IG9ibGlnYXRpb25zIGFuZC9vciByaWdodHMgY29uc2lzdGVudCB3aXRoIHRoaXMKICAgIExpY2Vuc2UuIEhvd2V2ZXIsIGluIGFjY2VwdGluZyBzdWNoIG9ibGlnYXRpb25zLCBZb3UgbWF5IGFjdCBvbmx5CiAgICBvbiBZb3VyIG93biBiZWhhbGYgYW5kIG9uIFlvdXIgc29sZSByZXNwb25zaWJpbGl0eSwgbm90IG9uIGJlaGFsZgogICAgb2YgYW55IG90aGVyIENvbnRyaWJ1dG9yLCBhbmQgb25seSBpZiBZb3UgYWdyZWUgdG8gaW5kZW1uaWZ5LAogICAgZGVmZW5kLCBhbmQgaG9sZCBlYWNoIENvbnRyaWJ1dG9yIGhhcm1sZXNzIGZvciBhbnkgbGlhYmlsaXR5CiAgICBpbmN1cnJlZCBieSwgb3IgY2xhaW1zIGFzc2VydGVkIGFnYWluc3QsIHN1Y2ggQ29udHJpYnV0b3IgYnkgcmVhc29uCiAgICBvZiB5b3VyIGFjY2VwdGluZyBhbnkgc3VjaCB3YXJyYW50eSBvciBhZGRpdGlvbmFsIGxpYWJpbGl0eS4KCiBFTkQgT0YgVEVSTVMgQU5EIENPTkRJVElPTlMKCiBBUFBFTkRJWDogSG93IHRvIGFwcGx5IHRoZSBBcGFjaGUgTGljZW5zZSB0byB5b3VyIHdvcmsuCgogICAgVG8gYXBwbHkgdGhlIEFwYWNoZSBMaWNlbnNlIHRvIHlvdXIgd29yaywgYXR0YWNoIHRoZSBmb2xsb3dpbmcKICAgIGJvaWxlcnBsYXRlIG5vdGljZSwgd2l0aCB0aGUgZmllbGRzIGVuY2xvc2VkIGJ5IGJyYWNrZXRzICJbXSIKICAgIHJlcGxhY2VkIHdpdGggeW91ciBvd24gaWRlbnRpZnlpbmcgaW5mb3JtYXRpb24uIChEb24ndCBpbmNsdWRlCiAgICB0aGUgYnJhY2tldHMhKSAgVGhlIHRleHQgc2hvdWxkIGJlIGVuY2xvc2VkIGluIHRoZSBhcHByb3ByaWF0ZQogICAgY29tbWVudCBzeW50YXggZm9yIHRoZSBmaWxlIGZvcm1hdC4gV2UgYWxzbyByZWNvbW1lbmQgdGhhdCBhCiAgICBmaWxlIG9yIGNsYXNzIG5hbWUgYW5kIGRlc2NyaXB0aW9uIG9mIHB1cnBvc2UgYmUgaW5jbHVkZWQgb24gdGhlCiAgICBzYW1lICJwcmludGVkIHBhZ2UiIGFzIHRoZSBjb3B5cmlnaHQgbm90aWNlIGZvciBlYXNpZXIKICAgIGlkZW50aWZpY2F0aW9uIHdpdGhpbiB0aGlyZC1wYXJ0eSBhcmNoaXZlcy4KCiBDb3B5cmlnaHQgKGMpIDIwMTUtMjAxOCBHb29nbGUsIEluYy4sIE5ldGZsaXgsIEluYy4sIE1pY3Jvc29mdCBDb3JwLiBhbmQgY29udHJpYnV0b3JzCgogTGljZW5zZWQgdW5kZXIgdGhlIEFwYWNoZSBMaWNlbnNlLCBWZXJzaW9uIDIuMCAodGhlICJMaWNlbnNlIik7CiB5b3UgbWF5IG5vdCB1c2UgdGhpcyBmaWxlIGV4Y2VwdCBpbiBjb21wbGlhbmNlIHdpdGggdGhlIExpY2Vuc2UuCiBZb3UgbWF5IG9idGFpbiBhIGNvcHkgb2YgdGhlIExpY2Vuc2UgYXQKCiAgICAgaHR0cDovL3d3dy5hcGFjaGUub3JnL2xpY2Vuc2VzL0xJQ0VOU0UtMi4wCgogVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yIGFncmVlZCB0byBpbiB3cml0aW5nLCBzb2Z0d2FyZQogZGlzdHJpYnV0ZWQgdW5kZXIgdGhlIExpY2Vuc2UgaXMgZGlzdHJpYnV0ZWQgb24gYW4gIkFTIElTIiBCQVNJUywKIFdJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvciBpbXBsaWVkLgogU2VlIHRoZSBMaWNlbnNlIGZvciB0aGUgc3BlY2lmaWMgbGFuZ3VhZ2UgZ292ZXJuaW5nIHBlcm1pc3Npb25zIGFuZAogbGltaXRhdGlvbnMgdW5kZXIgdGhlIExpY2Vuc2UuCiAK",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "tslib",
+      "version": "2.6.3",
+      "bom-ref": "tslib@2.6.3#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
+      "author": "Microsoft Corp.",
+      "description": "Runtime library for TypeScript helper functions",
+      "licenses": [
+        {
+          "license": {
+            "id": "0BSD",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/Microsoft/TypeScript/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/Microsoft/tslib.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://www.typescriptlang.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE.txt",
+              "text": {
+                "content": "Q29weXJpZ2h0IChjKSBNaWNyb3NvZnQgQ29ycG9yYXRpb24uDQoNClBlcm1pc3Npb24gdG8gdXNlLCBjb3B5LCBtb2RpZnksIGFuZC9vciBkaXN0cmlidXRlIHRoaXMgc29mdHdhcmUgZm9yIGFueQ0KcHVycG9zZSB3aXRoIG9yIHdpdGhvdXQgZmVlIGlzIGhlcmVieSBncmFudGVkLg0KDQpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiBBTkQgVEhFIEFVVEhPUiBESVNDTEFJTVMgQUxMIFdBUlJBTlRJRVMgV0lUSA0KUkVHQVJEIFRPIFRISVMgU09GVFdBUkUgSU5DTFVESU5HIEFMTCBJTVBMSUVEIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZDQpBTkQgRklUTkVTUy4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUiBCRSBMSUFCTEUgRk9SIEFOWSBTUEVDSUFMLCBESVJFQ1QsDQpJTkRJUkVDVCwgT1IgQ09OU0VRVUVOVElBTCBEQU1BR0VTIE9SIEFOWSBEQU1BR0VTIFdIQVRTT0VWRVIgUkVTVUxUSU5HIEZST00NCkxPU1MgT0YgVVNFLCBEQVRBIE9SIFBST0ZJVFMsIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBORUdMSUdFTkNFIE9SDQpPVEhFUiBUT1JUSU9VUyBBQ1RJT04sIEFSSVNJTkcgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgVVNFIE9SDQpQRVJGT1JNQU5DRSBPRiBUSElTIFNPRlRXQVJFLg==",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "zone.js",
+      "version": "0.14.10",
+      "bom-ref": "zone.js@0.14.10#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
+      "author": "Brian Ford",
+      "description": "Zones for JavaScript",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/zone.js@0.14.10?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/angular/angular.git#packages/zone.js",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuaW8vbGljZW5zZQoKUGVybWlzc2lvbiBpcyBoZXJlYnkgZ3JhbnRlZCwgZnJlZSBvZiBjaGFyZ2UsIHRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weQpvZiB0aGlzIHNvZnR3YXJlIGFuZCBhc3NvY2lhdGVkIGRvY3VtZW50YXRpb24gZmlsZXMgKHRoZSAiU29mdHdhcmUiKSwgdG8gZGVhbAppbiB0aGUgU29mdHdhcmUgd2l0aG91dCByZXN0cmljdGlvbiwgaW5jbHVkaW5nIHdpdGhvdXQgbGltaXRhdGlvbiB0aGUgcmlnaHRzCnRvIHVzZSwgY29weSwgbW9kaWZ5LCBtZXJnZSwgcHVibGlzaCwgZGlzdHJpYnV0ZSwgc3VibGljZW5zZSwgYW5kL29yIHNlbGwKY29waWVzIG9mIHRoZSBTb2Z0d2FyZSwgYW5kIHRvIHBlcm1pdCBwZXJzb25zIHRvIHdob20gdGhlIFNvZnR3YXJlIGlzCmZ1cm5pc2hlZCB0byBkbyBzbywgc3ViamVjdCB0byB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnM6CgpUaGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBzaGFsbCBiZSBpbmNsdWRlZCBpbgphbGwgY29waWVzIG9yIHN1YnN0YW50aWFsIHBvcnRpb25zIG9mIHRoZSBTb2Z0d2FyZS4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiLCBXSVRIT1VUIFdBUlJBTlRZIE9GIEFOWSBLSU5ELCBFWFBSRVNTIE9SCklNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZLApGSVRORVNTIEZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRSBBTkQgTk9OSU5GUklOR0VNRU5ULiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUKQVVUSE9SUyBPUiBDT1BZUklHSFQgSE9MREVSUyBCRSBMSUFCTEUgRk9SIEFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUgpMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBUT1JUIE9SIE9USEVSV0lTRSwgQVJJU0lORyBGUk9NLApPVVQgT0YgT1IgSU4gQ09OTkVDVElPTiBXSVRIIFRIRSBTT0ZUV0FSRSBPUiBUSEUgVVNFIE9SIE9USEVSIERFQUxJTkdTIElOClRIRSBTT0ZUV0FSRS4K",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
     }
   ],
   "dependencies": [
     {
-      "ref": "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "ref": "@angular/common@18.2.7#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
       "dependsOn": [
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@babel/runtime@7.25.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
+        "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
-    },
-    {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
       "dependsOn": [
-        "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-        "a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
-        "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
+        "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+      "ref": "@angular/platform-browser@18.2.7#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
       "dependsOn": [
-        "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+        "@angular/common@18.2.7#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
       ]
     },
     {
-      "ref": "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"
-    },
-    {
-      "ref": "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+      "ref": "@angular/router@18.2.7#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
       "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/common@18.2.7#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/platform-browser@18.2.7#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+        "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
+      "ref": "@babel/runtime@7.25.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"
+    },
+    {
+      "ref": "@cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/platform-browser@18.2.7#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+        "@angular/router@18.2.7#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
+        "css-loader@7.1.2#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
       ]
     },
     {
-      "ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+      "ref": "css-loader@7.1.2#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
     },
     {
-      "ref": "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+      "ref": "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
       "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
+        "tslib@2.6.3#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
       ]
     },
     {
-      "ref": "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
+      "ref": "tslib@2.6.3#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+    },
+    {
+      "ref": "zone.js@0.14.10#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
     }
   ]
 }"
@@ -1371,7 +1371,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
         </component>
       </components>
     </tools>
-    <component type="application" bom-ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+    <component type="application" bom-ref="@cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
       <author>Jan Kowalleck</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>feature-issue676</name>
@@ -1412,145 +1412,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378">
-      <author>angular</author>
-      <group>@angular</group>
-      <name>platform-browser</name>
-      <version>18.2.7</version>
-      <description>Angular - library for using Angular in a web browser</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/angular/angular/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/angular/angular.git#packages/platform-browser</url>
-          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/angular/angular#readme</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-      <evidence>
-        <licenses>
-          <license>
-            <name>file: LICENSE</name>
-            <text content-type="text/plain" encoding="base64">VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuZGV2L2xpY2Vuc2UKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==</text>
-          </license>
-        </licenses>
-      </evidence>
-    </component>
-    <component type="library" bom-ref="5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f">
-      <author>Brian Ford</author>
-      <name>zone.js</name>
-      <version>0.14.10</version>
-      <description>Zones for JavaScript</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/zone.js@0.14.10?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/angular/angular/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git://github.com/angular/angular.git#packages/zone.js</url>
-          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/angular/angular#readme</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-      <evidence>
-        <licenses>
-          <license>
-            <name>file: LICENSE</name>
-            <text content-type="text/plain" encoding="base64">VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuaW8vbGljZW5zZQoKUGVybWlzc2lvbiBpcyBoZXJlYnkgZ3JhbnRlZCwgZnJlZSBvZiBjaGFyZ2UsIHRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weQpvZiB0aGlzIHNvZnR3YXJlIGFuZCBhc3NvY2lhdGVkIGRvY3VtZW50YXRpb24gZmlsZXMgKHRoZSAiU29mdHdhcmUiKSwgdG8gZGVhbAppbiB0aGUgU29mdHdhcmUgd2l0aG91dCByZXN0cmljdGlvbiwgaW5jbHVkaW5nIHdpdGhvdXQgbGltaXRhdGlvbiB0aGUgcmlnaHRzCnRvIHVzZSwgY29weSwgbW9kaWZ5LCBtZXJnZSwgcHVibGlzaCwgZGlzdHJpYnV0ZSwgc3VibGljZW5zZSwgYW5kL29yIHNlbGwKY29waWVzIG9mIHRoZSBTb2Z0d2FyZSwgYW5kIHRvIHBlcm1pdCBwZXJzb25zIHRvIHdob20gdGhlIFNvZnR3YXJlIGlzCmZ1cm5pc2hlZCB0byBkbyBzbywgc3ViamVjdCB0byB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnM6CgpUaGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBzaGFsbCBiZSBpbmNsdWRlZCBpbgphbGwgY29waWVzIG9yIHN1YnN0YW50aWFsIHBvcnRpb25zIG9mIHRoZSBTb2Z0d2FyZS4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiLCBXSVRIT1VUIFdBUlJBTlRZIE9GIEFOWSBLSU5ELCBFWFBSRVNTIE9SCklNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZLApGSVRORVNTIEZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRSBBTkQgTk9OSU5GUklOR0VNRU5ULiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUKQVVUSE9SUyBPUiBDT1BZUklHSFQgSE9MREVSUyBCRSBMSUFCTEUgRk9SIEFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUgpMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBUT1JUIE9SIE9USEVSV0lTRSwgQVJJU0lORyBGUk9NLApPVVQgT0YgT1IgSU4gQ09OTkVDVElPTiBXSVRIIFRIRSBTT0ZUV0FSRSBPUiBUSEUgVVNFIE9SIE9USEVSIERFQUxJTkdTIElOClRIRSBTT0ZUV0FSRS4K</text>
-          </license>
-        </licenses>
-      </evidence>
-    </component>
-    <component type="library" bom-ref="964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a">
-      <author>Ben Lesh</author>
-      <name>rxjs</name>
-      <version>7.8.1</version>
-      <description>Reactive Extensions for modern JavaScript</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>Apache-2.0</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/ReactiveX/RxJS/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/reactivex/rxjs.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://rxjs.dev</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-      <evidence>
-        <licenses>
-          <license>
-            <name>file: LICENSE.txt</name>
-            <text content-type="text/plain" encoding="base64">ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEFwYWNoZSBMaWNlbnNlCiAgICAgICAgICAgICAgICAgICAgICAgICBWZXJzaW9uIDIuMCwgSmFudWFyeSAyMDA0CiAgICAgICAgICAgICAgICAgICAgICBodHRwOi8vd3d3LmFwYWNoZS5vcmcvbGljZW5zZXMvCgogVEVSTVMgQU5EIENPTkRJVElPTlMgRk9SIFVTRSwgUkVQUk9EVUNUSU9OLCBBTkQgRElTVFJJQlVUSU9OCgogMS4gRGVmaW5pdGlvbnMuCgogICAgIkxpY2Vuc2UiIHNoYWxsIG1lYW4gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIGZvciB1c2UsIHJlcHJvZHVjdGlvbiwKICAgIGFuZCBkaXN0cmlidXRpb24gYXMgZGVmaW5lZCBieSBTZWN0aW9ucyAxIHRocm91Z2ggOSBvZiB0aGlzIGRvY3VtZW50LgoKICAgICJMaWNlbnNvciIgc2hhbGwgbWVhbiB0aGUgY29weXJpZ2h0IG93bmVyIG9yIGVudGl0eSBhdXRob3JpemVkIGJ5CiAgICB0aGUgY29weXJpZ2h0IG93bmVyIHRoYXQgaXMgZ3JhbnRpbmcgdGhlIExpY2Vuc2UuCgogICAgIkxlZ2FsIEVudGl0eSIgc2hhbGwgbWVhbiB0aGUgdW5pb24gb2YgdGhlIGFjdGluZyBlbnRpdHkgYW5kIGFsbAogICAgb3RoZXIgZW50aXRpZXMgdGhhdCBjb250cm9sLCBhcmUgY29udHJvbGxlZCBieSwgb3IgYXJlIHVuZGVyIGNvbW1vbgogICAgY29udHJvbCB3aXRoIHRoYXQgZW50aXR5LiBGb3IgdGhlIHB1cnBvc2VzIG9mIHRoaXMgZGVmaW5pdGlvbiwKICAgICJjb250cm9sIiBtZWFucyAoaSkgdGhlIHBvd2VyLCBkaXJlY3Qgb3IgaW5kaXJlY3QsIHRvIGNhdXNlIHRoZQogICAgZGlyZWN0aW9uIG9yIG1hbmFnZW1lbnQgb2Ygc3VjaCBlbnRpdHksIHdoZXRoZXIgYnkgY29udHJhY3Qgb3IKICAgIG90aGVyd2lzZSwgb3IgKGlpKSBvd25lcnNoaXAgb2YgZmlmdHkgcGVyY2VudCAoNTAlKSBvciBtb3JlIG9mIHRoZQogICAgb3V0c3RhbmRpbmcgc2hhcmVzLCBvciAoaWlpKSBiZW5lZmljaWFsIG93bmVyc2hpcCBvZiBzdWNoIGVudGl0eS4KCiAgICAiWW91IiAob3IgIllvdXIiKSBzaGFsbCBtZWFuIGFuIGluZGl2aWR1YWwgb3IgTGVnYWwgRW50aXR5CiAgICBleGVyY2lzaW5nIHBlcm1pc3Npb25zIGdyYW50ZWQgYnkgdGhpcyBMaWNlbnNlLgoKICAgICJTb3VyY2UiIGZvcm0gc2hhbGwgbWVhbiB0aGUgcHJlZmVycmVkIGZvcm0gZm9yIG1ha2luZyBtb2RpZmljYXRpb25zLAogICAgaW5jbHVkaW5nIGJ1dCBub3QgbGltaXRlZCB0byBzb2Z0d2FyZSBzb3VyY2UgY29kZSwgZG9jdW1lbnRhdGlvbgogICAgc291cmNlLCBhbmQgY29uZmlndXJhdGlvbiBmaWxlcy4KCiAgICAiT2JqZWN0IiBmb3JtIHNoYWxsIG1lYW4gYW55IGZvcm0gcmVzdWx0aW5nIGZyb20gbWVjaGFuaWNhbAogICAgdHJhbnNmb3JtYXRpb24gb3IgdHJhbnNsYXRpb24gb2YgYSBTb3VyY2UgZm9ybSwgaW5jbHVkaW5nIGJ1dAogICAgbm90IGxpbWl0ZWQgdG8gY29tcGlsZWQgb2JqZWN0IGNvZGUsIGdlbmVyYXRlZCBkb2N1bWVudGF0aW9uLAogICAgYW5kIGNvbnZlcnNpb25zIHRvIG90aGVyIG1lZGlhIHR5cGVzLgoKICAgICJXb3JrIiBzaGFsbCBtZWFuIHRoZSB3b3JrIG9mIGF1dGhvcnNoaXAsIHdoZXRoZXIgaW4gU291cmNlIG9yCiAgICBPYmplY3QgZm9ybSwgbWFkZSBhdmFpbGFibGUgdW5kZXIgdGhlIExpY2Vuc2UsIGFzIGluZGljYXRlZCBieSBhCiAgICBjb3B5cmlnaHQgbm90aWNlIHRoYXQgaXMgaW5jbHVkZWQgaW4gb3IgYXR0YWNoZWQgdG8gdGhlIHdvcmsKICAgIChhbiBleGFtcGxlIGlzIHByb3ZpZGVkIGluIHRoZSBBcHBlbmRpeCBiZWxvdykuCgogICAgIkRlcml2YXRpdmUgV29ya3MiIHNoYWxsIG1lYW4gYW55IHdvcmssIHdoZXRoZXIgaW4gU291cmNlIG9yIE9iamVjdAogICAgZm9ybSwgdGhhdCBpcyBiYXNlZCBvbiAob3IgZGVyaXZlZCBmcm9tKSB0aGUgV29yayBhbmQgZm9yIHdoaWNoIHRoZQogICAgZWRpdG9yaWFsIHJldmlzaW9ucywgYW5ub3RhdGlvbnMsIGVsYWJvcmF0aW9ucywgb3Igb3RoZXIgbW9kaWZpY2F0aW9ucwogICAgcmVwcmVzZW50LCBhcyBhIHdob2xlLCBhbiBvcmlnaW5hbCB3b3JrIG9mIGF1dGhvcnNoaXAuIEZvciB0aGUgcHVycG9zZXMKICAgIG9mIHRoaXMgTGljZW5zZSwgRGVyaXZhdGl2ZSBXb3JrcyBzaGFsbCBub3QgaW5jbHVkZSB3b3JrcyB0aGF0IHJlbWFpbgogICAgc2VwYXJhYmxlIGZyb20sIG9yIG1lcmVseSBsaW5rIChvciBiaW5kIGJ5IG5hbWUpIHRvIHRoZSBpbnRlcmZhY2VzIG9mLAogICAgdGhlIFdvcmsgYW5kIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZi4KCiAgICAiQ29udHJpYnV0aW9uIiBzaGFsbCBtZWFuIGFueSB3b3JrIG9mIGF1dGhvcnNoaXAsIGluY2x1ZGluZwogICAgdGhlIG9yaWdpbmFsIHZlcnNpb24gb2YgdGhlIFdvcmsgYW5kIGFueSBtb2RpZmljYXRpb25zIG9yIGFkZGl0aW9ucwogICAgdG8gdGhhdCBXb3JrIG9yIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZiwgdGhhdCBpcyBpbnRlbnRpb25hbGx5CiAgICBzdWJtaXR0ZWQgdG8gTGljZW5zb3IgZm9yIGluY2x1c2lvbiBpbiB0aGUgV29yayBieSB0aGUgY29weXJpZ2h0IG93bmVyCiAgICBvciBieSBhbiBpbmRpdmlkdWFsIG9yIExlZ2FsIEVudGl0eSBhdXRob3JpemVkIHRvIHN1Ym1pdCBvbiBiZWhhbGYgb2YKICAgIHRoZSBjb3B5cmlnaHQgb3duZXIuIEZvciB0aGUgcHVycG9zZXMgb2YgdGhpcyBkZWZpbml0aW9uLCAic3VibWl0dGVkIgogICAgbWVhbnMgYW55IGZvcm0gb2YgZWxlY3Ryb25pYywgdmVyYmFsLCBvciB3cml0dGVuIGNvbW11bmljYXRpb24gc2VudAogICAgdG8gdGhlIExpY2Vuc29yIG9yIGl0cyByZXByZXNlbnRhdGl2ZXMsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQgdG8KICAgIGNvbW11bmljYXRpb24gb24gZWxlY3Ryb25pYyBtYWlsaW5nIGxpc3RzLCBzb3VyY2UgY29kZSBjb250cm9sIHN5c3RlbXMsCiAgICBhbmQgaXNzdWUgdHJhY2tpbmcgc3lzdGVtcyB0aGF0IGFyZSBtYW5hZ2VkIGJ5LCBvciBvbiBiZWhhbGYgb2YsIHRoZQogICAgTGljZW5zb3IgZm9yIHRoZSBwdXJwb3NlIG9mIGRpc2N1c3NpbmcgYW5kIGltcHJvdmluZyB0aGUgV29yaywgYnV0CiAgICBleGNsdWRpbmcgY29tbXVuaWNhdGlvbiB0aGF0IGlzIGNvbnNwaWN1b3VzbHkgbWFya2VkIG9yIG90aGVyd2lzZQogICAgZGVzaWduYXRlZCBpbiB3cml0aW5nIGJ5IHRoZSBjb3B5cmlnaHQgb3duZXIgYXMgIk5vdCBhIENvbnRyaWJ1dGlvbi4iCgogICAgIkNvbnRyaWJ1dG9yIiBzaGFsbCBtZWFuIExpY2Vuc29yIGFuZCBhbnkgaW5kaXZpZHVhbCBvciBMZWdhbCBFbnRpdHkKICAgIG9uIGJlaGFsZiBvZiB3aG9tIGEgQ29udHJpYnV0aW9uIGhhcyBiZWVuIHJlY2VpdmVkIGJ5IExpY2Vuc29yIGFuZAogICAgc3Vic2VxdWVudGx5IGluY29ycG9yYXRlZCB3aXRoaW4gdGhlIFdvcmsuCgogMi4gR3JhbnQgb2YgQ29weXJpZ2h0IExpY2Vuc2UuIFN1YmplY3QgdG8gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mCiAgICB0aGlzIExpY2Vuc2UsIGVhY2ggQ29udHJpYnV0b3IgaGVyZWJ5IGdyYW50cyB0byBZb3UgYSBwZXJwZXR1YWwsCiAgICB3b3JsZHdpZGUsIG5vbi1leGNsdXNpdmUsIG5vLWNoYXJnZSwgcm95YWx0eS1mcmVlLCBpcnJldm9jYWJsZQogICAgY29weXJpZ2h0IGxpY2Vuc2UgdG8gcmVwcm9kdWNlLCBwcmVwYXJlIERlcml2YXRpdmUgV29ya3Mgb2YsCiAgICBwdWJsaWNseSBkaXNwbGF5LCBwdWJsaWNseSBwZXJmb3JtLCBzdWJsaWNlbnNlLCBhbmQgZGlzdHJpYnV0ZSB0aGUKICAgIFdvcmsgYW5kIHN1Y2ggRGVyaXZhdGl2ZSBXb3JrcyBpbiBTb3VyY2Ugb3IgT2JqZWN0IGZvcm0uCgogMy4gR3JhbnQgb2YgUGF0ZW50IExpY2Vuc2UuIFN1YmplY3QgdG8gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mCiAgICB0aGlzIExpY2Vuc2UsIGVhY2ggQ29udHJpYnV0b3IgaGVyZWJ5IGdyYW50cyB0byBZb3UgYSBwZXJwZXR1YWwsCiAgICB3b3JsZHdpZGUsIG5vbi1leGNsdXNpdmUsIG5vLWNoYXJnZSwgcm95YWx0eS1mcmVlLCBpcnJldm9jYWJsZQogICAgKGV4Y2VwdCBhcyBzdGF0ZWQgaW4gdGhpcyBzZWN0aW9uKSBwYXRlbnQgbGljZW5zZSB0byBtYWtlLCBoYXZlIG1hZGUsCiAgICB1c2UsIG9mZmVyIHRvIHNlbGwsIHNlbGwsIGltcG9ydCwgYW5kIG90aGVyd2lzZSB0cmFuc2ZlciB0aGUgV29yaywKICAgIHdoZXJlIHN1Y2ggbGljZW5zZSBhcHBsaWVzIG9ubHkgdG8gdGhvc2UgcGF0ZW50IGNsYWltcyBsaWNlbnNhYmxlCiAgICBieSBzdWNoIENvbnRyaWJ1dG9yIHRoYXQgYXJlIG5lY2Vzc2FyaWx5IGluZnJpbmdlZCBieSB0aGVpcgogICAgQ29udHJpYnV0aW9uKHMpIGFsb25lIG9yIGJ5IGNvbWJpbmF0aW9uIG9mIHRoZWlyIENvbnRyaWJ1dGlvbihzKQogICAgd2l0aCB0aGUgV29yayB0byB3aGljaCBzdWNoIENvbnRyaWJ1dGlvbihzKSB3YXMgc3VibWl0dGVkLiBJZiBZb3UKICAgIGluc3RpdHV0ZSBwYXRlbnQgbGl0aWdhdGlvbiBhZ2FpbnN0IGFueSBlbnRpdHkgKGluY2x1ZGluZyBhCiAgICBjcm9zcy1jbGFpbSBvciBjb3VudGVyY2xhaW0gaW4gYSBsYXdzdWl0KSBhbGxlZ2luZyB0aGF0IHRoZSBXb3JrCiAgICBvciBhIENvbnRyaWJ1dGlvbiBpbmNvcnBvcmF0ZWQgd2l0aGluIHRoZSBXb3JrIGNvbnN0aXR1dGVzIGRpcmVjdAogICAgb3IgY29udHJpYnV0b3J5IHBhdGVudCBpbmZyaW5nZW1lbnQsIHRoZW4gYW55IHBhdGVudCBsaWNlbnNlcwogICAgZ3JhbnRlZCB0byBZb3UgdW5kZXIgdGhpcyBMaWNlbnNlIGZvciB0aGF0IFdvcmsgc2hhbGwgdGVybWluYXRlCiAgICBhcyBvZiB0aGUgZGF0ZSBzdWNoIGxpdGlnYXRpb24gaXMgZmlsZWQuCgogNC4gUmVkaXN0cmlidXRpb24uIFlvdSBtYXkgcmVwcm9kdWNlIGFuZCBkaXN0cmlidXRlIGNvcGllcyBvZiB0aGUKICAgIFdvcmsgb3IgRGVyaXZhdGl2ZSBXb3JrcyB0aGVyZW9mIGluIGFueSBtZWRpdW0sIHdpdGggb3Igd2l0aG91dAogICAgbW9kaWZpY2F0aW9ucywgYW5kIGluIFNvdXJjZSBvciBPYmplY3QgZm9ybSwgcHJvdmlkZWQgdGhhdCBZb3UKICAgIG1lZXQgdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKICAgIChhKSBZb3UgbXVzdCBnaXZlIGFueSBvdGhlciByZWNpcGllbnRzIG9mIHRoZSBXb3JrIG9yCiAgICAgICAgRGVyaXZhdGl2ZSBXb3JrcyBhIGNvcHkgb2YgdGhpcyBMaWNlbnNlOyBhbmQKCiAgICAoYikgWW91IG11c3QgY2F1c2UgYW55IG1vZGlmaWVkIGZpbGVzIHRvIGNhcnJ5IHByb21pbmVudCBub3RpY2VzCiAgICAgICAgc3RhdGluZyB0aGF0IFlvdSBjaGFuZ2VkIHRoZSBmaWxlczsgYW5kCgogICAgKGMpIFlvdSBtdXN0IHJldGFpbiwgaW4gdGhlIFNvdXJjZSBmb3JtIG9mIGFueSBEZXJpdmF0aXZlIFdvcmtzCiAgICAgICAgdGhhdCBZb3UgZGlzdHJpYnV0ZSwgYWxsIGNvcHlyaWdodCwgcGF0ZW50LCB0cmFkZW1hcmssIGFuZAogICAgICAgIGF0dHJpYnV0aW9uIG5vdGljZXMgZnJvbSB0aGUgU291cmNlIGZvcm0gb2YgdGhlIFdvcmssCiAgICAgICAgZXhjbHVkaW5nIHRob3NlIG5vdGljZXMgdGhhdCBkbyBub3QgcGVydGFpbiB0byBhbnkgcGFydCBvZgogICAgICAgIHRoZSBEZXJpdmF0aXZlIFdvcmtzOyBhbmQKCiAgICAoZCkgSWYgdGhlIFdvcmsgaW5jbHVkZXMgYSAiTk9USUNFIiB0ZXh0IGZpbGUgYXMgcGFydCBvZiBpdHMKICAgICAgICBkaXN0cmlidXRpb24sIHRoZW4gYW55IERlcml2YXRpdmUgV29ya3MgdGhhdCBZb3UgZGlzdHJpYnV0ZSBtdXN0CiAgICAgICAgaW5jbHVkZSBhIHJlYWRhYmxlIGNvcHkgb2YgdGhlIGF0dHJpYnV0aW9uIG5vdGljZXMgY29udGFpbmVkCiAgICAgICAgd2l0aGluIHN1Y2ggTk9USUNFIGZpbGUsIGV4Y2x1ZGluZyB0aG9zZSBub3RpY2VzIHRoYXQgZG8gbm90CiAgICAgICAgcGVydGFpbiB0byBhbnkgcGFydCBvZiB0aGUgRGVyaXZhdGl2ZSBXb3JrcywgaW4gYXQgbGVhc3Qgb25lCiAgICAgICAgb2YgdGhlIGZvbGxvd2luZyBwbGFjZXM6IHdpdGhpbiBhIE5PVElDRSB0ZXh0IGZpbGUgZGlzdHJpYnV0ZWQKICAgICAgICBhcyBwYXJ0IG9mIHRoZSBEZXJpdmF0aXZlIFdvcmtzOyB3aXRoaW4gdGhlIFNvdXJjZSBmb3JtIG9yCiAgICAgICAgZG9jdW1lbnRhdGlvbiwgaWYgcHJvdmlkZWQgYWxvbmcgd2l0aCB0aGUgRGVyaXZhdGl2ZSBXb3Jrczsgb3IsCiAgICAgICAgd2l0aGluIGEgZGlzcGxheSBnZW5lcmF0ZWQgYnkgdGhlIERlcml2YXRpdmUgV29ya3MsIGlmIGFuZAogICAgICAgIHdoZXJldmVyIHN1Y2ggdGhpcmQtcGFydHkgbm90aWNlcyBub3JtYWxseSBhcHBlYXIuIFRoZSBjb250ZW50cwogICAgICAgIG9mIHRoZSBOT1RJQ0UgZmlsZSBhcmUgZm9yIGluZm9ybWF0aW9uYWwgcHVycG9zZXMgb25seSBhbmQKICAgICAgICBkbyBub3QgbW9kaWZ5IHRoZSBMaWNlbnNlLiBZb3UgbWF5IGFkZCBZb3VyIG93biBhdHRyaWJ1dGlvbgogICAgICAgIG5vdGljZXMgd2l0aGluIERlcml2YXRpdmUgV29ya3MgdGhhdCBZb3UgZGlzdHJpYnV0ZSwgYWxvbmdzaWRlCiAgICAgICAgb3IgYXMgYW4gYWRkZW5kdW0gdG8gdGhlIE5PVElDRSB0ZXh0IGZyb20gdGhlIFdvcmssIHByb3ZpZGVkCiAgICAgICAgdGhhdCBzdWNoIGFkZGl0aW9uYWwgYXR0cmlidXRpb24gbm90aWNlcyBjYW5ub3QgYmUgY29uc3RydWVkCiAgICAgICAgYXMgbW9kaWZ5aW5nIHRoZSBMaWNlbnNlLgoKICAgIFlvdSBtYXkgYWRkIFlvdXIgb3duIGNvcHlyaWdodCBzdGF0ZW1lbnQgdG8gWW91ciBtb2RpZmljYXRpb25zIGFuZAogICAgbWF5IHByb3ZpZGUgYWRkaXRpb25hbCBvciBkaWZmZXJlbnQgbGljZW5zZSB0ZXJtcyBhbmQgY29uZGl0aW9ucwogICAgZm9yIHVzZSwgcmVwcm9kdWN0aW9uLCBvciBkaXN0cmlidXRpb24gb2YgWW91ciBtb2RpZmljYXRpb25zLCBvcgogICAgZm9yIGFueSBzdWNoIERlcml2YXRpdmUgV29ya3MgYXMgYSB3aG9sZSwgcHJvdmlkZWQgWW91ciB1c2UsCiAgICByZXByb2R1Y3Rpb24sIGFuZCBkaXN0cmlidXRpb24gb2YgdGhlIFdvcmsgb3RoZXJ3aXNlIGNvbXBsaWVzIHdpdGgKICAgIHRoZSBjb25kaXRpb25zIHN0YXRlZCBpbiB0aGlzIExpY2Vuc2UuCgogNS4gU3VibWlzc2lvbiBvZiBDb250cmlidXRpb25zLiBVbmxlc3MgWW91IGV4cGxpY2l0bHkgc3RhdGUgb3RoZXJ3aXNlLAogICAgYW55IENvbnRyaWJ1dGlvbiBpbnRlbnRpb25hbGx5IHN1Ym1pdHRlZCBmb3IgaW5jbHVzaW9uIGluIHRoZSBXb3JrCiAgICBieSBZb3UgdG8gdGhlIExpY2Vuc29yIHNoYWxsIGJlIHVuZGVyIHRoZSB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZgogICAgdGhpcyBMaWNlbnNlLCB3aXRob3V0IGFueSBhZGRpdGlvbmFsIHRlcm1zIG9yIGNvbmRpdGlvbnMuCiAgICBOb3R3aXRoc3RhbmRpbmcgdGhlIGFib3ZlLCBub3RoaW5nIGhlcmVpbiBzaGFsbCBzdXBlcnNlZGUgb3IgbW9kaWZ5CiAgICB0aGUgdGVybXMgb2YgYW55IHNlcGFyYXRlIGxpY2Vuc2UgYWdyZWVtZW50IHlvdSBtYXkgaGF2ZSBleGVjdXRlZAogICAgd2l0aCBMaWNlbnNvciByZWdhcmRpbmcgc3VjaCBDb250cmlidXRpb25zLgoKIDYuIFRyYWRlbWFya3MuIFRoaXMgTGljZW5zZSBkb2VzIG5vdCBncmFudCBwZXJtaXNzaW9uIHRvIHVzZSB0aGUgdHJhZGUKICAgIG5hbWVzLCB0cmFkZW1hcmtzLCBzZXJ2aWNlIG1hcmtzLCBvciBwcm9kdWN0IG5hbWVzIG9mIHRoZSBMaWNlbnNvciwKICAgIGV4Y2VwdCBhcyByZXF1aXJlZCBmb3IgcmVhc29uYWJsZSBhbmQgY3VzdG9tYXJ5IHVzZSBpbiBkZXNjcmliaW5nIHRoZQogICAgb3JpZ2luIG9mIHRoZSBXb3JrIGFuZCByZXByb2R1Y2luZyB0aGUgY29udGVudCBvZiB0aGUgTk9USUNFIGZpbGUuCgogNy4gRGlzY2xhaW1lciBvZiBXYXJyYW50eS4gVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yCiAgICBhZ3JlZWQgdG8gaW4gd3JpdGluZywgTGljZW5zb3IgcHJvdmlkZXMgdGhlIFdvcmsgKGFuZCBlYWNoCiAgICBDb250cmlidXRvciBwcm92aWRlcyBpdHMgQ29udHJpYnV0aW9ucykgb24gYW4gIkFTIElTIiBCQVNJUywKICAgIFdJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvcgogICAgaW1wbGllZCwgaW5jbHVkaW5nLCB3aXRob3V0IGxpbWl0YXRpb24sIGFueSB3YXJyYW50aWVzIG9yIGNvbmRpdGlvbnMKICAgIG9mIFRJVExFLCBOT04tSU5GUklOR0VNRU5ULCBNRVJDSEFOVEFCSUxJVFksIG9yIEZJVE5FU1MgRk9SIEEKICAgIFBBUlRJQ1VMQVIgUFVSUE9TRS4gWW91IGFyZSBzb2xlbHkgcmVzcG9uc2libGUgZm9yIGRldGVybWluaW5nIHRoZQogICAgYXBwcm9wcmlhdGVuZXNzIG9mIHVzaW5nIG9yIHJlZGlzdHJpYnV0aW5nIHRoZSBXb3JrIGFuZCBhc3N1bWUgYW55CiAgICByaXNrcyBhc3NvY2lhdGVkIHdpdGggWW91ciBleGVyY2lzZSBvZiBwZXJtaXNzaW9ucyB1bmRlciB0aGlzIExpY2Vuc2UuCgogOC4gTGltaXRhdGlvbiBvZiBMaWFiaWxpdHkuIEluIG5vIGV2ZW50IGFuZCB1bmRlciBubyBsZWdhbCB0aGVvcnksCiAgICB3aGV0aGVyIGluIHRvcnQgKGluY2x1ZGluZyBuZWdsaWdlbmNlKSwgY29udHJhY3QsIG9yIG90aGVyd2lzZSwKICAgIHVubGVzcyByZXF1aXJlZCBieSBhcHBsaWNhYmxlIGxhdyAoc3VjaCBhcyBkZWxpYmVyYXRlIGFuZCBncm9zc2x5CiAgICBuZWdsaWdlbnQgYWN0cykgb3IgYWdyZWVkIHRvIGluIHdyaXRpbmcsIHNoYWxsIGFueSBDb250cmlidXRvciBiZQogICAgbGlhYmxlIHRvIFlvdSBmb3IgZGFtYWdlcywgaW5jbHVkaW5nIGFueSBkaXJlY3QsIGluZGlyZWN0LCBzcGVjaWFsLAogICAgaW5jaWRlbnRhbCwgb3IgY29uc2VxdWVudGlhbCBkYW1hZ2VzIG9mIGFueSBjaGFyYWN0ZXIgYXJpc2luZyBhcyBhCiAgICByZXN1bHQgb2YgdGhpcyBMaWNlbnNlIG9yIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0byB1c2UgdGhlCiAgICBXb3JrIChpbmNsdWRpbmcgYnV0IG5vdCBsaW1pdGVkIHRvIGRhbWFnZXMgZm9yIGxvc3Mgb2YgZ29vZHdpbGwsCiAgICB3b3JrIHN0b3BwYWdlLCBjb21wdXRlciBmYWlsdXJlIG9yIG1hbGZ1bmN0aW9uLCBvciBhbnkgYW5kIGFsbAogICAgb3RoZXIgY29tbWVyY2lhbCBkYW1hZ2VzIG9yIGxvc3NlcyksIGV2ZW4gaWYgc3VjaCBDb250cmlidXRvcgogICAgaGFzIGJlZW4gYWR2aXNlZCBvZiB0aGUgcG9zc2liaWxpdHkgb2Ygc3VjaCBkYW1hZ2VzLgoKIDkuIEFjY2VwdGluZyBXYXJyYW50eSBvciBBZGRpdGlvbmFsIExpYWJpbGl0eS4gV2hpbGUgcmVkaXN0cmlidXRpbmcKICAgIHRoZSBXb3JrIG9yIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZiwgWW91IG1heSBjaG9vc2UgdG8gb2ZmZXIsCiAgICBhbmQgY2hhcmdlIGEgZmVlIGZvciwgYWNjZXB0YW5jZSBvZiBzdXBwb3J0LCB3YXJyYW50eSwgaW5kZW1uaXR5LAogICAgb3Igb3RoZXIgbGlhYmlsaXR5IG9ibGlnYXRpb25zIGFuZC9vciByaWdodHMgY29uc2lzdGVudCB3aXRoIHRoaXMKICAgIExpY2Vuc2UuIEhvd2V2ZXIsIGluIGFjY2VwdGluZyBzdWNoIG9ibGlnYXRpb25zLCBZb3UgbWF5IGFjdCBvbmx5CiAgICBvbiBZb3VyIG93biBiZWhhbGYgYW5kIG9uIFlvdXIgc29sZSByZXNwb25zaWJpbGl0eSwgbm90IG9uIGJlaGFsZgogICAgb2YgYW55IG90aGVyIENvbnRyaWJ1dG9yLCBhbmQgb25seSBpZiBZb3UgYWdyZWUgdG8gaW5kZW1uaWZ5LAogICAgZGVmZW5kLCBhbmQgaG9sZCBlYWNoIENvbnRyaWJ1dG9yIGhhcm1sZXNzIGZvciBhbnkgbGlhYmlsaXR5CiAgICBpbmN1cnJlZCBieSwgb3IgY2xhaW1zIGFzc2VydGVkIGFnYWluc3QsIHN1Y2ggQ29udHJpYnV0b3IgYnkgcmVhc29uCiAgICBvZiB5b3VyIGFjY2VwdGluZyBhbnkgc3VjaCB3YXJyYW50eSBvciBhZGRpdGlvbmFsIGxpYWJpbGl0eS4KCiBFTkQgT0YgVEVSTVMgQU5EIENPTkRJVElPTlMKCiBBUFBFTkRJWDogSG93IHRvIGFwcGx5IHRoZSBBcGFjaGUgTGljZW5zZSB0byB5b3VyIHdvcmsuCgogICAgVG8gYXBwbHkgdGhlIEFwYWNoZSBMaWNlbnNlIHRvIHlvdXIgd29yaywgYXR0YWNoIHRoZSBmb2xsb3dpbmcKICAgIGJvaWxlcnBsYXRlIG5vdGljZSwgd2l0aCB0aGUgZmllbGRzIGVuY2xvc2VkIGJ5IGJyYWNrZXRzICJbXSIKICAgIHJlcGxhY2VkIHdpdGggeW91ciBvd24gaWRlbnRpZnlpbmcgaW5mb3JtYXRpb24uIChEb24ndCBpbmNsdWRlCiAgICB0aGUgYnJhY2tldHMhKSAgVGhlIHRleHQgc2hvdWxkIGJlIGVuY2xvc2VkIGluIHRoZSBhcHByb3ByaWF0ZQogICAgY29tbWVudCBzeW50YXggZm9yIHRoZSBmaWxlIGZvcm1hdC4gV2UgYWxzbyByZWNvbW1lbmQgdGhhdCBhCiAgICBmaWxlIG9yIGNsYXNzIG5hbWUgYW5kIGRlc2NyaXB0aW9uIG9mIHB1cnBvc2UgYmUgaW5jbHVkZWQgb24gdGhlCiAgICBzYW1lICJwcmludGVkIHBhZ2UiIGFzIHRoZSBjb3B5cmlnaHQgbm90aWNlIGZvciBlYXNpZXIKICAgIGlkZW50aWZpY2F0aW9uIHdpdGhpbiB0aGlyZC1wYXJ0eSBhcmNoaXZlcy4KCiBDb3B5cmlnaHQgKGMpIDIwMTUtMjAxOCBHb29nbGUsIEluYy4sIE5ldGZsaXgsIEluYy4sIE1pY3Jvc29mdCBDb3JwLiBhbmQgY29udHJpYnV0b3JzCgogTGljZW5zZWQgdW5kZXIgdGhlIEFwYWNoZSBMaWNlbnNlLCBWZXJzaW9uIDIuMCAodGhlICJMaWNlbnNlIik7CiB5b3UgbWF5IG5vdCB1c2UgdGhpcyBmaWxlIGV4Y2VwdCBpbiBjb21wbGlhbmNlIHdpdGggdGhlIExpY2Vuc2UuCiBZb3UgbWF5IG9idGFpbiBhIGNvcHkgb2YgdGhlIExpY2Vuc2UgYXQKCiAgICAgaHR0cDovL3d3dy5hcGFjaGUub3JnL2xpY2Vuc2VzL0xJQ0VOU0UtMi4wCgogVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yIGFncmVlZCB0byBpbiB3cml0aW5nLCBzb2Z0d2FyZQogZGlzdHJpYnV0ZWQgdW5kZXIgdGhlIExpY2Vuc2UgaXMgZGlzdHJpYnV0ZWQgb24gYW4gIkFTIElTIiBCQVNJUywKIFdJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvciBpbXBsaWVkLgogU2VlIHRoZSBMaWNlbnNlIGZvciB0aGUgc3BlY2lmaWMgbGFuZ3VhZ2UgZ292ZXJuaW5nIHBlcm1pc3Npb25zIGFuZAogbGltaXRhdGlvbnMgdW5kZXIgdGhlIExpY2Vuc2UuCiAK</text>
-          </license>
-        </licenses>
-      </evidence>
-    </component>
-    <component type="library" bom-ref="9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b">
-      <author>The Babel Team</author>
-      <group>@babel</group>
-      <name>runtime</name>
-      <version>7.25.0</version>
-      <description>babel's modular runtime helpers</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git%23packages%2Fbabel-runtime</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/babel/babel/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/babel/babel.git#packages/babel-runtime</url>
-          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://babel.dev/docs/en/next/babel-runtime</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-      <evidence>
-        <licenses>
-          <license>
-            <name>file: LICENSE</name>
-            <text content-type="text/plain" encoding="base64">TUlUIExpY2Vuc2UKCkNvcHlyaWdodCAoYykgMjAxNC1wcmVzZW50IFNlYmFzdGlhbiBNY0tlbnppZSBhbmQgb3RoZXIgY29udHJpYnV0b3JzCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcKYSBjb3B5IG9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlCiJTb2Z0d2FyZSIpLCB0byBkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcKd2l0aG91dCBsaW1pdGF0aW9uIHRoZSByaWdodHMgdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLApkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3Igc2VsbCBjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8KcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMgZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvCnRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlCmluY2x1ZGVkIGluIGFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsCkVYUFJFU1MgT1IgSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRgpNRVJDSEFOVEFCSUxJVFksIEZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORApOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRSBBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFCkxJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSIExJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04KT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HIEZST00sIE9VVCBPRiBPUiBJTiBDT05ORUNUSU9OCldJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4gVEhFIFNPRlRXQVJFLgo=</text>
-          </license>
-        </licenses>
-      </evidence>
-    </component>
-    <component type="library" bom-ref="a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5">
+    <component type="library" bom-ref="@angular/common@18.2.7#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5">
       <author>angular</author>
       <group>@angular</group>
       <name>common</name>
@@ -1585,76 +1447,7 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1">
-      <author>angular</author>
-      <group>@angular</group>
-      <name>router</name>
-      <version>18.2.7</version>
-      <description>Angular - the routing library</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Frouter</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/angular/angular/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/angular/angular.git#packages/router</url>
-          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/angular/angular/tree/main/packages/router</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-      <evidence>
-        <licenses>
-          <license>
-            <name>file: LICENSE</name>
-            <text content-type="text/plain" encoding="base64">VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuZGV2L2xpY2Vuc2UKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==</text>
-          </license>
-        </licenses>
-      </evidence>
-    </component>
-    <component type="library" bom-ref="cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc">
-      <author>Microsoft Corp.</author>
-      <name>tslib</name>
-      <version>2.6.3</version>
-      <description>Runtime library for TypeScript helper functions</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>0BSD</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/Microsoft/TypeScript/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/Microsoft/tslib.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://www.typescriptlang.org/</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-      <evidence>
-        <licenses>
-          <license>
-            <name>file: LICENSE.txt</name>
-            <text content-type="text/plain" encoding="base64">Q29weXJpZ2h0IChjKSBNaWNyb3NvZnQgQ29ycG9yYXRpb24uDQoNClBlcm1pc3Npb24gdG8gdXNlLCBjb3B5LCBtb2RpZnksIGFuZC9vciBkaXN0cmlidXRlIHRoaXMgc29mdHdhcmUgZm9yIGFueQ0KcHVycG9zZSB3aXRoIG9yIHdpdGhvdXQgZmVlIGlzIGhlcmVieSBncmFudGVkLg0KDQpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiBBTkQgVEhFIEFVVEhPUiBESVNDTEFJTVMgQUxMIFdBUlJBTlRJRVMgV0lUSA0KUkVHQVJEIFRPIFRISVMgU09GVFdBUkUgSU5DTFVESU5HIEFMTCBJTVBMSUVEIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZDQpBTkQgRklUTkVTUy4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUiBCRSBMSUFCTEUgRk9SIEFOWSBTUEVDSUFMLCBESVJFQ1QsDQpJTkRJUkVDVCwgT1IgQ09OU0VRVUVOVElBTCBEQU1BR0VTIE9SIEFOWSBEQU1BR0VTIFdIQVRTT0VWRVIgUkVTVUxUSU5HIEZST00NCkxPU1MgT0YgVVNFLCBEQVRBIE9SIFBST0ZJVFMsIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBORUdMSUdFTkNFIE9SDQpPVEhFUiBUT1JUSU9VUyBBQ1RJT04sIEFSSVNJTkcgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgVVNFIE9SDQpQRVJGT1JNQU5DRSBPRiBUSElTIFNPRlRXQVJFLg==</text>
-          </license>
-        </licenses>
-      </evidence>
-    </component>
-    <component type="library" bom-ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17">
+    <component type="library" bom-ref="@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17">
       <author>angular</author>
       <group>@angular</group>
       <name>core</name>
@@ -1689,7 +1482,112 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a">
+    <component type="library" bom-ref="@angular/platform-browser@18.2.7#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378">
+      <author>angular</author>
+      <group>@angular</group>
+      <name>platform-browser</name>
+      <version>18.2.7</version>
+      <description>Angular - library for using Angular in a web browser</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/%40angular/platform-browser@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/angular/angular/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/angular/angular.git#packages/platform-browser</url>
+          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/angular/angular#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+      <evidence>
+        <licenses>
+          <license>
+            <name>file: LICENSE</name>
+            <text content-type="text/plain" encoding="base64">VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuZGV2L2xpY2Vuc2UKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==</text>
+          </license>
+        </licenses>
+      </evidence>
+    </component>
+    <component type="library" bom-ref="@angular/router@18.2.7#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1">
+      <author>angular</author>
+      <group>@angular</group>
+      <name>router</name>
+      <version>18.2.7</version>
+      <description>Angular - the routing library</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/%40angular/router@18.2.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Frouter</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/angular/angular/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/angular/angular.git#packages/router</url>
+          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/angular/angular/tree/main/packages/router</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+      <evidence>
+        <licenses>
+          <license>
+            <name>file: LICENSE</name>
+            <text content-type="text/plain" encoding="base64">VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuZGV2L2xpY2Vuc2UKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==</text>
+          </license>
+        </licenses>
+      </evidence>
+    </component>
+    <component type="library" bom-ref="@babel/runtime@7.25.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b">
+      <author>The Babel Team</author>
+      <group>@babel</group>
+      <name>runtime</name>
+      <version>7.25.0</version>
+      <description>babel's modular runtime helpers</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/%40babel/runtime@7.25.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git%23packages%2Fbabel-runtime</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/babel/babel/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/babel/babel.git#packages/babel-runtime</url>
+          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://babel.dev/docs/en/next/babel-runtime</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+      <evidence>
+        <licenses>
+          <license>
+            <name>file: LICENSE</name>
+            <text content-type="text/plain" encoding="base64">TUlUIExpY2Vuc2UKCkNvcHlyaWdodCAoYykgMjAxNC1wcmVzZW50IFNlYmFzdGlhbiBNY0tlbnppZSBhbmQgb3RoZXIgY29udHJpYnV0b3JzCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcKYSBjb3B5IG9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlCiJTb2Z0d2FyZSIpLCB0byBkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcKd2l0aG91dCBsaW1pdGF0aW9uIHRoZSByaWdodHMgdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLApkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3Igc2VsbCBjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8KcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMgZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvCnRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlCmluY2x1ZGVkIGluIGFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsCkVYUFJFU1MgT1IgSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRgpNRVJDSEFOVEFCSUxJVFksIEZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORApOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRSBBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFCkxJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSIExJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04KT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HIEZST00sIE9VVCBPRiBPUiBJTiBDT05ORUNUSU9OCldJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4gVEhFIFNPRlRXQVJFLgo=</text>
+          </license>
+        </licenses>
+      </evidence>
+    </component>
+    <component type="library" bom-ref="css-loader@7.1.2#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a">
       <author>Tobias Koppers @sokra</author>
       <name>css-loader</name>
       <version>7.1.2</version>
@@ -1723,39 +1621,141 @@ exports[`integration feature: component evidence generated xml file: dist/.bom/b
         </licenses>
       </evidence>
     </component>
+    <component type="library" bom-ref="rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a">
+      <author>Ben Lesh</author>
+      <name>rxjs</name>
+      <version>7.8.1</version>
+      <description>Reactive Extensions for modern JavaScript</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/ReactiveX/RxJS/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/reactivex/rxjs.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://rxjs.dev</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+      <evidence>
+        <licenses>
+          <license>
+            <name>file: LICENSE.txt</name>
+            <text content-type="text/plain" encoding="base64">ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEFwYWNoZSBMaWNlbnNlCiAgICAgICAgICAgICAgICAgICAgICAgICBWZXJzaW9uIDIuMCwgSmFudWFyeSAyMDA0CiAgICAgICAgICAgICAgICAgICAgICBodHRwOi8vd3d3LmFwYWNoZS5vcmcvbGljZW5zZXMvCgogVEVSTVMgQU5EIENPTkRJVElPTlMgRk9SIFVTRSwgUkVQUk9EVUNUSU9OLCBBTkQgRElTVFJJQlVUSU9OCgogMS4gRGVmaW5pdGlvbnMuCgogICAgIkxpY2Vuc2UiIHNoYWxsIG1lYW4gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIGZvciB1c2UsIHJlcHJvZHVjdGlvbiwKICAgIGFuZCBkaXN0cmlidXRpb24gYXMgZGVmaW5lZCBieSBTZWN0aW9ucyAxIHRocm91Z2ggOSBvZiB0aGlzIGRvY3VtZW50LgoKICAgICJMaWNlbnNvciIgc2hhbGwgbWVhbiB0aGUgY29weXJpZ2h0IG93bmVyIG9yIGVudGl0eSBhdXRob3JpemVkIGJ5CiAgICB0aGUgY29weXJpZ2h0IG93bmVyIHRoYXQgaXMgZ3JhbnRpbmcgdGhlIExpY2Vuc2UuCgogICAgIkxlZ2FsIEVudGl0eSIgc2hhbGwgbWVhbiB0aGUgdW5pb24gb2YgdGhlIGFjdGluZyBlbnRpdHkgYW5kIGFsbAogICAgb3RoZXIgZW50aXRpZXMgdGhhdCBjb250cm9sLCBhcmUgY29udHJvbGxlZCBieSwgb3IgYXJlIHVuZGVyIGNvbW1vbgogICAgY29udHJvbCB3aXRoIHRoYXQgZW50aXR5LiBGb3IgdGhlIHB1cnBvc2VzIG9mIHRoaXMgZGVmaW5pdGlvbiwKICAgICJjb250cm9sIiBtZWFucyAoaSkgdGhlIHBvd2VyLCBkaXJlY3Qgb3IgaW5kaXJlY3QsIHRvIGNhdXNlIHRoZQogICAgZGlyZWN0aW9uIG9yIG1hbmFnZW1lbnQgb2Ygc3VjaCBlbnRpdHksIHdoZXRoZXIgYnkgY29udHJhY3Qgb3IKICAgIG90aGVyd2lzZSwgb3IgKGlpKSBvd25lcnNoaXAgb2YgZmlmdHkgcGVyY2VudCAoNTAlKSBvciBtb3JlIG9mIHRoZQogICAgb3V0c3RhbmRpbmcgc2hhcmVzLCBvciAoaWlpKSBiZW5lZmljaWFsIG93bmVyc2hpcCBvZiBzdWNoIGVudGl0eS4KCiAgICAiWW91IiAob3IgIllvdXIiKSBzaGFsbCBtZWFuIGFuIGluZGl2aWR1YWwgb3IgTGVnYWwgRW50aXR5CiAgICBleGVyY2lzaW5nIHBlcm1pc3Npb25zIGdyYW50ZWQgYnkgdGhpcyBMaWNlbnNlLgoKICAgICJTb3VyY2UiIGZvcm0gc2hhbGwgbWVhbiB0aGUgcHJlZmVycmVkIGZvcm0gZm9yIG1ha2luZyBtb2RpZmljYXRpb25zLAogICAgaW5jbHVkaW5nIGJ1dCBub3QgbGltaXRlZCB0byBzb2Z0d2FyZSBzb3VyY2UgY29kZSwgZG9jdW1lbnRhdGlvbgogICAgc291cmNlLCBhbmQgY29uZmlndXJhdGlvbiBmaWxlcy4KCiAgICAiT2JqZWN0IiBmb3JtIHNoYWxsIG1lYW4gYW55IGZvcm0gcmVzdWx0aW5nIGZyb20gbWVjaGFuaWNhbAogICAgdHJhbnNmb3JtYXRpb24gb3IgdHJhbnNsYXRpb24gb2YgYSBTb3VyY2UgZm9ybSwgaW5jbHVkaW5nIGJ1dAogICAgbm90IGxpbWl0ZWQgdG8gY29tcGlsZWQgb2JqZWN0IGNvZGUsIGdlbmVyYXRlZCBkb2N1bWVudGF0aW9uLAogICAgYW5kIGNvbnZlcnNpb25zIHRvIG90aGVyIG1lZGlhIHR5cGVzLgoKICAgICJXb3JrIiBzaGFsbCBtZWFuIHRoZSB3b3JrIG9mIGF1dGhvcnNoaXAsIHdoZXRoZXIgaW4gU291cmNlIG9yCiAgICBPYmplY3QgZm9ybSwgbWFkZSBhdmFpbGFibGUgdW5kZXIgdGhlIExpY2Vuc2UsIGFzIGluZGljYXRlZCBieSBhCiAgICBjb3B5cmlnaHQgbm90aWNlIHRoYXQgaXMgaW5jbHVkZWQgaW4gb3IgYXR0YWNoZWQgdG8gdGhlIHdvcmsKICAgIChhbiBleGFtcGxlIGlzIHByb3ZpZGVkIGluIHRoZSBBcHBlbmRpeCBiZWxvdykuCgogICAgIkRlcml2YXRpdmUgV29ya3MiIHNoYWxsIG1lYW4gYW55IHdvcmssIHdoZXRoZXIgaW4gU291cmNlIG9yIE9iamVjdAogICAgZm9ybSwgdGhhdCBpcyBiYXNlZCBvbiAob3IgZGVyaXZlZCBmcm9tKSB0aGUgV29yayBhbmQgZm9yIHdoaWNoIHRoZQogICAgZWRpdG9yaWFsIHJldmlzaW9ucywgYW5ub3RhdGlvbnMsIGVsYWJvcmF0aW9ucywgb3Igb3RoZXIgbW9kaWZpY2F0aW9ucwogICAgcmVwcmVzZW50LCBhcyBhIHdob2xlLCBhbiBvcmlnaW5hbCB3b3JrIG9mIGF1dGhvcnNoaXAuIEZvciB0aGUgcHVycG9zZXMKICAgIG9mIHRoaXMgTGljZW5zZSwgRGVyaXZhdGl2ZSBXb3JrcyBzaGFsbCBub3QgaW5jbHVkZSB3b3JrcyB0aGF0IHJlbWFpbgogICAgc2VwYXJhYmxlIGZyb20sIG9yIG1lcmVseSBsaW5rIChvciBiaW5kIGJ5IG5hbWUpIHRvIHRoZSBpbnRlcmZhY2VzIG9mLAogICAgdGhlIFdvcmsgYW5kIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZi4KCiAgICAiQ29udHJpYnV0aW9uIiBzaGFsbCBtZWFuIGFueSB3b3JrIG9mIGF1dGhvcnNoaXAsIGluY2x1ZGluZwogICAgdGhlIG9yaWdpbmFsIHZlcnNpb24gb2YgdGhlIFdvcmsgYW5kIGFueSBtb2RpZmljYXRpb25zIG9yIGFkZGl0aW9ucwogICAgdG8gdGhhdCBXb3JrIG9yIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZiwgdGhhdCBpcyBpbnRlbnRpb25hbGx5CiAgICBzdWJtaXR0ZWQgdG8gTGljZW5zb3IgZm9yIGluY2x1c2lvbiBpbiB0aGUgV29yayBieSB0aGUgY29weXJpZ2h0IG93bmVyCiAgICBvciBieSBhbiBpbmRpdmlkdWFsIG9yIExlZ2FsIEVudGl0eSBhdXRob3JpemVkIHRvIHN1Ym1pdCBvbiBiZWhhbGYgb2YKICAgIHRoZSBjb3B5cmlnaHQgb3duZXIuIEZvciB0aGUgcHVycG9zZXMgb2YgdGhpcyBkZWZpbml0aW9uLCAic3VibWl0dGVkIgogICAgbWVhbnMgYW55IGZvcm0gb2YgZWxlY3Ryb25pYywgdmVyYmFsLCBvciB3cml0dGVuIGNvbW11bmljYXRpb24gc2VudAogICAgdG8gdGhlIExpY2Vuc29yIG9yIGl0cyByZXByZXNlbnRhdGl2ZXMsIGluY2x1ZGluZyBidXQgbm90IGxpbWl0ZWQgdG8KICAgIGNvbW11bmljYXRpb24gb24gZWxlY3Ryb25pYyBtYWlsaW5nIGxpc3RzLCBzb3VyY2UgY29kZSBjb250cm9sIHN5c3RlbXMsCiAgICBhbmQgaXNzdWUgdHJhY2tpbmcgc3lzdGVtcyB0aGF0IGFyZSBtYW5hZ2VkIGJ5LCBvciBvbiBiZWhhbGYgb2YsIHRoZQogICAgTGljZW5zb3IgZm9yIHRoZSBwdXJwb3NlIG9mIGRpc2N1c3NpbmcgYW5kIGltcHJvdmluZyB0aGUgV29yaywgYnV0CiAgICBleGNsdWRpbmcgY29tbXVuaWNhdGlvbiB0aGF0IGlzIGNvbnNwaWN1b3VzbHkgbWFya2VkIG9yIG90aGVyd2lzZQogICAgZGVzaWduYXRlZCBpbiB3cml0aW5nIGJ5IHRoZSBjb3B5cmlnaHQgb3duZXIgYXMgIk5vdCBhIENvbnRyaWJ1dGlvbi4iCgogICAgIkNvbnRyaWJ1dG9yIiBzaGFsbCBtZWFuIExpY2Vuc29yIGFuZCBhbnkgaW5kaXZpZHVhbCBvciBMZWdhbCBFbnRpdHkKICAgIG9uIGJlaGFsZiBvZiB3aG9tIGEgQ29udHJpYnV0aW9uIGhhcyBiZWVuIHJlY2VpdmVkIGJ5IExpY2Vuc29yIGFuZAogICAgc3Vic2VxdWVudGx5IGluY29ycG9yYXRlZCB3aXRoaW4gdGhlIFdvcmsuCgogMi4gR3JhbnQgb2YgQ29weXJpZ2h0IExpY2Vuc2UuIFN1YmplY3QgdG8gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mCiAgICB0aGlzIExpY2Vuc2UsIGVhY2ggQ29udHJpYnV0b3IgaGVyZWJ5IGdyYW50cyB0byBZb3UgYSBwZXJwZXR1YWwsCiAgICB3b3JsZHdpZGUsIG5vbi1leGNsdXNpdmUsIG5vLWNoYXJnZSwgcm95YWx0eS1mcmVlLCBpcnJldm9jYWJsZQogICAgY29weXJpZ2h0IGxpY2Vuc2UgdG8gcmVwcm9kdWNlLCBwcmVwYXJlIERlcml2YXRpdmUgV29ya3Mgb2YsCiAgICBwdWJsaWNseSBkaXNwbGF5LCBwdWJsaWNseSBwZXJmb3JtLCBzdWJsaWNlbnNlLCBhbmQgZGlzdHJpYnV0ZSB0aGUKICAgIFdvcmsgYW5kIHN1Y2ggRGVyaXZhdGl2ZSBXb3JrcyBpbiBTb3VyY2Ugb3IgT2JqZWN0IGZvcm0uCgogMy4gR3JhbnQgb2YgUGF0ZW50IExpY2Vuc2UuIFN1YmplY3QgdG8gdGhlIHRlcm1zIGFuZCBjb25kaXRpb25zIG9mCiAgICB0aGlzIExpY2Vuc2UsIGVhY2ggQ29udHJpYnV0b3IgaGVyZWJ5IGdyYW50cyB0byBZb3UgYSBwZXJwZXR1YWwsCiAgICB3b3JsZHdpZGUsIG5vbi1leGNsdXNpdmUsIG5vLWNoYXJnZSwgcm95YWx0eS1mcmVlLCBpcnJldm9jYWJsZQogICAgKGV4Y2VwdCBhcyBzdGF0ZWQgaW4gdGhpcyBzZWN0aW9uKSBwYXRlbnQgbGljZW5zZSB0byBtYWtlLCBoYXZlIG1hZGUsCiAgICB1c2UsIG9mZmVyIHRvIHNlbGwsIHNlbGwsIGltcG9ydCwgYW5kIG90aGVyd2lzZSB0cmFuc2ZlciB0aGUgV29yaywKICAgIHdoZXJlIHN1Y2ggbGljZW5zZSBhcHBsaWVzIG9ubHkgdG8gdGhvc2UgcGF0ZW50IGNsYWltcyBsaWNlbnNhYmxlCiAgICBieSBzdWNoIENvbnRyaWJ1dG9yIHRoYXQgYXJlIG5lY2Vzc2FyaWx5IGluZnJpbmdlZCBieSB0aGVpcgogICAgQ29udHJpYnV0aW9uKHMpIGFsb25lIG9yIGJ5IGNvbWJpbmF0aW9uIG9mIHRoZWlyIENvbnRyaWJ1dGlvbihzKQogICAgd2l0aCB0aGUgV29yayB0byB3aGljaCBzdWNoIENvbnRyaWJ1dGlvbihzKSB3YXMgc3VibWl0dGVkLiBJZiBZb3UKICAgIGluc3RpdHV0ZSBwYXRlbnQgbGl0aWdhdGlvbiBhZ2FpbnN0IGFueSBlbnRpdHkgKGluY2x1ZGluZyBhCiAgICBjcm9zcy1jbGFpbSBvciBjb3VudGVyY2xhaW0gaW4gYSBsYXdzdWl0KSBhbGxlZ2luZyB0aGF0IHRoZSBXb3JrCiAgICBvciBhIENvbnRyaWJ1dGlvbiBpbmNvcnBvcmF0ZWQgd2l0aGluIHRoZSBXb3JrIGNvbnN0aXR1dGVzIGRpcmVjdAogICAgb3IgY29udHJpYnV0b3J5IHBhdGVudCBpbmZyaW5nZW1lbnQsIHRoZW4gYW55IHBhdGVudCBsaWNlbnNlcwogICAgZ3JhbnRlZCB0byBZb3UgdW5kZXIgdGhpcyBMaWNlbnNlIGZvciB0aGF0IFdvcmsgc2hhbGwgdGVybWluYXRlCiAgICBhcyBvZiB0aGUgZGF0ZSBzdWNoIGxpdGlnYXRpb24gaXMgZmlsZWQuCgogNC4gUmVkaXN0cmlidXRpb24uIFlvdSBtYXkgcmVwcm9kdWNlIGFuZCBkaXN0cmlidXRlIGNvcGllcyBvZiB0aGUKICAgIFdvcmsgb3IgRGVyaXZhdGl2ZSBXb3JrcyB0aGVyZW9mIGluIGFueSBtZWRpdW0sIHdpdGggb3Igd2l0aG91dAogICAgbW9kaWZpY2F0aW9ucywgYW5kIGluIFNvdXJjZSBvciBPYmplY3QgZm9ybSwgcHJvdmlkZWQgdGhhdCBZb3UKICAgIG1lZXQgdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKICAgIChhKSBZb3UgbXVzdCBnaXZlIGFueSBvdGhlciByZWNpcGllbnRzIG9mIHRoZSBXb3JrIG9yCiAgICAgICAgRGVyaXZhdGl2ZSBXb3JrcyBhIGNvcHkgb2YgdGhpcyBMaWNlbnNlOyBhbmQKCiAgICAoYikgWW91IG11c3QgY2F1c2UgYW55IG1vZGlmaWVkIGZpbGVzIHRvIGNhcnJ5IHByb21pbmVudCBub3RpY2VzCiAgICAgICAgc3RhdGluZyB0aGF0IFlvdSBjaGFuZ2VkIHRoZSBmaWxlczsgYW5kCgogICAgKGMpIFlvdSBtdXN0IHJldGFpbiwgaW4gdGhlIFNvdXJjZSBmb3JtIG9mIGFueSBEZXJpdmF0aXZlIFdvcmtzCiAgICAgICAgdGhhdCBZb3UgZGlzdHJpYnV0ZSwgYWxsIGNvcHlyaWdodCwgcGF0ZW50LCB0cmFkZW1hcmssIGFuZAogICAgICAgIGF0dHJpYnV0aW9uIG5vdGljZXMgZnJvbSB0aGUgU291cmNlIGZvcm0gb2YgdGhlIFdvcmssCiAgICAgICAgZXhjbHVkaW5nIHRob3NlIG5vdGljZXMgdGhhdCBkbyBub3QgcGVydGFpbiB0byBhbnkgcGFydCBvZgogICAgICAgIHRoZSBEZXJpdmF0aXZlIFdvcmtzOyBhbmQKCiAgICAoZCkgSWYgdGhlIFdvcmsgaW5jbHVkZXMgYSAiTk9USUNFIiB0ZXh0IGZpbGUgYXMgcGFydCBvZiBpdHMKICAgICAgICBkaXN0cmlidXRpb24sIHRoZW4gYW55IERlcml2YXRpdmUgV29ya3MgdGhhdCBZb3UgZGlzdHJpYnV0ZSBtdXN0CiAgICAgICAgaW5jbHVkZSBhIHJlYWRhYmxlIGNvcHkgb2YgdGhlIGF0dHJpYnV0aW9uIG5vdGljZXMgY29udGFpbmVkCiAgICAgICAgd2l0aGluIHN1Y2ggTk9USUNFIGZpbGUsIGV4Y2x1ZGluZyB0aG9zZSBub3RpY2VzIHRoYXQgZG8gbm90CiAgICAgICAgcGVydGFpbiB0byBhbnkgcGFydCBvZiB0aGUgRGVyaXZhdGl2ZSBXb3JrcywgaW4gYXQgbGVhc3Qgb25lCiAgICAgICAgb2YgdGhlIGZvbGxvd2luZyBwbGFjZXM6IHdpdGhpbiBhIE5PVElDRSB0ZXh0IGZpbGUgZGlzdHJpYnV0ZWQKICAgICAgICBhcyBwYXJ0IG9mIHRoZSBEZXJpdmF0aXZlIFdvcmtzOyB3aXRoaW4gdGhlIFNvdXJjZSBmb3JtIG9yCiAgICAgICAgZG9jdW1lbnRhdGlvbiwgaWYgcHJvdmlkZWQgYWxvbmcgd2l0aCB0aGUgRGVyaXZhdGl2ZSBXb3Jrczsgb3IsCiAgICAgICAgd2l0aGluIGEgZGlzcGxheSBnZW5lcmF0ZWQgYnkgdGhlIERlcml2YXRpdmUgV29ya3MsIGlmIGFuZAogICAgICAgIHdoZXJldmVyIHN1Y2ggdGhpcmQtcGFydHkgbm90aWNlcyBub3JtYWxseSBhcHBlYXIuIFRoZSBjb250ZW50cwogICAgICAgIG9mIHRoZSBOT1RJQ0UgZmlsZSBhcmUgZm9yIGluZm9ybWF0aW9uYWwgcHVycG9zZXMgb25seSBhbmQKICAgICAgICBkbyBub3QgbW9kaWZ5IHRoZSBMaWNlbnNlLiBZb3UgbWF5IGFkZCBZb3VyIG93biBhdHRyaWJ1dGlvbgogICAgICAgIG5vdGljZXMgd2l0aGluIERlcml2YXRpdmUgV29ya3MgdGhhdCBZb3UgZGlzdHJpYnV0ZSwgYWxvbmdzaWRlCiAgICAgICAgb3IgYXMgYW4gYWRkZW5kdW0gdG8gdGhlIE5PVElDRSB0ZXh0IGZyb20gdGhlIFdvcmssIHByb3ZpZGVkCiAgICAgICAgdGhhdCBzdWNoIGFkZGl0aW9uYWwgYXR0cmlidXRpb24gbm90aWNlcyBjYW5ub3QgYmUgY29uc3RydWVkCiAgICAgICAgYXMgbW9kaWZ5aW5nIHRoZSBMaWNlbnNlLgoKICAgIFlvdSBtYXkgYWRkIFlvdXIgb3duIGNvcHlyaWdodCBzdGF0ZW1lbnQgdG8gWW91ciBtb2RpZmljYXRpb25zIGFuZAogICAgbWF5IHByb3ZpZGUgYWRkaXRpb25hbCBvciBkaWZmZXJlbnQgbGljZW5zZSB0ZXJtcyBhbmQgY29uZGl0aW9ucwogICAgZm9yIHVzZSwgcmVwcm9kdWN0aW9uLCBvciBkaXN0cmlidXRpb24gb2YgWW91ciBtb2RpZmljYXRpb25zLCBvcgogICAgZm9yIGFueSBzdWNoIERlcml2YXRpdmUgV29ya3MgYXMgYSB3aG9sZSwgcHJvdmlkZWQgWW91ciB1c2UsCiAgICByZXByb2R1Y3Rpb24sIGFuZCBkaXN0cmlidXRpb24gb2YgdGhlIFdvcmsgb3RoZXJ3aXNlIGNvbXBsaWVzIHdpdGgKICAgIHRoZSBjb25kaXRpb25zIHN0YXRlZCBpbiB0aGlzIExpY2Vuc2UuCgogNS4gU3VibWlzc2lvbiBvZiBDb250cmlidXRpb25zLiBVbmxlc3MgWW91IGV4cGxpY2l0bHkgc3RhdGUgb3RoZXJ3aXNlLAogICAgYW55IENvbnRyaWJ1dGlvbiBpbnRlbnRpb25hbGx5IHN1Ym1pdHRlZCBmb3IgaW5jbHVzaW9uIGluIHRoZSBXb3JrCiAgICBieSBZb3UgdG8gdGhlIExpY2Vuc29yIHNoYWxsIGJlIHVuZGVyIHRoZSB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZgogICAgdGhpcyBMaWNlbnNlLCB3aXRob3V0IGFueSBhZGRpdGlvbmFsIHRlcm1zIG9yIGNvbmRpdGlvbnMuCiAgICBOb3R3aXRoc3RhbmRpbmcgdGhlIGFib3ZlLCBub3RoaW5nIGhlcmVpbiBzaGFsbCBzdXBlcnNlZGUgb3IgbW9kaWZ5CiAgICB0aGUgdGVybXMgb2YgYW55IHNlcGFyYXRlIGxpY2Vuc2UgYWdyZWVtZW50IHlvdSBtYXkgaGF2ZSBleGVjdXRlZAogICAgd2l0aCBMaWNlbnNvciByZWdhcmRpbmcgc3VjaCBDb250cmlidXRpb25zLgoKIDYuIFRyYWRlbWFya3MuIFRoaXMgTGljZW5zZSBkb2VzIG5vdCBncmFudCBwZXJtaXNzaW9uIHRvIHVzZSB0aGUgdHJhZGUKICAgIG5hbWVzLCB0cmFkZW1hcmtzLCBzZXJ2aWNlIG1hcmtzLCBvciBwcm9kdWN0IG5hbWVzIG9mIHRoZSBMaWNlbnNvciwKICAgIGV4Y2VwdCBhcyByZXF1aXJlZCBmb3IgcmVhc29uYWJsZSBhbmQgY3VzdG9tYXJ5IHVzZSBpbiBkZXNjcmliaW5nIHRoZQogICAgb3JpZ2luIG9mIHRoZSBXb3JrIGFuZCByZXByb2R1Y2luZyB0aGUgY29udGVudCBvZiB0aGUgTk9USUNFIGZpbGUuCgogNy4gRGlzY2xhaW1lciBvZiBXYXJyYW50eS4gVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yCiAgICBhZ3JlZWQgdG8gaW4gd3JpdGluZywgTGljZW5zb3IgcHJvdmlkZXMgdGhlIFdvcmsgKGFuZCBlYWNoCiAgICBDb250cmlidXRvciBwcm92aWRlcyBpdHMgQ29udHJpYnV0aW9ucykgb24gYW4gIkFTIElTIiBCQVNJUywKICAgIFdJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvcgogICAgaW1wbGllZCwgaW5jbHVkaW5nLCB3aXRob3V0IGxpbWl0YXRpb24sIGFueSB3YXJyYW50aWVzIG9yIGNvbmRpdGlvbnMKICAgIG9mIFRJVExFLCBOT04tSU5GUklOR0VNRU5ULCBNRVJDSEFOVEFCSUxJVFksIG9yIEZJVE5FU1MgRk9SIEEKICAgIFBBUlRJQ1VMQVIgUFVSUE9TRS4gWW91IGFyZSBzb2xlbHkgcmVzcG9uc2libGUgZm9yIGRldGVybWluaW5nIHRoZQogICAgYXBwcm9wcmlhdGVuZXNzIG9mIHVzaW5nIG9yIHJlZGlzdHJpYnV0aW5nIHRoZSBXb3JrIGFuZCBhc3N1bWUgYW55CiAgICByaXNrcyBhc3NvY2lhdGVkIHdpdGggWW91ciBleGVyY2lzZSBvZiBwZXJtaXNzaW9ucyB1bmRlciB0aGlzIExpY2Vuc2UuCgogOC4gTGltaXRhdGlvbiBvZiBMaWFiaWxpdHkuIEluIG5vIGV2ZW50IGFuZCB1bmRlciBubyBsZWdhbCB0aGVvcnksCiAgICB3aGV0aGVyIGluIHRvcnQgKGluY2x1ZGluZyBuZWdsaWdlbmNlKSwgY29udHJhY3QsIG9yIG90aGVyd2lzZSwKICAgIHVubGVzcyByZXF1aXJlZCBieSBhcHBsaWNhYmxlIGxhdyAoc3VjaCBhcyBkZWxpYmVyYXRlIGFuZCBncm9zc2x5CiAgICBuZWdsaWdlbnQgYWN0cykgb3IgYWdyZWVkIHRvIGluIHdyaXRpbmcsIHNoYWxsIGFueSBDb250cmlidXRvciBiZQogICAgbGlhYmxlIHRvIFlvdSBmb3IgZGFtYWdlcywgaW5jbHVkaW5nIGFueSBkaXJlY3QsIGluZGlyZWN0LCBzcGVjaWFsLAogICAgaW5jaWRlbnRhbCwgb3IgY29uc2VxdWVudGlhbCBkYW1hZ2VzIG9mIGFueSBjaGFyYWN0ZXIgYXJpc2luZyBhcyBhCiAgICByZXN1bHQgb2YgdGhpcyBMaWNlbnNlIG9yIG91dCBvZiB0aGUgdXNlIG9yIGluYWJpbGl0eSB0byB1c2UgdGhlCiAgICBXb3JrIChpbmNsdWRpbmcgYnV0IG5vdCBsaW1pdGVkIHRvIGRhbWFnZXMgZm9yIGxvc3Mgb2YgZ29vZHdpbGwsCiAgICB3b3JrIHN0b3BwYWdlLCBjb21wdXRlciBmYWlsdXJlIG9yIG1hbGZ1bmN0aW9uLCBvciBhbnkgYW5kIGFsbAogICAgb3RoZXIgY29tbWVyY2lhbCBkYW1hZ2VzIG9yIGxvc3NlcyksIGV2ZW4gaWYgc3VjaCBDb250cmlidXRvcgogICAgaGFzIGJlZW4gYWR2aXNlZCBvZiB0aGUgcG9zc2liaWxpdHkgb2Ygc3VjaCBkYW1hZ2VzLgoKIDkuIEFjY2VwdGluZyBXYXJyYW50eSBvciBBZGRpdGlvbmFsIExpYWJpbGl0eS4gV2hpbGUgcmVkaXN0cmlidXRpbmcKICAgIHRoZSBXb3JrIG9yIERlcml2YXRpdmUgV29ya3MgdGhlcmVvZiwgWW91IG1heSBjaG9vc2UgdG8gb2ZmZXIsCiAgICBhbmQgY2hhcmdlIGEgZmVlIGZvciwgYWNjZXB0YW5jZSBvZiBzdXBwb3J0LCB3YXJyYW50eSwgaW5kZW1uaXR5LAogICAgb3Igb3RoZXIgbGlhYmlsaXR5IG9ibGlnYXRpb25zIGFuZC9vciByaWdodHMgY29uc2lzdGVudCB3aXRoIHRoaXMKICAgIExpY2Vuc2UuIEhvd2V2ZXIsIGluIGFjY2VwdGluZyBzdWNoIG9ibGlnYXRpb25zLCBZb3UgbWF5IGFjdCBvbmx5CiAgICBvbiBZb3VyIG93biBiZWhhbGYgYW5kIG9uIFlvdXIgc29sZSByZXNwb25zaWJpbGl0eSwgbm90IG9uIGJlaGFsZgogICAgb2YgYW55IG90aGVyIENvbnRyaWJ1dG9yLCBhbmQgb25seSBpZiBZb3UgYWdyZWUgdG8gaW5kZW1uaWZ5LAogICAgZGVmZW5kLCBhbmQgaG9sZCBlYWNoIENvbnRyaWJ1dG9yIGhhcm1sZXNzIGZvciBhbnkgbGlhYmlsaXR5CiAgICBpbmN1cnJlZCBieSwgb3IgY2xhaW1zIGFzc2VydGVkIGFnYWluc3QsIHN1Y2ggQ29udHJpYnV0b3IgYnkgcmVhc29uCiAgICBvZiB5b3VyIGFjY2VwdGluZyBhbnkgc3VjaCB3YXJyYW50eSBvciBhZGRpdGlvbmFsIGxpYWJpbGl0eS4KCiBFTkQgT0YgVEVSTVMgQU5EIENPTkRJVElPTlMKCiBBUFBFTkRJWDogSG93IHRvIGFwcGx5IHRoZSBBcGFjaGUgTGljZW5zZSB0byB5b3VyIHdvcmsuCgogICAgVG8gYXBwbHkgdGhlIEFwYWNoZSBMaWNlbnNlIHRvIHlvdXIgd29yaywgYXR0YWNoIHRoZSBmb2xsb3dpbmcKICAgIGJvaWxlcnBsYXRlIG5vdGljZSwgd2l0aCB0aGUgZmllbGRzIGVuY2xvc2VkIGJ5IGJyYWNrZXRzICJbXSIKICAgIHJlcGxhY2VkIHdpdGggeW91ciBvd24gaWRlbnRpZnlpbmcgaW5mb3JtYXRpb24uIChEb24ndCBpbmNsdWRlCiAgICB0aGUgYnJhY2tldHMhKSAgVGhlIHRleHQgc2hvdWxkIGJlIGVuY2xvc2VkIGluIHRoZSBhcHByb3ByaWF0ZQogICAgY29tbWVudCBzeW50YXggZm9yIHRoZSBmaWxlIGZvcm1hdC4gV2UgYWxzbyByZWNvbW1lbmQgdGhhdCBhCiAgICBmaWxlIG9yIGNsYXNzIG5hbWUgYW5kIGRlc2NyaXB0aW9uIG9mIHB1cnBvc2UgYmUgaW5jbHVkZWQgb24gdGhlCiAgICBzYW1lICJwcmludGVkIHBhZ2UiIGFzIHRoZSBjb3B5cmlnaHQgbm90aWNlIGZvciBlYXNpZXIKICAgIGlkZW50aWZpY2F0aW9uIHdpdGhpbiB0aGlyZC1wYXJ0eSBhcmNoaXZlcy4KCiBDb3B5cmlnaHQgKGMpIDIwMTUtMjAxOCBHb29nbGUsIEluYy4sIE5ldGZsaXgsIEluYy4sIE1pY3Jvc29mdCBDb3JwLiBhbmQgY29udHJpYnV0b3JzCgogTGljZW5zZWQgdW5kZXIgdGhlIEFwYWNoZSBMaWNlbnNlLCBWZXJzaW9uIDIuMCAodGhlICJMaWNlbnNlIik7CiB5b3UgbWF5IG5vdCB1c2UgdGhpcyBmaWxlIGV4Y2VwdCBpbiBjb21wbGlhbmNlIHdpdGggdGhlIExpY2Vuc2UuCiBZb3UgbWF5IG9idGFpbiBhIGNvcHkgb2YgdGhlIExpY2Vuc2UgYXQKCiAgICAgaHR0cDovL3d3dy5hcGFjaGUub3JnL2xpY2Vuc2VzL0xJQ0VOU0UtMi4wCgogVW5sZXNzIHJlcXVpcmVkIGJ5IGFwcGxpY2FibGUgbGF3IG9yIGFncmVlZCB0byBpbiB3cml0aW5nLCBzb2Z0d2FyZQogZGlzdHJpYnV0ZWQgdW5kZXIgdGhlIExpY2Vuc2UgaXMgZGlzdHJpYnV0ZWQgb24gYW4gIkFTIElTIiBCQVNJUywKIFdJVEhPVVQgV0FSUkFOVElFUyBPUiBDT05ESVRJT05TIE9GIEFOWSBLSU5ELCBlaXRoZXIgZXhwcmVzcyBvciBpbXBsaWVkLgogU2VlIHRoZSBMaWNlbnNlIGZvciB0aGUgc3BlY2lmaWMgbGFuZ3VhZ2UgZ292ZXJuaW5nIHBlcm1pc3Npb25zIGFuZAogbGltaXRhdGlvbnMgdW5kZXIgdGhlIExpY2Vuc2UuCiAK</text>
+          </license>
+        </licenses>
+      </evidence>
+    </component>
+    <component type="library" bom-ref="tslib@2.6.3#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc">
+      <author>Microsoft Corp.</author>
+      <name>tslib</name>
+      <version>2.6.3</version>
+      <description>Runtime library for TypeScript helper functions</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>0BSD</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/tslib@2.6.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/Microsoft/TypeScript/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/Microsoft/tslib.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://www.typescriptlang.org/</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+      <evidence>
+        <licenses>
+          <license>
+            <name>file: LICENSE.txt</name>
+            <text content-type="text/plain" encoding="base64">Q29weXJpZ2h0IChjKSBNaWNyb3NvZnQgQ29ycG9yYXRpb24uDQoNClBlcm1pc3Npb24gdG8gdXNlLCBjb3B5LCBtb2RpZnksIGFuZC9vciBkaXN0cmlidXRlIHRoaXMgc29mdHdhcmUgZm9yIGFueQ0KcHVycG9zZSB3aXRoIG9yIHdpdGhvdXQgZmVlIGlzIGhlcmVieSBncmFudGVkLg0KDQpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiBBTkQgVEhFIEFVVEhPUiBESVNDTEFJTVMgQUxMIFdBUlJBTlRJRVMgV0lUSA0KUkVHQVJEIFRPIFRISVMgU09GVFdBUkUgSU5DTFVESU5HIEFMTCBJTVBMSUVEIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZDQpBTkQgRklUTkVTUy4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUiBCRSBMSUFCTEUgRk9SIEFOWSBTUEVDSUFMLCBESVJFQ1QsDQpJTkRJUkVDVCwgT1IgQ09OU0VRVUVOVElBTCBEQU1BR0VTIE9SIEFOWSBEQU1BR0VTIFdIQVRTT0VWRVIgUkVTVUxUSU5HIEZST00NCkxPU1MgT0YgVVNFLCBEQVRBIE9SIFBST0ZJVFMsIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBORUdMSUdFTkNFIE9SDQpPVEhFUiBUT1JUSU9VUyBBQ1RJT04sIEFSSVNJTkcgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgVVNFIE9SDQpQRVJGT1JNQU5DRSBPRiBUSElTIFNPRlRXQVJFLg==</text>
+          </license>
+        </licenses>
+      </evidence>
+    </component>
+    <component type="library" bom-ref="zone.js@0.14.10#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f">
+      <author>Brian Ford</author>
+      <name>zone.js</name>
+      <version>0.14.10</version>
+      <description>Zones for JavaScript</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/zone.js@0.14.10?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/angular/angular/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git://github.com/angular/angular.git#packages/zone.js</url>
+          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/angular/angular#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+      <evidence>
+        <licenses>
+          <license>
+            <name>file: LICENSE</name>
+            <text content-type="text/plain" encoding="base64">VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTAtMjAyNCBHb29nbGUgTExDLiBodHRwczovL2FuZ3VsYXIuaW8vbGljZW5zZQoKUGVybWlzc2lvbiBpcyBoZXJlYnkgZ3JhbnRlZCwgZnJlZSBvZiBjaGFyZ2UsIHRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weQpvZiB0aGlzIHNvZnR3YXJlIGFuZCBhc3NvY2lhdGVkIGRvY3VtZW50YXRpb24gZmlsZXMgKHRoZSAiU29mdHdhcmUiKSwgdG8gZGVhbAppbiB0aGUgU29mdHdhcmUgd2l0aG91dCByZXN0cmljdGlvbiwgaW5jbHVkaW5nIHdpdGhvdXQgbGltaXRhdGlvbiB0aGUgcmlnaHRzCnRvIHVzZSwgY29weSwgbW9kaWZ5LCBtZXJnZSwgcHVibGlzaCwgZGlzdHJpYnV0ZSwgc3VibGljZW5zZSwgYW5kL29yIHNlbGwKY29waWVzIG9mIHRoZSBTb2Z0d2FyZSwgYW5kIHRvIHBlcm1pdCBwZXJzb25zIHRvIHdob20gdGhlIFNvZnR3YXJlIGlzCmZ1cm5pc2hlZCB0byBkbyBzbywgc3ViamVjdCB0byB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnM6CgpUaGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBzaGFsbCBiZSBpbmNsdWRlZCBpbgphbGwgY29waWVzIG9yIHN1YnN0YW50aWFsIHBvcnRpb25zIG9mIHRoZSBTb2Z0d2FyZS4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiLCBXSVRIT1VUIFdBUlJBTlRZIE9GIEFOWSBLSU5ELCBFWFBSRVNTIE9SCklNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZLApGSVRORVNTIEZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRSBBTkQgTk9OSU5GUklOR0VNRU5ULiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUKQVVUSE9SUyBPUiBDT1BZUklHSFQgSE9MREVSUyBCRSBMSUFCTEUgRk9SIEFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUgpMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBUT1JUIE9SIE9USEVSV0lTRSwgQVJJU0lORyBGUk9NLApPVVQgT0YgT1IgSU4gQ09OTkVDVElPTiBXSVRIIFRIRSBTT0ZUV0FSRSBPUiBUSEUgVVNFIE9SIE9USEVSIERFQUxJTkdTIElOClRIRSBTT0ZUV0FSRS4K</text>
+          </license>
+        </licenses>
+      </evidence>
+    </component>
   </components>
   <dependencies>
-    <dependency ref="2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378">
-      <dependency ref="a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5"/>
-      <dependency ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
+    <dependency ref="@angular/common@18.2.7#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5">
+      <dependency ref="@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
+      <dependency ref="@babel/runtime@7.25.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"/>
+      <dependency ref="rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"/>
     </dependency>
-    <dependency ref="5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"/>
-    <dependency ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
-      <dependency ref="2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378"/>
-      <dependency ref="a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1"/>
-      <dependency ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
-      <dependency ref="daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"/>
+    <dependency ref="@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17">
+      <dependency ref="rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"/>
     </dependency>
-    <dependency ref="964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a">
-      <dependency ref="cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
+    <dependency ref="@angular/platform-browser@18.2.7#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378">
+      <dependency ref="@angular/common@18.2.7#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5"/>
+      <dependency ref="@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
     </dependency>
-    <dependency ref="9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"/>
-    <dependency ref="a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5">
-      <dependency ref="964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"/>
-      <dependency ref="9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"/>
-      <dependency ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
+    <dependency ref="@angular/router@18.2.7#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1">
+      <dependency ref="@angular/common@18.2.7#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5"/>
+      <dependency ref="@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
+      <dependency ref="@angular/platform-browser@18.2.7#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378"/>
+      <dependency ref="rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"/>
     </dependency>
-    <dependency ref="a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1">
-      <dependency ref="2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378"/>
-      <dependency ref="964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"/>
-      <dependency ref="a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5"/>
-      <dependency ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
+    <dependency ref="@babel/runtime@7.25.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"/>
+    <dependency ref="@cyclonedx-webpack-plugin-tests/feature-issue676@0.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+      <dependency ref="@angular/core@18.2.7#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
+      <dependency ref="@angular/platform-browser@18.2.7#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378"/>
+      <dependency ref="@angular/router@18.2.7#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1"/>
+      <dependency ref="css-loader@7.1.2#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"/>
     </dependency>
-    <dependency ref="cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
-    <dependency ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17">
-      <dependency ref="964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"/>
+    <dependency ref="css-loader@7.1.2#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"/>
+    <dependency ref="rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a">
+      <dependency ref="tslib@2.6.3#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
     </dependency>
-    <dependency ref="daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"/>
+    <dependency ref="tslib@2.6.3#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
+    <dependency ref="zone.js@0.14.10#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"/>
   </dependencies>
 </bom>"
 `;
@@ -1849,7 +1849,7 @@ exports[`integration feature: root component BuildSystem generated json file: di
       "type": "application",
       "name": "feature-issue1344",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/feature-issue1344@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jeremy Long",
       "description": "example setup with properly configured \`rootComponentBuildSystem\`",
       "licenses": [
@@ -1888,7 +1888,7 @@ exports[`integration feature: root component BuildSystem generated json file: di
   "components": [],
   "dependencies": [
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519"
+      "ref": "@cyclonedx-webpack-plugin-tests/feature-issue1344@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519"
     }
   ]
 }"
@@ -1983,7 +1983,7 @@ exports[`integration feature: root component BuildSystem generated json file: di
       "type": "application",
       "name": "feature-issue1344",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/feature-issue1344@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jeremy Long",
       "description": "example setup with properly configured \`rootComponentBuildSystem\`",
       "licenses": [
@@ -2022,7 +2022,7 @@ exports[`integration feature: root component BuildSystem generated json file: di
   "components": [],
   "dependencies": [
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519"
+      "ref": "@cyclonedx-webpack-plugin-tests/feature-issue1344@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519"
     }
   ]
 }"
@@ -2097,7 +2097,7 @@ exports[`integration feature: root component BuildSystem generated xml file: dis
         </component>
       </components>
     </tools>
-    <component type="application" bom-ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+    <component type="application" bom-ref="@cyclonedx-webpack-plugin-tests/feature-issue1344@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
       <author>Jeremy Long</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>feature-issue1344</name>
@@ -2130,7 +2130,7 @@ exports[`integration feature: root component BuildSystem generated xml file: dis
   </metadata>
   <components/>
   <dependencies>
-    <dependency ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519"/>
+    <dependency ref="@cyclonedx-webpack-plugin-tests/feature-issue1344@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519"/>
   </dependencies>
 </bom>"
 `;
@@ -2541,7 +2541,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "type": "application",
       "name": "example-webpack5-angular13",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-angular13@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jan Kowalleck",
       "description": "example setup witch Angular13 in WebPack5",
       "licenses": [
@@ -2575,113 +2575,10 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
   "components": [
     {
       "type": "library",
-      "name": "platform-browser",
-      "group": "@angular",
-      "version": "13.3.12",
-      "bom-ref": "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-      "author": "angular",
-      "description": "Angular - library for using Angular in a web browser",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/angular/angular.git#packages/platform-browser",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "zone.js",
-      "version": "0.11.8",
-      "bom-ref": "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
-      "author": "Brian Ford",
-      "description": "Zones for JavaScript",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/angular/angular.git#packages/zone.js",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "rxjs",
-      "version": "7.5.7",
-      "bom-ref": "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-      "author": "Ben Lesh",
-      "description": "Reactive Extensions for modern JavaScript",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ReactiveX/RxJS/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/reactivex/rxjs.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://rxjs.dev",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "common",
       "group": "@angular",
       "version": "13.3.12",
-      "bom-ref": "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+      "bom-ref": "@angular/common@13.3.12#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
       "author": "angular",
       "description": "Angular - commonly needed directives and services",
       "licenses": [
@@ -2713,44 +2610,10 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
     },
     {
       "type": "library",
-      "name": "tslib",
-      "version": "2.3.1",
-      "bom-ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
-      "author": "Microsoft Corp.",
-      "description": "Runtime library for TypeScript helper functions",
-      "licenses": [
-        {
-          "license": {
-            "id": "0BSD",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/Microsoft/TypeScript/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/Microsoft/tslib.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://www.typescriptlang.org/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "core",
       "group": "@angular",
       "version": "13.3.12",
-      "bom-ref": "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+      "bom-ref": "@angular/core@13.3.12#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
       "author": "angular",
       "description": "Angular - the core framework",
       "licenses": [
@@ -2782,9 +2645,44 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
     },
     {
       "type": "library",
+      "name": "platform-browser",
+      "group": "@angular",
+      "version": "13.3.12",
+      "bom-ref": "@angular/platform-browser@13.3.12#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "author": "angular",
+      "description": "Angular - library for using Angular in a web browser",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/angular/angular.git#packages/platform-browser",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
       "name": "css-loader",
       "version": "6.5.1",
-      "bom-ref": "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
+      "bom-ref": "css-loader@6.5.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
       "author": "Tobias Koppers @sokra",
       "description": "css loader module for webpack",
       "licenses": [
@@ -2813,52 +2711,154 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
       ]
+    },
+    {
+      "type": "library",
+      "name": "rxjs",
+      "version": "7.5.7",
+      "bom-ref": "rxjs@7.5.7#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+      "author": "Ben Lesh",
+      "description": "Reactive Extensions for modern JavaScript",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ReactiveX/RxJS/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/reactivex/rxjs.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://rxjs.dev",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "tslib",
+      "version": "2.3.1",
+      "bom-ref": "tslib@2.3.1#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
+      "author": "Microsoft Corp.",
+      "description": "Runtime library for TypeScript helper functions",
+      "licenses": [
+        {
+          "license": {
+            "id": "0BSD",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/Microsoft/TypeScript/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/Microsoft/tslib.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://www.typescriptlang.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "zone.js",
+      "version": "0.11.8",
+      "bom-ref": "zone.js@0.11.8#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
+      "author": "Brian Ford",
+      "description": "Zones for JavaScript",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/angular/angular.git#packages/zone.js",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
     }
   ],
   "dependencies": [
     {
-      "ref": "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "ref": "@angular/common@13.3.12#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
       "dependsOn": [
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/core@13.3.12#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
       ]
     },
     {
-      "ref": "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
-    },
-    {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@angular/core@13.3.12#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
       "dependsOn": [
-        "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-        "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
-        "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
+        "rxjs@7.5.7#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+      "ref": "@angular/platform-browser@13.3.12#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
       "dependsOn": [
-        "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+        "@angular/common@13.3.12#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@13.3.12#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
       ]
     },
     {
-      "ref": "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+      "ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-angular13@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/common@13.3.12#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@13.3.12#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/platform-browser@13.3.12#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+        "css-loader@6.5.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
+        "zone.js@0.11.8#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
       ]
     },
     {
-      "ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+      "ref": "css-loader@6.5.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
     },
     {
-      "ref": "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+      "ref": "rxjs@7.5.7#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
       "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
+        "tslib@2.3.1#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
       ]
     },
     {
-      "ref": "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
+      "ref": "tslib@2.3.1#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+    },
+    {
+      "ref": "zone.js@0.11.8#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
     }
   ]
 }"
@@ -2953,7 +2953,7 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
       "type": "application",
       "name": "example-webpack5-angular13",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-angular13@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jan Kowalleck",
       "description": "example setup witch Angular13 in WebPack5",
       "licenses": [
@@ -2987,113 +2987,10 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
   "components": [
     {
       "type": "library",
-      "name": "platform-browser",
-      "group": "@angular",
-      "version": "13.3.12",
-      "bom-ref": "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-      "author": "angular",
-      "description": "Angular - library for using Angular in a web browser",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/angular/angular.git#packages/platform-browser",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "zone.js",
-      "version": "0.11.8",
-      "bom-ref": "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
-      "author": "Brian Ford",
-      "description": "Zones for JavaScript",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/angular/angular.git#packages/zone.js",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "rxjs",
-      "version": "7.5.7",
-      "bom-ref": "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-      "author": "Ben Lesh",
-      "description": "Reactive Extensions for modern JavaScript",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ReactiveX/RxJS/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/reactivex/rxjs.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://rxjs.dev",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "common",
       "group": "@angular",
       "version": "13.3.12",
-      "bom-ref": "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+      "bom-ref": "@angular/common@13.3.12#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
       "author": "angular",
       "description": "Angular - commonly needed directives and services",
       "licenses": [
@@ -3125,44 +3022,10 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
     },
     {
       "type": "library",
-      "name": "tslib",
-      "version": "2.3.1",
-      "bom-ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
-      "author": "Microsoft Corp.",
-      "description": "Runtime library for TypeScript helper functions",
-      "licenses": [
-        {
-          "license": {
-            "id": "0BSD",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/Microsoft/TypeScript/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/Microsoft/tslib.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://www.typescriptlang.org/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "core",
       "group": "@angular",
       "version": "13.3.12",
-      "bom-ref": "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+      "bom-ref": "@angular/core@13.3.12#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
       "author": "angular",
       "description": "Angular - the core framework",
       "licenses": [
@@ -3194,9 +3057,44 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
     },
     {
       "type": "library",
+      "name": "platform-browser",
+      "group": "@angular",
+      "version": "13.3.12",
+      "bom-ref": "@angular/platform-browser@13.3.12#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "author": "angular",
+      "description": "Angular - library for using Angular in a web browser",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/angular/angular.git#packages/platform-browser",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
       "name": "css-loader",
       "version": "6.5.1",
-      "bom-ref": "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
+      "bom-ref": "css-loader@6.5.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
       "author": "Tobias Koppers @sokra",
       "description": "css loader module for webpack",
       "licenses": [
@@ -3225,52 +3123,154 @@ exports[`integration functional: webpack5 with angular13 generated json file: di
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
       ]
+    },
+    {
+      "type": "library",
+      "name": "rxjs",
+      "version": "7.5.7",
+      "bom-ref": "rxjs@7.5.7#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+      "author": "Ben Lesh",
+      "description": "Reactive Extensions for modern JavaScript",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ReactiveX/RxJS/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/reactivex/rxjs.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://rxjs.dev",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "tslib",
+      "version": "2.3.1",
+      "bom-ref": "tslib@2.3.1#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
+      "author": "Microsoft Corp.",
+      "description": "Runtime library for TypeScript helper functions",
+      "licenses": [
+        {
+          "license": {
+            "id": "0BSD",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/Microsoft/TypeScript/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/Microsoft/tslib.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://www.typescriptlang.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "zone.js",
+      "version": "0.11.8",
+      "bom-ref": "zone.js@0.11.8#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
+      "author": "Brian Ford",
+      "description": "Zones for JavaScript",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/angular/angular.git#packages/zone.js",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
     }
   ],
   "dependencies": [
     {
-      "ref": "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "ref": "@angular/common@13.3.12#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
       "dependsOn": [
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/core@13.3.12#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
       ]
     },
     {
-      "ref": "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
-    },
-    {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@angular/core@13.3.12#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
       "dependsOn": [
-        "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-        "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
-        "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
+        "rxjs@7.5.7#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+      "ref": "@angular/platform-browser@13.3.12#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
       "dependsOn": [
-        "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+        "@angular/common@13.3.12#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@13.3.12#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
       ]
     },
     {
-      "ref": "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+      "ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-angular13@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/common@13.3.12#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@13.3.12#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/platform-browser@13.3.12#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+        "css-loader@6.5.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
+        "zone.js@0.11.8#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
       ]
     },
     {
-      "ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+      "ref": "css-loader@6.5.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
     },
     {
-      "ref": "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+      "ref": "rxjs@7.5.7#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
       "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
+        "tslib@2.3.1#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
       ]
     },
     {
-      "ref": "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
+      "ref": "tslib@2.3.1#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+    },
+    {
+      "ref": "zone.js@0.11.8#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
     }
   ]
 }"
@@ -3345,7 +3345,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
         </component>
       </components>
     </tools>
-    <component type="application" bom-ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+    <component type="application" bom-ref="@cyclonedx-webpack-plugin-tests/example-webpack5-angular13@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
       <author>Jan Kowalleck</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>example-webpack5-angular13</name>
@@ -3373,86 +3373,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378">
-      <author>angular</author>
-      <group>@angular</group>
-      <name>platform-browser</name>
-      <version>13.3.12</version>
-      <description>Angular - library for using Angular in a web browser</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/angular/angular/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/angular/angular.git#packages/platform-browser</url>
-          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/angular/angular#readme</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f">
-      <author>Brian Ford</author>
-      <name>zone.js</name>
-      <version>0.11.8</version>
-      <description>Zones for JavaScript</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/angular/angular/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git://github.com/angular/angular.git#packages/zone.js</url>
-          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/angular/angular#readme</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a">
-      <author>Ben Lesh</author>
-      <name>rxjs</name>
-      <version>7.5.7</version>
-      <description>Reactive Extensions for modern JavaScript</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>Apache-2.0</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/ReactiveX/RxJS/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/reactivex/rxjs.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://rxjs.dev</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5">
+    <component type="library" bom-ref="@angular/common@13.3.12#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5">
       <author>angular</author>
       <group>@angular</group>
       <name>common</name>
@@ -3479,33 +3400,7 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc">
-      <author>Microsoft Corp.</author>
-      <name>tslib</name>
-      <version>2.3.1</version>
-      <description>Runtime library for TypeScript helper functions</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>0BSD</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/Microsoft/TypeScript/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/Microsoft/tslib.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://www.typescriptlang.org/</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17">
+    <component type="library" bom-ref="@angular/core@13.3.12#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17">
       <author>angular</author>
       <group>@angular</group>
       <name>core</name>
@@ -3532,7 +3427,34 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a">
+    <component type="library" bom-ref="@angular/platform-browser@13.3.12#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378">
+      <author>angular</author>
+      <group>@angular</group>
+      <name>platform-browser</name>
+      <version>13.3.12</version>
+      <description>Angular - library for using Angular in a web browser</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/%40angular/platform-browser@13.3.12?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/angular/angular/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/angular/angular.git#packages/platform-browser</url>
+          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/angular/angular#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="css-loader@6.5.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a">
       <author>Tobias Koppers @sokra</author>
       <name>css-loader</name>
       <version>6.5.1</version>
@@ -3558,31 +3480,109 @@ exports[`integration functional: webpack5 with angular13 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="rxjs@7.5.7#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a">
+      <author>Ben Lesh</author>
+      <name>rxjs</name>
+      <version>7.5.7</version>
+      <description>Reactive Extensions for modern JavaScript</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/rxjs@7.5.7?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/ReactiveX/RxJS/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/reactivex/rxjs.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://rxjs.dev</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="tslib@2.3.1#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc">
+      <author>Microsoft Corp.</author>
+      <name>tslib</name>
+      <version>2.3.1</version>
+      <description>Runtime library for TypeScript helper functions</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>0BSD</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/tslib@2.3.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/Microsoft/TypeScript/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/Microsoft/tslib.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://www.typescriptlang.org/</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="zone.js@0.11.8#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f">
+      <author>Brian Ford</author>
+      <name>zone.js</name>
+      <version>0.11.8</version>
+      <description>Zones for JavaScript</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/zone.js@0.11.8?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/angular/angular/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git://github.com/angular/angular.git#packages/zone.js</url>
+          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/angular/angular#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
   </components>
   <dependencies>
-    <dependency ref="2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378">
-      <dependency ref="a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5"/>
-      <dependency ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
+    <dependency ref="@angular/common@13.3.12#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5">
+      <dependency ref="@angular/core@13.3.12#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
     </dependency>
-    <dependency ref="5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"/>
-    <dependency ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
-      <dependency ref="2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378"/>
-      <dependency ref="5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"/>
-      <dependency ref="a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5"/>
-      <dependency ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
-      <dependency ref="daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"/>
+    <dependency ref="@angular/core@13.3.12#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17">
+      <dependency ref="rxjs@7.5.7#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"/>
     </dependency>
-    <dependency ref="964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a">
-      <dependency ref="cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
+    <dependency ref="@angular/platform-browser@13.3.12#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378">
+      <dependency ref="@angular/common@13.3.12#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5"/>
+      <dependency ref="@angular/core@13.3.12#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
     </dependency>
-    <dependency ref="a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5">
-      <dependency ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
+    <dependency ref="@cyclonedx-webpack-plugin-tests/example-webpack5-angular13@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+      <dependency ref="@angular/common@13.3.12#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5"/>
+      <dependency ref="@angular/core@13.3.12#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
+      <dependency ref="@angular/platform-browser@13.3.12#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378"/>
+      <dependency ref="css-loader@6.5.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"/>
+      <dependency ref="zone.js@0.11.8#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"/>
     </dependency>
-    <dependency ref="cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
-    <dependency ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17">
-      <dependency ref="964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"/>
+    <dependency ref="css-loader@6.5.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"/>
+    <dependency ref="rxjs@7.5.7#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a">
+      <dependency ref="tslib@2.3.1#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
     </dependency>
-    <dependency ref="daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"/>
+    <dependency ref="tslib@2.3.1#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
+    <dependency ref="zone.js@0.11.8#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"/>
   </dependencies>
 </bom>"
 `;
@@ -3677,7 +3677,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "name": "example-webpack5-angular17",
       "group": "@cyclonedx-webpack-plugin-tests",
       "version": "0.0.0",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jan Kowalleck",
       "description": "example setup witch Angular17 in WebPack5",
       "licenses": [
@@ -3706,148 +3706,10 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
   "components": [
     {
       "type": "library",
-      "name": "platform-browser",
-      "group": "@angular",
-      "version": "17.3.0",
-      "bom-ref": "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-      "author": "angular",
-      "description": "Angular - library for using Angular in a web browser",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/angular/angular.git#packages/platform-browser",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "zone.js",
-      "version": "0.14.4",
-      "bom-ref": "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
-      "author": "Brian Ford",
-      "description": "Zones for JavaScript",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/zone.js@0.14.4?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/angular/angular.git#packages/zone.js",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "rxjs",
-      "version": "7.8.1",
-      "bom-ref": "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-      "author": "Ben Lesh",
-      "description": "Reactive Extensions for modern JavaScript",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ReactiveX/RxJS/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/reactivex/rxjs.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://rxjs.dev",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "runtime",
-      "group": "@babel",
-      "version": "7.24.0",
-      "bom-ref": "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
-      "author": "The Babel Team",
-      "description": "babel's modular runtime helpers",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git%23packages%2Fbabel-runtime",
-      "externalReferences": [
-        {
-          "url": "https://github.com/babel/babel/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/babel/babel.git#packages/babel-runtime",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://babel.dev/docs/en/next/babel-runtime",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "common",
       "group": "@angular",
       "version": "17.3.0",
-      "bom-ref": "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+      "bom-ref": "@angular/common@17.3.0#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
       "author": "angular",
       "description": "Angular - commonly needed directives and services",
       "licenses": [
@@ -3879,79 +3741,10 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
     },
     {
       "type": "library",
-      "name": "router",
-      "group": "@angular",
-      "version": "17.3.0",
-      "bom-ref": "a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
-      "author": "angular",
-      "description": "Angular - the routing library",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Frouter",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/angular/angular.git#packages/router",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular/tree/main/packages/router",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "tslib",
-      "version": "2.6.2",
-      "bom-ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
-      "author": "Microsoft Corp.",
-      "description": "Runtime library for TypeScript helper functions",
-      "licenses": [
-        {
-          "license": {
-            "id": "0BSD",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/Microsoft/TypeScript/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/Microsoft/tslib.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://www.typescriptlang.org/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "core",
       "group": "@angular",
       "version": "17.3.0",
-      "bom-ref": "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+      "bom-ref": "@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
       "author": "angular",
       "description": "Angular - the core framework",
       "licenses": [
@@ -3983,9 +3776,114 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
     },
     {
       "type": "library",
+      "name": "platform-browser",
+      "group": "@angular",
+      "version": "17.3.0",
+      "bom-ref": "@angular/platform-browser@17.3.0#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "author": "angular",
+      "description": "Angular - library for using Angular in a web browser",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/angular/angular.git#packages/platform-browser",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "router",
+      "group": "@angular",
+      "version": "17.3.0",
+      "bom-ref": "@angular/router@17.3.0#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
+      "author": "angular",
+      "description": "Angular - the routing library",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Frouter",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/angular/angular.git#packages/router",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular/tree/main/packages/router",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "runtime",
+      "group": "@babel",
+      "version": "7.24.0",
+      "bom-ref": "@babel/runtime@7.24.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
+      "author": "The Babel Team",
+      "description": "babel's modular runtime helpers",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git%23packages%2Fbabel-runtime",
+      "externalReferences": [
+        {
+          "url": "https://github.com/babel/babel/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/babel/babel.git#packages/babel-runtime",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://babel.dev/docs/en/next/babel-runtime",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
       "name": "css-loader",
       "version": "6.10.0",
-      "bom-ref": "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
+      "bom-ref": "css-loader@6.10.0#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
       "author": "Tobias Koppers @sokra",
       "description": "css loader module for webpack",
       "licenses": [
@@ -4014,66 +3912,168 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
       ]
+    },
+    {
+      "type": "library",
+      "name": "rxjs",
+      "version": "7.8.1",
+      "bom-ref": "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+      "author": "Ben Lesh",
+      "description": "Reactive Extensions for modern JavaScript",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ReactiveX/RxJS/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/reactivex/rxjs.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://rxjs.dev",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "tslib",
+      "version": "2.6.2",
+      "bom-ref": "tslib@2.6.2#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
+      "author": "Microsoft Corp.",
+      "description": "Runtime library for TypeScript helper functions",
+      "licenses": [
+        {
+          "license": {
+            "id": "0BSD",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/Microsoft/TypeScript/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/Microsoft/tslib.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://www.typescriptlang.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "zone.js",
+      "version": "0.14.4",
+      "bom-ref": "zone.js@0.14.4#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
+      "author": "Brian Ford",
+      "description": "Zones for JavaScript",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/zone.js@0.14.4?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/angular/angular.git#packages/zone.js",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
     }
   ],
   "dependencies": [
     {
-      "ref": "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "ref": "@angular/common@17.3.0#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
       "dependsOn": [
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@babel/runtime@7.24.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
+        "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
-    },
-    {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
       "dependsOn": [
-        "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-        "a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
-        "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
+        "@babel/runtime@7.24.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
+        "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+      "ref": "@angular/platform-browser@17.3.0#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
       "dependsOn": [
-        "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+        "@angular/common@17.3.0#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
       ]
     },
     {
-      "ref": "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"
-    },
-    {
-      "ref": "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+      "ref": "@angular/router@17.3.0#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
       "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/common@17.3.0#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/platform-browser@17.3.0#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+        "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
+      "ref": "@babel/runtime@7.24.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"
+    },
+    {
+      "ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/platform-browser@17.3.0#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+        "@angular/router@17.3.0#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
+        "css-loader@6.10.0#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
       ]
     },
     {
-      "ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+      "ref": "css-loader@6.10.0#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
     },
     {
-      "ref": "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+      "ref": "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
       "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"
+        "tslib@2.6.2#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
       ]
     },
     {
-      "ref": "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
+      "ref": "tslib@2.6.2#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+    },
+    {
+      "ref": "zone.js@0.14.4#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
     }
   ]
 }"
@@ -4169,7 +4169,7 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
       "name": "example-webpack5-angular17",
       "group": "@cyclonedx-webpack-plugin-tests",
       "version": "0.0.0",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jan Kowalleck",
       "description": "example setup witch Angular17 in WebPack5",
       "licenses": [
@@ -4198,148 +4198,10 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
   "components": [
     {
       "type": "library",
-      "name": "platform-browser",
-      "group": "@angular",
-      "version": "17.3.0",
-      "bom-ref": "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-      "author": "angular",
-      "description": "Angular - library for using Angular in a web browser",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/angular/angular.git#packages/platform-browser",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "zone.js",
-      "version": "0.14.4",
-      "bom-ref": "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
-      "author": "Brian Ford",
-      "description": "Zones for JavaScript",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/zone.js@0.14.4?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/angular/angular.git#packages/zone.js",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "rxjs",
-      "version": "7.8.1",
-      "bom-ref": "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-      "author": "Ben Lesh",
-      "description": "Reactive Extensions for modern JavaScript",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/ReactiveX/RxJS/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/reactivex/rxjs.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://rxjs.dev",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "runtime",
-      "group": "@babel",
-      "version": "7.24.0",
-      "bom-ref": "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
-      "author": "The Babel Team",
-      "description": "babel's modular runtime helpers",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git%23packages%2Fbabel-runtime",
-      "externalReferences": [
-        {
-          "url": "https://github.com/babel/babel/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/babel/babel.git#packages/babel-runtime",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://babel.dev/docs/en/next/babel-runtime",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "common",
       "group": "@angular",
       "version": "17.3.0",
-      "bom-ref": "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+      "bom-ref": "@angular/common@17.3.0#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
       "author": "angular",
       "description": "Angular - commonly needed directives and services",
       "licenses": [
@@ -4371,79 +4233,10 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
     },
     {
       "type": "library",
-      "name": "router",
-      "group": "@angular",
-      "version": "17.3.0",
-      "bom-ref": "a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
-      "author": "angular",
-      "description": "Angular - the routing library",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Frouter",
-      "externalReferences": [
-        {
-          "url": "https://github.com/angular/angular/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/angular/angular.git#packages/router",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://github.com/angular/angular/tree/main/packages/router",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "tslib",
-      "version": "2.6.2",
-      "bom-ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
-      "author": "Microsoft Corp.",
-      "description": "Runtime library for TypeScript helper functions",
-      "licenses": [
-        {
-          "license": {
-            "id": "0BSD",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/Microsoft/TypeScript/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/Microsoft/tslib.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://www.typescriptlang.org/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "core",
       "group": "@angular",
       "version": "17.3.0",
-      "bom-ref": "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+      "bom-ref": "@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
       "author": "angular",
       "description": "Angular - the core framework",
       "licenses": [
@@ -4475,9 +4268,114 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
     },
     {
       "type": "library",
+      "name": "platform-browser",
+      "group": "@angular",
+      "version": "17.3.0",
+      "bom-ref": "@angular/platform-browser@17.3.0#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "author": "angular",
+      "description": "Angular - library for using Angular in a web browser",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/angular/angular.git#packages/platform-browser",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "router",
+      "group": "@angular",
+      "version": "17.3.0",
+      "bom-ref": "@angular/router@17.3.0#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
+      "author": "angular",
+      "description": "Angular - the routing library",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Frouter",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/angular/angular.git#packages/router",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular/tree/main/packages/router",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "runtime",
+      "group": "@babel",
+      "version": "7.24.0",
+      "bom-ref": "@babel/runtime@7.24.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
+      "author": "The Babel Team",
+      "description": "babel's modular runtime helpers",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git%23packages%2Fbabel-runtime",
+      "externalReferences": [
+        {
+          "url": "https://github.com/babel/babel/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/babel/babel.git#packages/babel-runtime",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://babel.dev/docs/en/next/babel-runtime",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
       "name": "css-loader",
       "version": "6.10.0",
-      "bom-ref": "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
+      "bom-ref": "css-loader@6.10.0#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
       "author": "Tobias Koppers @sokra",
       "description": "css loader module for webpack",
       "licenses": [
@@ -4506,66 +4404,168 @@ exports[`integration functional: webpack5 with angular17 generated json file: di
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
       ]
+    },
+    {
+      "type": "library",
+      "name": "rxjs",
+      "version": "7.8.1",
+      "bom-ref": "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+      "author": "Ben Lesh",
+      "description": "Reactive Extensions for modern JavaScript",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/ReactiveX/RxJS/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/reactivex/rxjs.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://rxjs.dev",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "tslib",
+      "version": "2.6.2",
+      "bom-ref": "tslib@2.6.2#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
+      "author": "Microsoft Corp.",
+      "description": "Runtime library for TypeScript helper functions",
+      "licenses": [
+        {
+          "license": {
+            "id": "0BSD",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/Microsoft/TypeScript/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/Microsoft/tslib.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://www.typescriptlang.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "zone.js",
+      "version": "0.14.4",
+      "bom-ref": "zone.js@0.14.4#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f",
+      "author": "Brian Ford",
+      "description": "Zones for JavaScript",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/zone.js@0.14.4?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js",
+      "externalReferences": [
+        {
+          "url": "https://github.com/angular/angular/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/angular/angular.git#packages/zone.js",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://github.com/angular/angular#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
     }
   ],
   "dependencies": [
     {
-      "ref": "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+      "ref": "@angular/common@17.3.0#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
       "dependsOn": [
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@babel/runtime@7.24.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
+        "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
-    },
-    {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
       "dependsOn": [
-        "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-        "a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
-        "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
+        "@babel/runtime@7.24.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
+        "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
+      "ref": "@angular/platform-browser@17.3.0#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
       "dependsOn": [
-        "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+        "@angular/common@17.3.0#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
       ]
     },
     {
-      "ref": "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"
-    },
-    {
-      "ref": "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+      "ref": "@angular/router@17.3.0#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
       "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/common@17.3.0#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
+        "@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/platform-browser@17.3.0#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+        "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"
       ]
     },
     {
-      "ref": "a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
+      "ref": "@babel/runtime@7.24.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"
+    },
+    {
+      "ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5",
-        "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"
+        "@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+        "@angular/platform-browser@17.3.0#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378",
+        "@angular/router@17.3.0#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1",
+        "css-loader@6.10.0#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
       ]
     },
     {
-      "ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+      "ref": "css-loader@6.10.0#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
     },
     {
-      "ref": "ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17",
+      "ref": "rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
       "dependsOn": [
-        "964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a",
-        "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"
+        "tslib@2.6.2#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
       ]
     },
     {
-      "ref": "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
+      "ref": "tslib@2.6.2#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+    },
+    {
+      "ref": "zone.js@0.14.4#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"
     }
   ]
 }"
@@ -4640,7 +4640,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
         </component>
       </components>
     </tools>
-    <component type="application" bom-ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+    <component type="application" bom-ref="@cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
       <author>Jan Kowalleck</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>example-webpack5-angular17</name>
@@ -4665,113 +4665,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378">
-      <author>angular</author>
-      <group>@angular</group>
-      <name>platform-browser</name>
-      <version>17.3.0</version>
-      <description>Angular - library for using Angular in a web browser</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/angular/angular/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/angular/angular.git#packages/platform-browser</url>
-          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/angular/angular#readme</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f">
-      <author>Brian Ford</author>
-      <name>zone.js</name>
-      <version>0.14.4</version>
-      <description>Zones for JavaScript</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/zone.js@0.14.4?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/angular/angular/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git://github.com/angular/angular.git#packages/zone.js</url>
-          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/angular/angular#readme</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a">
-      <author>Ben Lesh</author>
-      <name>rxjs</name>
-      <version>7.8.1</version>
-      <description>Reactive Extensions for modern JavaScript</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>Apache-2.0</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/ReactiveX/RxJS/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/reactivex/rxjs.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://rxjs.dev</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b">
-      <author>The Babel Team</author>
-      <group>@babel</group>
-      <name>runtime</name>
-      <version>7.24.0</version>
-      <description>babel's modular runtime helpers</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git%23packages%2Fbabel-runtime</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/babel/babel/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/babel/babel.git#packages/babel-runtime</url>
-          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://babel.dev/docs/en/next/babel-runtime</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5">
+    <component type="library" bom-ref="@angular/common@17.3.0#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5">
       <author>angular</author>
       <group>@angular</group>
       <name>common</name>
@@ -4798,60 +4692,7 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1">
-      <author>angular</author>
-      <group>@angular</group>
-      <name>router</name>
-      <version>17.3.0</version>
-      <description>Angular - the routing library</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Frouter</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/angular/angular/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/angular/angular.git#packages/router</url>
-          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/angular/angular/tree/main/packages/router</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc">
-      <author>Microsoft Corp.</author>
-      <name>tslib</name>
-      <version>2.6.2</version>
-      <description>Runtime library for TypeScript helper functions</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>0BSD</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/Microsoft/TypeScript/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/Microsoft/tslib.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://www.typescriptlang.org/</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17">
+    <component type="library" bom-ref="@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17">
       <author>angular</author>
       <group>@angular</group>
       <name>core</name>
@@ -4878,7 +4719,88 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a">
+    <component type="library" bom-ref="@angular/platform-browser@17.3.0#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378">
+      <author>angular</author>
+      <group>@angular</group>
+      <name>platform-browser</name>
+      <version>17.3.0</version>
+      <description>Angular - library for using Angular in a web browser</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/%40angular/platform-browser@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fplatform-browser</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/angular/angular/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/angular/angular.git#packages/platform-browser</url>
+          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/angular/angular#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="@angular/router@17.3.0#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1">
+      <author>angular</author>
+      <group>@angular</group>
+      <name>router</name>
+      <version>17.3.0</version>
+      <description>Angular - the routing library</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/%40angular/router@17.3.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Frouter</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/angular/angular/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/angular/angular.git#packages/router</url>
+          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/angular/angular/tree/main/packages/router</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="@babel/runtime@7.24.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b">
+      <author>The Babel Team</author>
+      <group>@babel</group>
+      <name>runtime</name>
+      <version>7.24.0</version>
+      <description>babel's modular runtime helpers</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/%40babel/runtime@7.24.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbabel%2Fbabel.git%23packages%2Fbabel-runtime</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/babel/babel/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/babel/babel.git#packages/babel-runtime</url>
+          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://babel.dev/docs/en/next/babel-runtime</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="css-loader@6.10.0#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a">
       <author>Tobias Koppers @sokra</author>
       <name>css-loader</name>
       <version>6.10.0</version>
@@ -4904,40 +4826,118 @@ exports[`integration functional: webpack5 with angular17 generated xml file: dis
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a">
+      <author>Ben Lesh</author>
+      <name>rxjs</name>
+      <version>7.8.1</version>
+      <description>Reactive Extensions for modern JavaScript</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/rxjs@7.8.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Freactivex%2Frxjs.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/ReactiveX/RxJS/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/reactivex/rxjs.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://rxjs.dev</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="tslib@2.6.2#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc">
+      <author>Microsoft Corp.</author>
+      <name>tslib</name>
+      <version>2.6.2</version>
+      <description>Runtime library for TypeScript helper functions</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>0BSD</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/tslib@2.6.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/Microsoft/TypeScript/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/Microsoft/tslib.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://www.typescriptlang.org/</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="zone.js@0.14.4#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f">
+      <author>Brian Ford</author>
+      <name>zone.js</name>
+      <version>0.14.4</version>
+      <description>Zones for JavaScript</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/zone.js@0.14.4?vcs_url=git%3A%2F%2Fgithub.com%2Fangular%2Fangular.git%23packages%2Fzone.js</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/angular/angular/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git://github.com/angular/angular.git#packages/zone.js</url>
+          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/angular/angular#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
   </components>
   <dependencies>
-    <dependency ref="2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378">
-      <dependency ref="a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5"/>
-      <dependency ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
+    <dependency ref="@angular/common@17.3.0#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5">
+      <dependency ref="@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
+      <dependency ref="@babel/runtime@7.24.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"/>
+      <dependency ref="rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"/>
     </dependency>
-    <dependency ref="5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"/>
-    <dependency ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
-      <dependency ref="2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378"/>
-      <dependency ref="a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1"/>
-      <dependency ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
-      <dependency ref="daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"/>
+    <dependency ref="@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17">
+      <dependency ref="@babel/runtime@7.24.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"/>
+      <dependency ref="rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"/>
     </dependency>
-    <dependency ref="964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a">
-      <dependency ref="cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
+    <dependency ref="@angular/platform-browser@17.3.0#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378">
+      <dependency ref="@angular/common@17.3.0#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5"/>
+      <dependency ref="@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
     </dependency>
-    <dependency ref="9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"/>
-    <dependency ref="a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5">
-      <dependency ref="964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"/>
-      <dependency ref="9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"/>
-      <dependency ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
+    <dependency ref="@angular/router@17.3.0#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1">
+      <dependency ref="@angular/common@17.3.0#a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5"/>
+      <dependency ref="@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
+      <dependency ref="@angular/platform-browser@17.3.0#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378"/>
+      <dependency ref="rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"/>
     </dependency>
-    <dependency ref="a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1">
-      <dependency ref="2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378"/>
-      <dependency ref="964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"/>
-      <dependency ref="a8ab9714ac8f3afee60feeb69e749289d3bb0e08c37a7e4a7771944016aea0e5"/>
-      <dependency ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
+    <dependency ref="@babel/runtime@7.24.0#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"/>
+    <dependency ref="@cyclonedx-webpack-plugin-tests/example-webpack5-angular17@0.0.0#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+      <dependency ref="@angular/core@17.3.0#ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17"/>
+      <dependency ref="@angular/platform-browser@17.3.0#2672f7b819d52ffa2b2bdcd3a0920bb1dc7bff99dd1dd1124f0929e3b134f378"/>
+      <dependency ref="@angular/router@17.3.0#a99b7cefcaf9918864bb583ac276159ca0d597212f1304166f00d69a407f4aa1"/>
+      <dependency ref="css-loader@6.10.0#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"/>
     </dependency>
-    <dependency ref="cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
-    <dependency ref="ccf96d519a01e749e889ebc527bae74eb8ca18bedf24ba3616388e9f6ba69d17">
-      <dependency ref="964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a"/>
-      <dependency ref="9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"/>
+    <dependency ref="css-loader@6.10.0#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"/>
+    <dependency ref="rxjs@7.8.1#964271ed27195d6c61e3da02b45077b583e6f1586488cf90970f3995006a412a">
+      <dependency ref="tslib@2.6.2#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
     </dependency>
-    <dependency ref="daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"/>
+    <dependency ref="tslib@2.6.2#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
+    <dependency ref="zone.js@0.14.4#5b3f5d53e0d9777586349e7e693fbccc5d77389054db817358a0b5bd4476195f"/>
   </dependencies>
 </bom>"
 `;
@@ -5032,7 +5032,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "name": "example-webpack5-react18",
       "group": "@cyclonedx-webpack-plugin-tests",
       "version": "0.0.1",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jan Kowalleck",
       "description": "example setup with react and webpack5",
       "licenses": [
@@ -5066,77 +5066,10 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
   "components": [
     {
       "type": "library",
-      "name": "react-dom",
-      "version": "18.2.0",
-      "bom-ref": "23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
-      "description": "React package for working with the DOM.",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Freact-dom",
-      "externalReferences": [
-        {
-          "url": "https://github.com/facebook/react/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/facebook/react.git#packages/react-dom",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://reactjs.org/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "web-vitals",
-      "version": "2.1.4",
-      "bom-ref": "95074e4bc863bb89cdc9486e4462e4a89d52b9bb1c8e26bed4e612c9d0cfa5cd",
-      "author": "Philip Walton",
-      "description": "Easily measure performance metrics in JavaScript",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FGoogleChrome%2Fweb-vitals.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/GoogleChrome/web-vitals/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/GoogleChrome/web-vitals.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/GoogleChrome/web-vitals#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "runtime",
       "group": "@babel",
       "version": "7.18.3",
-      "bom-ref": "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
+      "bom-ref": "@babel/runtime@7.18.3#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
       "author": "The Babel Team",
       "description": "babel's modular runtime helpers",
       "licenses": [
@@ -5168,42 +5101,9 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
     },
     {
       "type": "library",
-      "name": "scheduler",
-      "version": "0.23.0",
-      "bom-ref": "ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403",
-      "description": "Cooperative scheduler for the browser environment.",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Fscheduler",
-      "externalReferences": [
-        {
-          "url": "https://github.com/facebook/react/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/facebook/react.git#packages/scheduler",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://reactjs.org/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "css-loader",
       "version": "6.7.1",
-      "bom-ref": "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
+      "bom-ref": "css-loader@6.7.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
       "author": "Tobias Koppers @sokra",
       "description": "css loader module for webpack",
       "licenses": [
@@ -5235,9 +5135,42 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
     },
     {
       "type": "library",
+      "name": "react-dom",
+      "version": "18.2.0",
+      "bom-ref": "react-dom@18.2.0#23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
+      "description": "React package for working with the DOM.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Freact-dom",
+      "externalReferences": [
+        {
+          "url": "https://github.com/facebook/react/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/facebook/react.git#packages/react-dom",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://reactjs.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
       "name": "react",
       "version": "18.2.0",
-      "bom-ref": "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
+      "bom-ref": "react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
       "description": "React is a JavaScript library for building user interfaces.",
       "licenses": [
         {
@@ -5265,39 +5198,106 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
       ]
+    },
+    {
+      "type": "library",
+      "name": "scheduler",
+      "version": "0.23.0",
+      "bom-ref": "scheduler@0.23.0#ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403",
+      "description": "Cooperative scheduler for the browser environment.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Fscheduler",
+      "externalReferences": [
+        {
+          "url": "https://github.com/facebook/react/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/facebook/react.git#packages/scheduler",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://reactjs.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "web-vitals",
+      "version": "2.1.4",
+      "bom-ref": "web-vitals@2.1.4#95074e4bc863bb89cdc9486e4462e4a89d52b9bb1c8e26bed4e612c9d0cfa5cd",
+      "author": "Philip Walton",
+      "description": "Easily measure performance metrics in JavaScript",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FGoogleChrome%2Fweb-vitals.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/GoogleChrome/web-vitals/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/GoogleChrome/web-vitals.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/GoogleChrome/web-vitals#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
     }
   ],
   "dependencies": [
     {
-      "ref": "23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
+      "ref": "@babel/runtime@7.18.3#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"
+    },
+    {
+      "ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403",
-        "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
+        "@babel/runtime@7.18.3#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
+        "css-loader@6.7.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
+        "react-dom@18.2.0#23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
+        "react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
       ]
     },
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "css-loader@6.7.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
+    },
+    {
+      "ref": "react-dom@18.2.0#23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
       "dependsOn": [
-        "23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
-        "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
-        "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
-        "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
+        "react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
+        "scheduler@0.23.0#ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403"
       ]
     },
     {
-      "ref": "95074e4bc863bb89cdc9486e4462e4a89d52b9bb1c8e26bed4e612c9d0cfa5cd"
+      "ref": "react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
     },
     {
-      "ref": "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"
+      "ref": "scheduler@0.23.0#ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403"
     },
     {
-      "ref": "ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403"
-    },
-    {
-      "ref": "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
-    },
-    {
-      "ref": "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
+      "ref": "web-vitals@2.1.4#95074e4bc863bb89cdc9486e4462e4a89d52b9bb1c8e26bed4e612c9d0cfa5cd"
     }
   ]
 }"
@@ -5393,7 +5393,7 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
       "name": "example-webpack5-react18",
       "group": "@cyclonedx-webpack-plugin-tests",
       "version": "0.0.1",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jan Kowalleck",
       "description": "example setup with react and webpack5",
       "licenses": [
@@ -5427,77 +5427,10 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
   "components": [
     {
       "type": "library",
-      "name": "react-dom",
-      "version": "18.2.0",
-      "bom-ref": "23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
-      "description": "React package for working with the DOM.",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Freact-dom",
-      "externalReferences": [
-        {
-          "url": "https://github.com/facebook/react/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/facebook/react.git#packages/react-dom",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://reactjs.org/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "web-vitals",
-      "version": "2.1.4",
-      "bom-ref": "95074e4bc863bb89cdc9486e4462e4a89d52b9bb1c8e26bed4e612c9d0cfa5cd",
-      "author": "Philip Walton",
-      "description": "Easily measure performance metrics in JavaScript",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FGoogleChrome%2Fweb-vitals.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/GoogleChrome/web-vitals/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/GoogleChrome/web-vitals.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/GoogleChrome/web-vitals#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "runtime",
       "group": "@babel",
       "version": "7.18.3",
-      "bom-ref": "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
+      "bom-ref": "@babel/runtime@7.18.3#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
       "author": "The Babel Team",
       "description": "babel's modular runtime helpers",
       "licenses": [
@@ -5529,42 +5462,9 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
     },
     {
       "type": "library",
-      "name": "scheduler",
-      "version": "0.23.0",
-      "bom-ref": "ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403",
-      "description": "Cooperative scheduler for the browser environment.",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Fscheduler",
-      "externalReferences": [
-        {
-          "url": "https://github.com/facebook/react/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/facebook/react.git#packages/scheduler",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
-        },
-        {
-          "url": "https://reactjs.org/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "css-loader",
       "version": "6.7.1",
-      "bom-ref": "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
+      "bom-ref": "css-loader@6.7.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
       "author": "Tobias Koppers @sokra",
       "description": "css loader module for webpack",
       "licenses": [
@@ -5596,9 +5496,42 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
     },
     {
       "type": "library",
+      "name": "react-dom",
+      "version": "18.2.0",
+      "bom-ref": "react-dom@18.2.0#23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
+      "description": "React package for working with the DOM.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Freact-dom",
+      "externalReferences": [
+        {
+          "url": "https://github.com/facebook/react/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/facebook/react.git#packages/react-dom",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://reactjs.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
       "name": "react",
       "version": "18.2.0",
-      "bom-ref": "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
+      "bom-ref": "react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
       "description": "React is a JavaScript library for building user interfaces.",
       "licenses": [
         {
@@ -5626,39 +5559,106 @@ exports[`integration functional: webpack5 with react18 generated json file: dist
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
       ]
+    },
+    {
+      "type": "library",
+      "name": "scheduler",
+      "version": "0.23.0",
+      "bom-ref": "scheduler@0.23.0#ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403",
+      "description": "Cooperative scheduler for the browser environment.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Fscheduler",
+      "externalReferences": [
+        {
+          "url": "https://github.com/facebook/react/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/facebook/react.git#packages/scheduler",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\" and \\"repository.directory\\""
+        },
+        {
+          "url": "https://reactjs.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "web-vitals",
+      "version": "2.1.4",
+      "bom-ref": "web-vitals@2.1.4#95074e4bc863bb89cdc9486e4462e4a89d52b9bb1c8e26bed4e612c9d0cfa5cd",
+      "author": "Philip Walton",
+      "description": "Easily measure performance metrics in JavaScript",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FGoogleChrome%2Fweb-vitals.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/GoogleChrome/web-vitals/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/GoogleChrome/web-vitals.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/GoogleChrome/web-vitals#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
     }
   ],
   "dependencies": [
     {
-      "ref": "23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
+      "ref": "@babel/runtime@7.18.3#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"
+    },
+    {
+      "ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403",
-        "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
+        "@babel/runtime@7.18.3#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
+        "css-loader@6.7.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
+        "react-dom@18.2.0#23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
+        "react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
       ]
     },
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "css-loader@6.7.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
+    },
+    {
+      "ref": "react-dom@18.2.0#23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
       "dependsOn": [
-        "23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471",
-        "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b",
-        "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a",
-        "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
+        "react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
+        "scheduler@0.23.0#ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403"
       ]
     },
     {
-      "ref": "95074e4bc863bb89cdc9486e4462e4a89d52b9bb1c8e26bed4e612c9d0cfa5cd"
+      "ref": "react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
     },
     {
-      "ref": "9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"
+      "ref": "scheduler@0.23.0#ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403"
     },
     {
-      "ref": "ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403"
-    },
-    {
-      "ref": "daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"
-    },
-    {
-      "ref": "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
+      "ref": "web-vitals@2.1.4#95074e4bc863bb89cdc9486e4462e4a89d52b9bb1c8e26bed4e612c9d0cfa5cd"
     }
   ]
 }"
@@ -5733,7 +5733,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
         </component>
       </components>
     </tools>
-    <component type="application" bom-ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+    <component type="application" bom-ref="@cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
       <author>Jan Kowalleck</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>example-webpack5-react18</name>
@@ -5762,58 +5762,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471">
-      <name>react-dom</name>
-      <version>18.2.0</version>
-      <description>React package for working with the DOM.</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Freact-dom</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/facebook/react/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/facebook/react.git#packages/react-dom</url>
-          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://reactjs.org/</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="95074e4bc863bb89cdc9486e4462e4a89d52b9bb1c8e26bed4e612c9d0cfa5cd">
-      <author>Philip Walton</author>
-      <name>web-vitals</name>
-      <version>2.1.4</version>
-      <description>Easily measure performance metrics in JavaScript</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>Apache-2.0</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FGoogleChrome%2Fweb-vitals.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/GoogleChrome/web-vitals/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/GoogleChrome/web-vitals.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/GoogleChrome/web-vitals#readme</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b">
+    <component type="library" bom-ref="@babel/runtime@7.18.3#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b">
       <author>The Babel Team</author>
       <group>@babel</group>
       <name>runtime</name>
@@ -5840,32 +5789,7 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403">
-      <name>scheduler</name>
-      <version>0.23.0</version>
-      <description>Cooperative scheduler for the browser environment.</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Fscheduler</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/facebook/react/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/facebook/react.git#packages/scheduler</url>
-          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://reactjs.org/</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a">
+    <component type="library" bom-ref="css-loader@6.7.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a">
       <author>Tobias Koppers @sokra</author>
       <name>css-loader</name>
       <version>6.7.1</version>
@@ -5891,7 +5815,32 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6">
+    <component type="library" bom-ref="react-dom@18.2.0#23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471">
+      <name>react-dom</name>
+      <version>18.2.0</version>
+      <description>React package for working with the DOM.</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/react-dom@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Freact-dom</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/facebook/react/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/facebook/react.git#packages/react-dom</url>
+          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://reactjs.org/</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6">
       <name>react</name>
       <version>18.2.0</version>
       <description>React is a JavaScript library for building user interfaces.</description>
@@ -5916,23 +5865,74 @@ exports[`integration functional: webpack5 with react18 generated xml file: dist/
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="scheduler@0.23.0#ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403">
+      <name>scheduler</name>
+      <version>0.23.0</version>
+      <description>Cooperative scheduler for the browser environment.</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/scheduler@0.23.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Fscheduler</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/facebook/react/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/facebook/react.git#packages/scheduler</url>
+          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://reactjs.org/</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="web-vitals@2.1.4#95074e4bc863bb89cdc9486e4462e4a89d52b9bb1c8e26bed4e612c9d0cfa5cd">
+      <author>Philip Walton</author>
+      <name>web-vitals</name>
+      <version>2.1.4</version>
+      <description>Easily measure performance metrics in JavaScript</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/web-vitals@2.1.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FGoogleChrome%2Fweb-vitals.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/GoogleChrome/web-vitals/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/GoogleChrome/web-vitals.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/GoogleChrome/web-vitals#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
   </components>
   <dependencies>
-    <dependency ref="23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471">
-      <dependency ref="ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403"/>
-      <dependency ref="de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"/>
+    <dependency ref="@babel/runtime@7.18.3#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"/>
+    <dependency ref="@cyclonedx-webpack-plugin-tests/example-webpack5-react18@0.0.1#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+      <dependency ref="@babel/runtime@7.18.3#9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"/>
+      <dependency ref="css-loader@6.7.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"/>
+      <dependency ref="react-dom@18.2.0#23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471"/>
+      <dependency ref="react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"/>
     </dependency>
-    <dependency ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
-      <dependency ref="23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471"/>
-      <dependency ref="9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"/>
-      <dependency ref="daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"/>
-      <dependency ref="de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"/>
+    <dependency ref="css-loader@6.7.1#daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"/>
+    <dependency ref="react-dom@18.2.0#23b7e7ebf9d294e4ee70193af7f8c1b262ecfb395ec410ce3bd0ab9ba3c64471">
+      <dependency ref="react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"/>
+      <dependency ref="scheduler@0.23.0#ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403"/>
     </dependency>
-    <dependency ref="95074e4bc863bb89cdc9486e4462e4a89d52b9bb1c8e26bed4e612c9d0cfa5cd"/>
-    <dependency ref="9f073fa101db0e23d8813effb6a000f388e88fa2fcf17e683b3d92b41e74c99b"/>
-    <dependency ref="ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403"/>
-    <dependency ref="daaac00e0a0f97f0db85f6f44f5646be5ad54e43db8b536db3ead3659b87268a"/>
-    <dependency ref="de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"/>
+    <dependency ref="react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"/>
+    <dependency ref="scheduler@0.23.0#ac9b008bbbb7598be92bc6f09ea4991f07e685b10289ffbeb5f159e9ccda0403"/>
+    <dependency ref="web-vitals@2.1.4#95074e4bc863bb89cdc9486e4462e4a89d52b9bb1c8e26bed4e612c9d0cfa5cd"/>
   </dependencies>
 </bom>"
 `;
@@ -6026,7 +6026,7 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.b
       "type": "application",
       "name": "example-webpack5-vue2",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-vue2@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jan Kowalleck",
       "description": "example setup witch Vue2 in WebPack5",
       "licenses": [
@@ -6062,7 +6062,7 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.b
       "type": "library",
       "name": "vue",
       "version": "2.6.14",
-      "bom-ref": "618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed",
+      "bom-ref": "vue@2.6.14#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed",
       "author": "Evan You",
       "description": "Reactive, component-oriented view layer for modern web interfaces.",
       "licenses": [
@@ -6095,13 +6095,13 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.b
   ],
   "dependencies": [
     {
-      "ref": "618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"
+      "ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-vue2@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "dependsOn": [
+        "vue@2.6.14#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"
+      ]
     },
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
-      "dependsOn": [
-        "618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"
-      ]
+      "ref": "vue@2.6.14#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"
     }
   ]
 }"
@@ -6196,7 +6196,7 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.w
       "type": "application",
       "name": "example-webpack5-vue2",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-vue2@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jan Kowalleck",
       "description": "example setup witch Vue2 in WebPack5",
       "licenses": [
@@ -6232,7 +6232,7 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.w
       "type": "library",
       "name": "vue",
       "version": "2.6.14",
-      "bom-ref": "618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed",
+      "bom-ref": "vue@2.6.14#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed",
       "author": "Evan You",
       "description": "Reactive, component-oriented view layer for modern web interfaces.",
       "licenses": [
@@ -6265,13 +6265,13 @@ exports[`integration functional: webpack5 with vue2 generated json file: dist/.w
   ],
   "dependencies": [
     {
-      "ref": "618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"
+      "ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-vue2@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "dependsOn": [
+        "vue@2.6.14#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"
+      ]
     },
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
-      "dependsOn": [
-        "618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"
-      ]
+      "ref": "vue@2.6.14#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"
     }
   ]
 }"
@@ -6346,7 +6346,7 @@ exports[`integration functional: webpack5 with vue2 generated xml file: dist/.bo
         </component>
       </components>
     </tools>
-    <component type="application" bom-ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+    <component type="application" bom-ref="@cyclonedx-webpack-plugin-tests/example-webpack5-vue2@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
       <author>Jan Kowalleck</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>example-webpack5-vue2</name>
@@ -6374,7 +6374,7 @@ exports[`integration functional: webpack5 with vue2 generated xml file: dist/.bo
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed">
+    <component type="library" bom-ref="vue@2.6.14#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed">
       <author>Evan You</author>
       <name>vue</name>
       <version>2.6.14</version>
@@ -6402,10 +6402,10 @@ exports[`integration functional: webpack5 with vue2 generated xml file: dist/.bo
     </component>
   </components>
   <dependencies>
-    <dependency ref="618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"/>
-    <dependency ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
-      <dependency ref="618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"/>
+    <dependency ref="@cyclonedx-webpack-plugin-tests/example-webpack5-vue2@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+      <dependency ref="vue@2.6.14#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"/>
     </dependency>
+    <dependency ref="vue@2.6.14#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"/>
   </dependencies>
 </bom>"
 `;
@@ -6499,7 +6499,7 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
       "type": "application",
       "name": "example-webpack5-vue2-yarn",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jan Kowalleck",
       "description": "example setup witch Vue2 in WebPack5 with yarn setup",
       "licenses": [
@@ -6535,7 +6535,7 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
       "type": "library",
       "name": "vue",
       "version": "2.7.16",
-      "bom-ref": "0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec",
+      "bom-ref": "vue@2.7.16#0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec",
       "author": "Evan You",
       "description": "Reactive, component-oriented view layer for modern web interfaces.",
       "licenses": [
@@ -6568,13 +6568,13 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
   ],
   "dependencies": [
     {
-      "ref": "0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec"
+      "ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "dependsOn": [
+        "vue@2.7.16#0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec"
+      ]
     },
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
-      "dependsOn": [
-        "0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec"
-      ]
+      "ref": "vue@2.7.16#0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec"
     }
   ]
 }"
@@ -6669,7 +6669,7 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
       "type": "application",
       "name": "example-webpack5-vue2-yarn",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jan Kowalleck",
       "description": "example setup witch Vue2 in WebPack5 with yarn setup",
       "licenses": [
@@ -6705,7 +6705,7 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
       "type": "library",
       "name": "vue",
       "version": "2.7.16",
-      "bom-ref": "0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec",
+      "bom-ref": "vue@2.7.16#0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec",
       "author": "Evan You",
       "description": "Reactive, component-oriented view layer for modern web interfaces.",
       "licenses": [
@@ -6738,13 +6738,13 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated json
   ],
   "dependencies": [
     {
-      "ref": "0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec"
+      "ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "dependsOn": [
+        "vue@2.7.16#0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec"
+      ]
     },
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
-      "dependsOn": [
-        "0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec"
-      ]
+      "ref": "vue@2.7.16#0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec"
     }
   ]
 }"
@@ -6819,7 +6819,7 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated xml 
         </component>
       </components>
     </tools>
-    <component type="application" bom-ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+    <component type="application" bom-ref="@cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
       <author>Jan Kowalleck</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>example-webpack5-vue2-yarn</name>
@@ -6847,7 +6847,7 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated xml 
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec">
+    <component type="library" bom-ref="vue@2.7.16#0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec">
       <author>Evan You</author>
       <name>vue</name>
       <version>2.7.16</version>
@@ -6875,10 +6875,10 @@ exports[`integration functional: webpack5 with vue2 in yarn setup generated xml 
     </component>
   </components>
   <dependencies>
-    <dependency ref="0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec"/>
-    <dependency ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
-      <dependency ref="0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec"/>
+    <dependency ref="@cyclonedx-webpack-plugin-tests/example-webpack5-vue2-yarn@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+      <dependency ref="vue@2.7.16#0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec"/>
     </dependency>
+    <dependency ref="vue@2.7.16#0dee204e4c296465073096ae8685919c00a5552784a0cac37f73ee59697386ec"/>
   </dependencies>
 </bom>"
 `;
@@ -6972,7 +6972,7 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
       "type": "application",
       "name": "example-webpack5-vue2-cli",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "example setup witch Vue2 in WebPack5",
       "licenses": [
         {
@@ -7007,7 +7007,7 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
       "type": "library",
       "name": "vue",
       "version": "2.7.16",
-      "bom-ref": "618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed",
+      "bom-ref": "vue@2.7.16#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed",
       "author": "Evan You",
       "description": "Reactive, component-oriented view layer for modern web interfaces.",
       "licenses": [
@@ -7040,13 +7040,13 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
   ],
   "dependencies": [
     {
-      "ref": "618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"
+      "ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "dependsOn": [
+        "vue@2.7.16#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"
+      ]
     },
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
-      "dependsOn": [
-        "618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"
-      ]
+      "ref": "vue@2.7.16#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"
     }
   ]
 }"
@@ -7141,7 +7141,7 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
       "type": "application",
       "name": "example-webpack5-vue2-cli",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "example setup witch Vue2 in WebPack5",
       "licenses": [
         {
@@ -7176,7 +7176,7 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
       "type": "library",
       "name": "vue",
       "version": "2.7.16",
-      "bom-ref": "618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed",
+      "bom-ref": "vue@2.7.16#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed",
       "author": "Evan You",
       "description": "Reactive, component-oriented view layer for modern web interfaces.",
       "licenses": [
@@ -7209,13 +7209,13 @@ exports[`integration functional: webpack5 with vue2-cli-service generated json f
   ],
   "dependencies": [
     {
-      "ref": "618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"
+      "ref": "@cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "dependsOn": [
+        "vue@2.7.16#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"
+      ]
     },
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
-      "dependsOn": [
-        "618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"
-      ]
+      "ref": "vue@2.7.16#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"
     }
   ]
 }"
@@ -7290,7 +7290,7 @@ exports[`integration functional: webpack5 with vue2-cli-service generated xml fi
         </component>
       </components>
     </tools>
-    <component type="application" bom-ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+    <component type="application" bom-ref="@cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>example-webpack5-vue2-cli</name>
       <description>example setup witch Vue2 in WebPack5</description>
@@ -7317,7 +7317,7 @@ exports[`integration functional: webpack5 with vue2-cli-service generated xml fi
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed">
+    <component type="library" bom-ref="vue@2.7.16#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed">
       <author>Evan You</author>
       <name>vue</name>
       <version>2.7.16</version>
@@ -7345,10 +7345,10 @@ exports[`integration functional: webpack5 with vue2-cli-service generated xml fi
     </component>
   </components>
   <dependencies>
-    <dependency ref="618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"/>
-    <dependency ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
-      <dependency ref="618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"/>
+    <dependency ref="@cyclonedx-webpack-plugin-tests/example-webpack5-vue2-cli@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+      <dependency ref="vue@2.7.16#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"/>
     </dependency>
+    <dependency ref="vue@2.7.16#618d4de80402e0acff94b5ee1f9ec0dc1b96c65124e3ba6dded93cd1f71b95ed"/>
   </dependencies>
 </bom>"
 `;
@@ -7462,7 +7462,7 @@ exports[`integration regression: correctly renames root component generated json
       "type": "library",
       "name": "libphonenumber-js",
       "version": "1.11.16",
-      "bom-ref": "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725",
+      "bom-ref": "libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725",
       "author": "catamphetamine",
       "description": "A simpler (and smaller) rewrite of Google Android's libphonenumber library in javascript",
       "licenses": [
@@ -7497,11 +7497,11 @@ exports[`integration regression: correctly renames root component generated json
     {
       "ref": "__root_component__",
       "dependsOn": [
-        "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
+        "libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
       ]
     },
     {
-      "ref": "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
+      "ref": "libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
     }
   ]
 }"
@@ -7616,7 +7616,7 @@ exports[`integration regression: correctly renames root component generated json
       "type": "library",
       "name": "libphonenumber-js",
       "version": "1.11.16",
-      "bom-ref": "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725",
+      "bom-ref": "libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725",
       "author": "catamphetamine",
       "description": "A simpler (and smaller) rewrite of Google Android's libphonenumber library in javascript",
       "licenses": [
@@ -7651,11 +7651,11 @@ exports[`integration regression: correctly renames root component generated json
     {
       "ref": "__root_component__",
       "dependsOn": [
-        "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
+        "libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
       ]
     },
     {
-      "ref": "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
+      "ref": "libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
     }
   ]
 }"
@@ -7746,7 +7746,7 @@ exports[`integration regression: correctly renames root component generated xml 
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725">
+    <component type="library" bom-ref="libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725">
       <author>catamphetamine</author>
       <name>libphonenumber-js</name>
       <version>1.11.16</version>
@@ -7775,9 +7775,9 @@ exports[`integration regression: correctly renames root component generated xml 
   </components>
   <dependencies>
     <dependency ref="__root_component__">
-      <dependency ref="c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"/>
+      <dependency ref="libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"/>
     </dependency>
-    <dependency ref="c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"/>
+    <dependency ref="libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"/>
   </dependencies>
 </bom>"
 `;
@@ -7871,7 +7871,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "application",
       "name": "regression-issue1337",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/regression-issue1337@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jan Kowalleck",
       "description": "example setup for issue#1337",
       "licenses": [
@@ -7906,59 +7906,11 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
   "components": [
     {
       "type": "library",
-      "name": "ieee754",
-      "version": "1.2.1",
-      "bom-ref": "0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2",
-      "author": "Feross Aboukhadijeh",
-      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
-      "licenses": [
-        {
-          "license": {
-            "id": "BSD-3-Clause",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/feross/ieee754/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/feross/ieee754.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/feross/ieee754#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "Q29weXJpZ2h0IDIwMDggRmFpciBPYWtzIExhYnMsIEluYy4KClJlZGlzdHJpYnV0aW9uIGFuZCB1c2UgaW4gc291cmNlIGFuZCBiaW5hcnkgZm9ybXMsIHdpdGggb3Igd2l0aG91dCBtb2RpZmljYXRpb24sIGFyZSBwZXJtaXR0ZWQgcHJvdmlkZWQgdGhhdCB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnMgYXJlIG1ldDoKCjEuIFJlZGlzdHJpYnV0aW9ucyBvZiBzb3VyY2UgY29kZSBtdXN0IHJldGFpbiB0aGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSwgdGhpcyBsaXN0IG9mIGNvbmRpdGlvbnMgYW5kIHRoZSBmb2xsb3dpbmcgZGlzY2xhaW1lci4KCjIuIFJlZGlzdHJpYnV0aW9ucyBpbiBiaW5hcnkgZm9ybSBtdXN0IHJlcHJvZHVjZSB0aGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSwgdGhpcyBsaXN0IG9mIGNvbmRpdGlvbnMgYW5kIHRoZSBmb2xsb3dpbmcgZGlzY2xhaW1lciBpbiB0aGUgZG9jdW1lbnRhdGlvbiBhbmQvb3Igb3RoZXIgbWF0ZXJpYWxzIHByb3ZpZGVkIHdpdGggdGhlIGRpc3RyaWJ1dGlvbi4KCjMuIE5laXRoZXIgdGhlIG5hbWUgb2YgdGhlIGNvcHlyaWdodCBob2xkZXIgbm9yIHRoZSBuYW1lcyBvZiBpdHMgY29udHJpYnV0b3JzIG1heSBiZSB1c2VkIHRvIGVuZG9yc2Ugb3IgcHJvbW90ZSBwcm9kdWN0cyBkZXJpdmVkIGZyb20gdGhpcyBzb2Z0d2FyZSB3aXRob3V0IHNwZWNpZmljIHByaW9yIHdyaXR0ZW4gcGVybWlzc2lvbi4KClRISVMgU09GVFdBUkUgSVMgUFJPVklERUQgQlkgVEhFIENPUFlSSUdIVCBIT0xERVJTIEFORCBDT05UUklCVVRPUlMgIkFTIElTIiBBTkQgQU5ZIEVYUFJFU1MgT1IgSU1QTElFRCBXQVJSQU5USUVTLCBJTkNMVURJTkcsIEJVVCBOT1QgTElNSVRFRCBUTywgVEhFIElNUExJRUQgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFkgQU5EIEZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFSRSBESVNDTEFJTUVELiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUgQ09QWVJJR0hUIEhPTERFUiBPUiBDT05UUklCVVRPUlMgQkUgTElBQkxFIEZPUiBBTlkgRElSRUNULCBJTkRJUkVDVCwgSU5DSURFTlRBTCwgU1BFQ0lBTCwgRVhFTVBMQVJZLCBPUiBDT05TRVFVRU5USUFMIERBTUFHRVMgKElOQ0xVRElORywgQlVUIE5PVCBMSU1JVEVEIFRPLCBQUk9DVVJFTUVOVCBPRiBTVUJTVElUVVRFIEdPT0RTIE9SIFNFUlZJQ0VTOyBMT1NTIE9GIFVTRSwgREFUQSwgT1IgUFJPRklUUzsgT1IgQlVTSU5FU1MgSU5URVJSVVBUSU9OKSBIT1dFVkVSIENBVVNFRCBBTkQgT04gQU5ZIFRIRU9SWSBPRiBMSUFCSUxJVFksIFdIRVRIRVIgSU4gQ09OVFJBQ1QsIFNUUklDVCBMSUFCSUxJVFksIE9SIFRPUlQgKElOQ0xVRElORyBORUdMSUdFTkNFIE9SIE9USEVSV0lTRSkgQVJJU0lORyBJTiBBTlkgV0FZIE9VVCBPRiBUSEUgVVNFIE9GIFRISVMgU09GVFdBUkUsIEVWRU4gSUYgQURWSVNFRCBPRiBUSEUgUE9TU0lCSUxJVFkgT0YgU1VDSCBEQU1BR0UuCg==",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "util-deprecate",
-      "version": "1.0.2",
-      "bom-ref": "19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5",
-      "author": "Nathan Rajlich",
-      "description": "The Node.js \`util.deprecate()\` function with browser support",
+      "name": "base64-js",
+      "version": "1.5.1",
+      "bom-ref": "base64-js@1.5.1#db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199",
+      "author": "T. Jameson Little",
+      "description": "Base64 encoding/decoding in pure JS",
       "licenses": [
         {
           "license": {
@@ -7967,20 +7919,20 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git",
+      "purl": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git",
       "externalReferences": [
         {
-          "url": "https://github.com/TooTallNate/util-deprecate/issues",
+          "url": "https://github.com/beatgammit/base64-js/issues",
           "type": "issue-tracker",
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git://github.com/TooTallNate/util-deprecate.git",
+          "url": "git://github.com/beatgammit/base64-js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\""
         },
         {
-          "url": "https://github.com/TooTallNate/util-deprecate",
+          "url": "https://github.com/beatgammit/base64-js",
           "type": "website",
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
@@ -7991,7 +7943,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
             "license": {
               "name": "file: LICENSE",
               "text": {
-                "content": "KFRoZSBNSVQgTGljZW5zZSkKCkNvcHlyaWdodCAoYykgMjAxNCBOYXRoYW4gUmFqbGljaCA8bmF0aGFuQHRvb3RhbGxuYXRlLm5ldD4KClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uCm9idGFpbmluZyBhIGNvcHkgb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uCmZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwgaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQKcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cyB0byB1c2UsCmNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZQpTb2Z0d2FyZSBpcyBmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZwpjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUKaW5jbHVkZWQgaW4gYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwKRVhQUkVTUyBPUiBJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTCk9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5ECk5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUlMgT1IgQ09QWVJJR0hUCkhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIgTElBQklMSVRZLApXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcKRlJPTSwgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUgpPVEhFUiBERUFMSU5HUyBJTiBUSEUgU09GVFdBUkUuCg==",
+                "content": "VGhlIE1JVCBMaWNlbnNlIChNSVQpCgpDb3B5cmlnaHQgKGMpIDIwMTQgSmFtZXNvbiBMaXR0bGUKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==",
                 "contentType": "text/plain",
                 "encoding": "base64"
               }
@@ -8002,32 +7954,33 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
     },
     {
       "type": "library",
-      "name": "inherits",
-      "version": "2.0.4",
-      "bom-ref": "300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d",
-      "description": "Browser-friendly inheritance fully compatible with standard node.js inherits()",
+      "name": "buffer",
+      "version": "6.0.3",
+      "bom-ref": "buffer@6.0.3#d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283",
+      "author": "Feross Aboukhadijeh",
+      "description": "Node.js Buffer API, for the browser",
       "licenses": [
         {
           "license": {
-            "id": "ISC",
+            "id": "MIT",
             "acknowledgement": "declared"
           }
         }
       ],
-      "purl": "pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git",
+      "purl": "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git",
       "externalReferences": [
         {
-          "url": "https://github.com/isaacs/inherits/issues",
+          "url": "https://github.com/feross/buffer/issues",
           "type": "issue-tracker",
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git://github.com/isaacs/inherits.git",
+          "url": "git://github.com/feross/buffer.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\""
         },
         {
-          "url": "https://github.com/isaacs/inherits#readme",
+          "url": "https://github.com/feross/buffer",
           "type": "website",
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
@@ -8038,7 +7991,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
             "license": {
               "name": "file: LICENSE",
               "text": {
-                "content": "VGhlIElTQyBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIElzYWFjIFouIFNjaGx1ZXRlcgoKUGVybWlzc2lvbiB0byB1c2UsIGNvcHksIG1vZGlmeSwgYW5kL29yIGRpc3RyaWJ1dGUgdGhpcyBzb2Z0d2FyZSBmb3IgYW55CnB1cnBvc2Ugd2l0aCBvciB3aXRob3V0IGZlZSBpcyBoZXJlYnkgZ3JhbnRlZCwgcHJvdmlkZWQgdGhhdCB0aGUgYWJvdmUKY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBhcHBlYXIgaW4gYWxsIGNvcGllcy4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiIEFORCBUSEUgQVVUSE9SIERJU0NMQUlNUyBBTEwgV0FSUkFOVElFUyBXSVRIClJFR0FSRCBUTyBUSElTIFNPRlRXQVJFIElOQ0xVRElORyBBTEwgSU1QTElFRCBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSBBTkQKRklUTkVTUy4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUiBCRSBMSUFCTEUgRk9SIEFOWSBTUEVDSUFMLCBESVJFQ1QsCklORElSRUNULCBPUiBDT05TRVFVRU5USUFMIERBTUFHRVMgT1IgQU5ZIERBTUFHRVMgV0hBVFNPRVZFUiBSRVNVTFRJTkcgRlJPTQpMT1NTIE9GIFVTRSwgREFUQSBPUiBQUk9GSVRTLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgTkVHTElHRU5DRSBPUgpPVEhFUiBUT1JUSU9VUyBBQ1RJT04sIEFSSVNJTkcgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgVVNFIE9SClBFUkZPUk1BTkNFIE9GIFRISVMgU09GVFdBUkUuCgo=",
+                "content": "VGhlIE1JVCBMaWNlbnNlIChNSVQpCgpDb3B5cmlnaHQgKGMpIEZlcm9zcyBBYm91a2hhZGlqZWgsIGFuZCBvdGhlciBjb250cmlidXRvcnMuCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcgYSBjb3B5Cm9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlICJTb2Z0d2FyZSIpLCB0byBkZWFsCmluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgd2l0aG91dCBsaW1pdGF0aW9uIHRoZSByaWdodHMKdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLCBkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3Igc2VsbApjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMKZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvIHRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlIGluY2x1ZGVkIGluCmFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIEVYUFJFU1MgT1IKSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFksCkZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORCBOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRQpBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSCkxJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04gT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HIEZST00sCk9VVCBPRiBPUiBJTiBDT05ORUNUSU9OIFdJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4KVEhFIFNPRlRXQVJFLgo=",
                 "contentType": "text/plain",
                 "encoding": "base64"
               }
@@ -8051,7 +8004,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "esprima",
       "version": "4.0.1",
-      "bom-ref": "340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00",
+      "bom-ref": "esprima@4.0.1#340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00",
       "author": "Ariya Hidayat",
       "description": "ECMAScript parsing infrastructure for multipurpose analysis",
       "licenses": [
@@ -8099,7 +8052,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "events",
       "version": "3.3.0",
-      "bom-ref": "9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c",
+      "bom-ref": "events@3.3.0#9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c",
       "author": "Irakli Gozalishvili",
       "description": "Node's event emitter for all engines.",
       "licenses": [
@@ -8145,81 +8098,33 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
     },
     {
       "type": "library",
-      "name": "through",
-      "version": "2.3.8",
-      "bom-ref": "abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355",
-      "author": "Dominic Tarr",
-      "description": "simplified stream construction",
+      "name": "ieee754",
+      "version": "1.2.1",
+      "bom-ref": "ieee754@1.2.1#0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2",
+      "author": "Feross Aboukhadijeh",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
       "licenses": [
         {
           "license": {
-            "id": "MIT",
+            "id": "BSD-3-Clause",
             "acknowledgement": "declared"
           }
         }
       ],
-      "purl": "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git",
+      "purl": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git",
       "externalReferences": [
         {
-          "url": "https://github.com/dominictarr/through/issues",
+          "url": "https://github.com/feross/ieee754/issues",
           "type": "issue-tracker",
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git+https://github.com/dominictarr/through.git",
+          "url": "git://github.com/feross/ieee754.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\""
         },
         {
-          "url": "https://github.com/dominictarr/through",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE.MIT",
-              "text": {
-                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTEgRG9taW5pYyBUYXJyCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgCnRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weSBvZiB0aGlzIHNvZnR3YXJlIGFuZCAKYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIApkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgCndpdGhvdXQgbGltaXRhdGlvbiB0aGUgcmlnaHRzIHRvIHVzZSwgY29weSwgbW9kaWZ5LCAKbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsIApjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSAKdGhlIFNvZnR3YXJlIGlzIGZ1cm5pc2hlZCB0byBkbyBzbywgCnN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2UgCnNoYWxsIGJlIGluY2x1ZGVkIGluIGFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIApFWFBSRVNTIE9SIElNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgCk9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gCklOIE5PIEVWRU5UIFNIQUxMIFRIRSBBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgCkFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUiBMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCAKVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgClNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4gVEhFIFNPRlRXQVJFLgo=",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "stream-browserify",
-      "version": "3.0.0",
-      "bom-ref": "add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931",
-      "author": "James Halliday",
-      "description": "the stream module from node core for browsers",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/browserify/stream-browserify/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/browserify/stream-browserify.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/browserify/stream-browserify",
+          "url": "https://github.com/feross/ieee754#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
@@ -8230,7 +8135,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
             "license": {
               "name": "file: LICENSE",
               "text": {
-                "content": "TUlUIExpY2Vuc2UKCkNvcHlyaWdodCAoYykgSmFtZXMgSGFsbGlkYXkKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkgb2YKdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwgaW4KdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cyB0bwp1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsIGNvcGllcyBvZgp0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcyBmdXJuaXNoZWQgdG8gZG8gc28sCnN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4gYWxsCmNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUwpGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUlMgT1IKQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIgTElBQklMSVRZLCBXSEVUSEVSCklOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwgT1VUIE9GIE9SIElOCkNPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTiBUSEUgU09GVFdBUkUuCg==",
+                "content": "Q29weXJpZ2h0IDIwMDggRmFpciBPYWtzIExhYnMsIEluYy4KClJlZGlzdHJpYnV0aW9uIGFuZCB1c2UgaW4gc291cmNlIGFuZCBiaW5hcnkgZm9ybXMsIHdpdGggb3Igd2l0aG91dCBtb2RpZmljYXRpb24sIGFyZSBwZXJtaXR0ZWQgcHJvdmlkZWQgdGhhdCB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnMgYXJlIG1ldDoKCjEuIFJlZGlzdHJpYnV0aW9ucyBvZiBzb3VyY2UgY29kZSBtdXN0IHJldGFpbiB0aGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSwgdGhpcyBsaXN0IG9mIGNvbmRpdGlvbnMgYW5kIHRoZSBmb2xsb3dpbmcgZGlzY2xhaW1lci4KCjIuIFJlZGlzdHJpYnV0aW9ucyBpbiBiaW5hcnkgZm9ybSBtdXN0IHJlcHJvZHVjZSB0aGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSwgdGhpcyBsaXN0IG9mIGNvbmRpdGlvbnMgYW5kIHRoZSBmb2xsb3dpbmcgZGlzY2xhaW1lciBpbiB0aGUgZG9jdW1lbnRhdGlvbiBhbmQvb3Igb3RoZXIgbWF0ZXJpYWxzIHByb3ZpZGVkIHdpdGggdGhlIGRpc3RyaWJ1dGlvbi4KCjMuIE5laXRoZXIgdGhlIG5hbWUgb2YgdGhlIGNvcHlyaWdodCBob2xkZXIgbm9yIHRoZSBuYW1lcyBvZiBpdHMgY29udHJpYnV0b3JzIG1heSBiZSB1c2VkIHRvIGVuZG9yc2Ugb3IgcHJvbW90ZSBwcm9kdWN0cyBkZXJpdmVkIGZyb20gdGhpcyBzb2Z0d2FyZSB3aXRob3V0IHNwZWNpZmljIHByaW9yIHdyaXR0ZW4gcGVybWlzc2lvbi4KClRISVMgU09GVFdBUkUgSVMgUFJPVklERUQgQlkgVEhFIENPUFlSSUdIVCBIT0xERVJTIEFORCBDT05UUklCVVRPUlMgIkFTIElTIiBBTkQgQU5ZIEVYUFJFU1MgT1IgSU1QTElFRCBXQVJSQU5USUVTLCBJTkNMVURJTkcsIEJVVCBOT1QgTElNSVRFRCBUTywgVEhFIElNUExJRUQgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFkgQU5EIEZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFSRSBESVNDTEFJTUVELiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUgQ09QWVJJR0hUIEhPTERFUiBPUiBDT05UUklCVVRPUlMgQkUgTElBQkxFIEZPUiBBTlkgRElSRUNULCBJTkRJUkVDVCwgSU5DSURFTlRBTCwgU1BFQ0lBTCwgRVhFTVBMQVJZLCBPUiBDT05TRVFVRU5USUFMIERBTUFHRVMgKElOQ0xVRElORywgQlVUIE5PVCBMSU1JVEVEIFRPLCBQUk9DVVJFTUVOVCBPRiBTVUJTVElUVVRFIEdPT0RTIE9SIFNFUlZJQ0VTOyBMT1NTIE9GIFVTRSwgREFUQSwgT1IgUFJPRklUUzsgT1IgQlVTSU5FU1MgSU5URVJSVVBUSU9OKSBIT1dFVkVSIENBVVNFRCBBTkQgT04gQU5ZIFRIRU9SWSBPRiBMSUFCSUxJVFksIFdIRVRIRVIgSU4gQ09OVFJBQ1QsIFNUUklDVCBMSUFCSUxJVFksIE9SIFRPUlQgKElOQ0xVRElORyBORUdMSUdFTkNFIE9SIE9USEVSV0lTRSkgQVJJU0lORyBJTiBBTlkgV0FZIE9VVCBPRiBUSEUgVVNFIE9GIFRISVMgU09GVFdBUkUsIEVWRU4gSUYgQURWSVNFRCBPRiBUSEUgUE9TU0lCSUxJVFkgT0YgU1VDSCBEQU1BR0UuCg==",
                 "contentType": "text/plain",
                 "encoding": "base64"
               }
@@ -8241,32 +8146,32 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
     },
     {
       "type": "library",
-      "name": "string_decoder",
-      "version": "1.3.0",
-      "bom-ref": "c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef",
-      "description": "The string_decoder module from Node core",
+      "name": "inherits",
+      "version": "2.0.4",
+      "bom-ref": "inherits@2.0.4#300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d",
+      "description": "Browser-friendly inheritance fully compatible with standard node.js inherits()",
       "licenses": [
         {
           "license": {
-            "id": "MIT",
+            "id": "ISC",
             "acknowledgement": "declared"
           }
         }
       ],
-      "purl": "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git",
+      "purl": "pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git",
       "externalReferences": [
         {
-          "url": "https://github.com/nodejs/string_decoder/issues",
+          "url": "https://github.com/isaacs/inherits/issues",
           "type": "issue-tracker",
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git://github.com/nodejs/string_decoder.git",
+          "url": "git://github.com/isaacs/inherits.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\""
         },
         {
-          "url": "https://github.com/nodejs/string_decoder",
+          "url": "https://github.com/isaacs/inherits#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
@@ -8277,7 +8182,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
             "license": {
               "name": "file: LICENSE",
               "text": {
-                "content": "Tm9kZS5qcyBpcyBsaWNlbnNlZCBmb3IgdXNlIGFzIGZvbGxvd3M6CgoiIiIKQ29weXJpZ2h0IE5vZGUuanMgY29udHJpYnV0b3JzLiBBbGwgcmlnaHRzIHJlc2VydmVkLgoKUGVybWlzc2lvbiBpcyBoZXJlYnkgZ3JhbnRlZCwgZnJlZSBvZiBjaGFyZ2UsIHRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weQpvZiB0aGlzIHNvZnR3YXJlIGFuZCBhc3NvY2lhdGVkIGRvY3VtZW50YXRpb24gZmlsZXMgKHRoZSAiU29mdHdhcmUiKSwgdG8KZGVhbCBpbiB0aGUgU29mdHdhcmUgd2l0aG91dCByZXN0cmljdGlvbiwgaW5jbHVkaW5nIHdpdGhvdXQgbGltaXRhdGlvbiB0aGUKcmlnaHRzIHRvIHVzZSwgY29weSwgbW9kaWZ5LCBtZXJnZSwgcHVibGlzaCwgZGlzdHJpYnV0ZSwgc3VibGljZW5zZSwgYW5kL29yCnNlbGwgY29waWVzIG9mIHRoZSBTb2Z0d2FyZSwgYW5kIHRvIHBlcm1pdCBwZXJzb25zIHRvIHdob20gdGhlIFNvZnR3YXJlIGlzCmZ1cm5pc2hlZCB0byBkbyBzbywgc3ViamVjdCB0byB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnM6CgpUaGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBzaGFsbCBiZSBpbmNsdWRlZCBpbgphbGwgY29waWVzIG9yIHN1YnN0YW50aWFsIHBvcnRpb25zIG9mIHRoZSBTb2Z0d2FyZS4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiLCBXSVRIT1VUIFdBUlJBTlRZIE9GIEFOWSBLSU5ELCBFWFBSRVNTIE9SCklNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZLApGSVRORVNTIEZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRSBBTkQgTk9OSU5GUklOR0VNRU5ULiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUKQVVUSE9SUyBPUiBDT1BZUklHSFQgSE9MREVSUyBCRSBMSUFCTEUgRk9SIEFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUgpMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBUT1JUIE9SIE9USEVSV0lTRSwgQVJJU0lORwpGUk9NLCBPVVQgT0YgT1IgSU4gQ09OTkVDVElPTiBXSVRIIFRIRSBTT0ZUV0FSRSBPUiBUSEUgVVNFIE9SIE9USEVSIERFQUxJTkdTCklOIFRIRSBTT0ZUV0FSRS4KIiIiCgpUaGlzIGxpY2Vuc2UgYXBwbGllcyB0byBwYXJ0cyBvZiBOb2RlLmpzIG9yaWdpbmF0aW5nIGZyb20gdGhlCmh0dHBzOi8vZ2l0aHViLmNvbS9qb3llbnQvbm9kZSByZXBvc2l0b3J5OgoKIiIiCkNvcHlyaWdodCBKb3llbnQsIEluYy4gYW5kIG90aGVyIE5vZGUgY29udHJpYnV0b3JzLiBBbGwgcmlnaHRzIHJlc2VydmVkLgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcgYSBjb3B5Cm9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlICJTb2Z0d2FyZSIpLCB0bwpkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgd2l0aG91dCBsaW1pdGF0aW9uIHRoZQpyaWdodHMgdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLCBkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3IKc2VsbCBjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMKZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvIHRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlIGluY2x1ZGVkIGluCmFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIEVYUFJFU1MgT1IKSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFksCkZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORCBOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRQpBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSCkxJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04gT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HCkZST00sIE9VVCBPRiBPUiBJTiBDT05ORUNUSU9OIFdJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MKSU4gVEhFIFNPRlRXQVJFLgoiIiIKCg==",
+                "content": "VGhlIElTQyBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIElzYWFjIFouIFNjaGx1ZXRlcgoKUGVybWlzc2lvbiB0byB1c2UsIGNvcHksIG1vZGlmeSwgYW5kL29yIGRpc3RyaWJ1dGUgdGhpcyBzb2Z0d2FyZSBmb3IgYW55CnB1cnBvc2Ugd2l0aCBvciB3aXRob3V0IGZlZSBpcyBoZXJlYnkgZ3JhbnRlZCwgcHJvdmlkZWQgdGhhdCB0aGUgYWJvdmUKY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBhcHBlYXIgaW4gYWxsIGNvcGllcy4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiIEFORCBUSEUgQVVUSE9SIERJU0NMQUlNUyBBTEwgV0FSUkFOVElFUyBXSVRIClJFR0FSRCBUTyBUSElTIFNPRlRXQVJFIElOQ0xVRElORyBBTEwgSU1QTElFRCBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSBBTkQKRklUTkVTUy4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUiBCRSBMSUFCTEUgRk9SIEFOWSBTUEVDSUFMLCBESVJFQ1QsCklORElSRUNULCBPUiBDT05TRVFVRU5USUFMIERBTUFHRVMgT1IgQU5ZIERBTUFHRVMgV0hBVFNPRVZFUiBSRVNVTFRJTkcgRlJPTQpMT1NTIE9GIFVTRSwgREFUQSBPUiBQUk9GSVRTLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgTkVHTElHRU5DRSBPUgpPVEhFUiBUT1JUSU9VUyBBQ1RJT04sIEFSSVNJTkcgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgVVNFIE9SClBFUkZPUk1BTkNFIE9GIFRISVMgU09GVFdBUkUuCgo=",
                 "contentType": "text/plain",
                 "encoding": "base64"
               }
@@ -8290,7 +8195,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "libphonenumber-js",
       "version": "1.11.16",
-      "bom-ref": "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725",
+      "bom-ref": "libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725",
       "author": "catamphetamine",
       "description": "A simpler (and smaller) rewrite of Google Android's libphonenumber library in javascript",
       "licenses": [
@@ -8348,7 +8253,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "readable-stream",
       "version": "3.6.2",
-      "bom-ref": "d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb",
+      "bom-ref": "readable-stream@3.6.2#d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb",
       "description": "Streams3, a user-land copy of the stream library from Node.js",
       "licenses": [
         {
@@ -8393,105 +8298,9 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
     },
     {
       "type": "library",
-      "name": "buffer",
-      "version": "6.0.3",
-      "bom-ref": "d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283",
-      "author": "Feross Aboukhadijeh",
-      "description": "Node.js Buffer API, for the browser",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/feross/buffer/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/feross/buffer.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/feross/buffer",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "VGhlIE1JVCBMaWNlbnNlIChNSVQpCgpDb3B5cmlnaHQgKGMpIEZlcm9zcyBBYm91a2hhZGlqZWgsIGFuZCBvdGhlciBjb250cmlidXRvcnMuCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcgYSBjb3B5Cm9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlICJTb2Z0d2FyZSIpLCB0byBkZWFsCmluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgd2l0aG91dCBsaW1pdGF0aW9uIHRoZSByaWdodHMKdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLCBkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3Igc2VsbApjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMKZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvIHRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlIGluY2x1ZGVkIGluCmFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIEVYUFJFU1MgT1IKSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFksCkZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORCBOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRQpBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSCkxJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04gT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HIEZST00sCk9VVCBPRiBPUiBJTiBDT05ORUNUSU9OIFdJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4KVEhFIFNPRlRXQVJFLgo=",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "base64-js",
-      "version": "1.5.1",
-      "bom-ref": "db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199",
-      "author": "T. Jameson Little",
-      "description": "Base64 encoding/decoding in pure JS",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/beatgammit/base64-js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/beatgammit/base64-js.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/beatgammit/base64-js",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "VGhlIE1JVCBMaWNlbnNlIChNSVQpCgpDb3B5cmlnaHQgKGMpIDIwMTQgSmFtZXNvbiBMaXR0bGUKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
       "name": "safe-buffer",
       "version": "5.2.1",
-      "bom-ref": "e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884",
+      "bom-ref": "safe-buffer@5.2.1#e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884",
       "author": "Feross Aboukhadijeh",
       "description": "Safer Node.js Buffer API",
       "licenses": [
@@ -8534,80 +8343,271 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         ]
       }
+    },
+    {
+      "type": "library",
+      "name": "stream-browserify",
+      "version": "3.0.0",
+      "bom-ref": "stream-browserify@3.0.0#add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931",
+      "author": "James Halliday",
+      "description": "the stream module from node core for browsers",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/browserify/stream-browserify/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/browserify/stream-browserify.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/browserify/stream-browserify",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "TUlUIExpY2Vuc2UKCkNvcHlyaWdodCAoYykgSmFtZXMgSGFsbGlkYXkKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkgb2YKdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwgaW4KdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cyB0bwp1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsIGNvcGllcyBvZgp0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcyBmdXJuaXNoZWQgdG8gZG8gc28sCnN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4gYWxsCmNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUwpGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUlMgT1IKQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIgTElBQklMSVRZLCBXSEVUSEVSCklOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwgT1VUIE9GIE9SIElOCkNPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTiBUSEUgU09GVFdBUkUuCg==",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "string_decoder",
+      "version": "1.3.0",
+      "bom-ref": "string_decoder@1.3.0#c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef",
+      "description": "The string_decoder module from Node core",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/nodejs/string_decoder/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/nodejs/string_decoder.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/nodejs/string_decoder",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "Tm9kZS5qcyBpcyBsaWNlbnNlZCBmb3IgdXNlIGFzIGZvbGxvd3M6CgoiIiIKQ29weXJpZ2h0IE5vZGUuanMgY29udHJpYnV0b3JzLiBBbGwgcmlnaHRzIHJlc2VydmVkLgoKUGVybWlzc2lvbiBpcyBoZXJlYnkgZ3JhbnRlZCwgZnJlZSBvZiBjaGFyZ2UsIHRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weQpvZiB0aGlzIHNvZnR3YXJlIGFuZCBhc3NvY2lhdGVkIGRvY3VtZW50YXRpb24gZmlsZXMgKHRoZSAiU29mdHdhcmUiKSwgdG8KZGVhbCBpbiB0aGUgU29mdHdhcmUgd2l0aG91dCByZXN0cmljdGlvbiwgaW5jbHVkaW5nIHdpdGhvdXQgbGltaXRhdGlvbiB0aGUKcmlnaHRzIHRvIHVzZSwgY29weSwgbW9kaWZ5LCBtZXJnZSwgcHVibGlzaCwgZGlzdHJpYnV0ZSwgc3VibGljZW5zZSwgYW5kL29yCnNlbGwgY29waWVzIG9mIHRoZSBTb2Z0d2FyZSwgYW5kIHRvIHBlcm1pdCBwZXJzb25zIHRvIHdob20gdGhlIFNvZnR3YXJlIGlzCmZ1cm5pc2hlZCB0byBkbyBzbywgc3ViamVjdCB0byB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnM6CgpUaGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBzaGFsbCBiZSBpbmNsdWRlZCBpbgphbGwgY29waWVzIG9yIHN1YnN0YW50aWFsIHBvcnRpb25zIG9mIHRoZSBTb2Z0d2FyZS4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiLCBXSVRIT1VUIFdBUlJBTlRZIE9GIEFOWSBLSU5ELCBFWFBSRVNTIE9SCklNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZLApGSVRORVNTIEZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRSBBTkQgTk9OSU5GUklOR0VNRU5ULiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUKQVVUSE9SUyBPUiBDT1BZUklHSFQgSE9MREVSUyBCRSBMSUFCTEUgRk9SIEFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUgpMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBUT1JUIE9SIE9USEVSV0lTRSwgQVJJU0lORwpGUk9NLCBPVVQgT0YgT1IgSU4gQ09OTkVDVElPTiBXSVRIIFRIRSBTT0ZUV0FSRSBPUiBUSEUgVVNFIE9SIE9USEVSIERFQUxJTkdTCklOIFRIRSBTT0ZUV0FSRS4KIiIiCgpUaGlzIGxpY2Vuc2UgYXBwbGllcyB0byBwYXJ0cyBvZiBOb2RlLmpzIG9yaWdpbmF0aW5nIGZyb20gdGhlCmh0dHBzOi8vZ2l0aHViLmNvbS9qb3llbnQvbm9kZSByZXBvc2l0b3J5OgoKIiIiCkNvcHlyaWdodCBKb3llbnQsIEluYy4gYW5kIG90aGVyIE5vZGUgY29udHJpYnV0b3JzLiBBbGwgcmlnaHRzIHJlc2VydmVkLgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcgYSBjb3B5Cm9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlICJTb2Z0d2FyZSIpLCB0bwpkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgd2l0aG91dCBsaW1pdGF0aW9uIHRoZQpyaWdodHMgdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLCBkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3IKc2VsbCBjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMKZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvIHRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlIGluY2x1ZGVkIGluCmFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIEVYUFJFU1MgT1IKSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFksCkZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORCBOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRQpBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSCkxJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04gT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HCkZST00sIE9VVCBPRiBPUiBJTiBDT05ORUNUSU9OIFdJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MKSU4gVEhFIFNPRlRXQVJFLgoiIiIKCg==",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "through",
+      "version": "2.3.8",
+      "bom-ref": "through@2.3.8#abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355",
+      "author": "Dominic Tarr",
+      "description": "simplified stream construction",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/dominictarr/through/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/dominictarr/through.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/dominictarr/through",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE.MIT",
+              "text": {
+                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTEgRG9taW5pYyBUYXJyCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgCnRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weSBvZiB0aGlzIHNvZnR3YXJlIGFuZCAKYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIApkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgCndpdGhvdXQgbGltaXRhdGlvbiB0aGUgcmlnaHRzIHRvIHVzZSwgY29weSwgbW9kaWZ5LCAKbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsIApjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSAKdGhlIFNvZnR3YXJlIGlzIGZ1cm5pc2hlZCB0byBkbyBzbywgCnN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2UgCnNoYWxsIGJlIGluY2x1ZGVkIGluIGFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIApFWFBSRVNTIE9SIElNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgCk9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gCklOIE5PIEVWRU5UIFNIQUxMIFRIRSBBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgCkFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUiBMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCAKVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgClNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4gVEhFIFNPRlRXQVJFLgo=",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "util-deprecate",
+      "version": "1.0.2",
+      "bom-ref": "util-deprecate@1.0.2#19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5",
+      "author": "Nathan Rajlich",
+      "description": "The Node.js \`util.deprecate()\` function with browser support",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/TooTallNate/util-deprecate/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/TooTallNate/util-deprecate.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/TooTallNate/util-deprecate",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "KFRoZSBNSVQgTGljZW5zZSkKCkNvcHlyaWdodCAoYykgMjAxNCBOYXRoYW4gUmFqbGljaCA8bmF0aGFuQHRvb3RhbGxuYXRlLm5ldD4KClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uCm9idGFpbmluZyBhIGNvcHkgb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uCmZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwgaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQKcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cyB0byB1c2UsCmNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZQpTb2Z0d2FyZSBpcyBmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZwpjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUKaW5jbHVkZWQgaW4gYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwKRVhQUkVTUyBPUiBJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTCk9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5ECk5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUlMgT1IgQ09QWVJJR0hUCkhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIgTElBQklMSVRZLApXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcKRlJPTSwgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUgpPVEhFUiBERUFMSU5HUyBJTiBUSEUgU09GVFdBUkUuCg==",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
     }
   ],
   "dependencies": [
     {
-      "ref": "0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2"
-    },
-    {
-      "ref": "19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5"
-    },
-    {
-      "ref": "300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d"
-    },
-    {
-      "ref": "340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00"
-    },
-    {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@cyclonedx-webpack-plugin-tests/regression-issue1337@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00",
-        "abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355",
-        "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
+        "esprima@4.0.1#340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00",
+        "libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725",
+        "through@2.3.8#abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355"
       ]
     },
     {
-      "ref": "9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c"
+      "ref": "base64-js@1.5.1#db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199"
     },
     {
-      "ref": "abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355",
+      "ref": "buffer@6.0.3#d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283",
       "dependsOn": [
-        "add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931"
+        "base64-js@1.5.1#db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199",
+        "ieee754@1.2.1#0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2"
       ]
     },
     {
-      "ref": "add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931",
+      "ref": "esprima@4.0.1#340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00"
+    },
+    {
+      "ref": "events@3.3.0#9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c"
+    },
+    {
+      "ref": "ieee754@1.2.1#0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2"
+    },
+    {
+      "ref": "inherits@2.0.4#300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d"
+    },
+    {
+      "ref": "libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
+    },
+    {
+      "ref": "readable-stream@3.6.2#d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb",
       "dependsOn": [
-        "300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d",
-        "9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c",
-        "d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb"
+        "buffer@6.0.3#d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283",
+        "events@3.3.0#9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c",
+        "inherits@2.0.4#300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d",
+        "string_decoder@1.3.0#c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef",
+        "util-deprecate@1.0.2#19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5"
       ]
     },
     {
-      "ref": "c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef",
+      "ref": "safe-buffer@5.2.1#e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884",
       "dependsOn": [
-        "e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884"
+        "buffer@6.0.3#d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283"
       ]
     },
     {
-      "ref": "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
-    },
-    {
-      "ref": "d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb",
+      "ref": "stream-browserify@3.0.0#add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931",
       "dependsOn": [
-        "19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5",
-        "300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d",
-        "9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c",
-        "c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef",
-        "d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283"
+        "events@3.3.0#9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c",
+        "inherits@2.0.4#300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d",
+        "readable-stream@3.6.2#d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb"
       ]
     },
     {
-      "ref": "d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283",
+      "ref": "string_decoder@1.3.0#c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef",
       "dependsOn": [
-        "0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2",
-        "db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199"
+        "safe-buffer@5.2.1#e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884"
       ]
     },
     {
-      "ref": "db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199"
+      "ref": "through@2.3.8#abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355",
+      "dependsOn": [
+        "stream-browserify@3.0.0#add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931"
+      ]
     },
     {
-      "ref": "e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884",
-      "dependsOn": [
-        "d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283"
-      ]
+      "ref": "util-deprecate@1.0.2#19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5"
     }
   ]
 }"
@@ -8702,7 +8702,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "application",
       "name": "regression-issue1337",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/regression-issue1337@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jan Kowalleck",
       "description": "example setup for issue#1337",
       "licenses": [
@@ -8737,59 +8737,11 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
   "components": [
     {
       "type": "library",
-      "name": "ieee754",
-      "version": "1.2.1",
-      "bom-ref": "0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2",
-      "author": "Feross Aboukhadijeh",
-      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
-      "licenses": [
-        {
-          "license": {
-            "id": "BSD-3-Clause",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/feross/ieee754/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/feross/ieee754.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/feross/ieee754#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "Q29weXJpZ2h0IDIwMDggRmFpciBPYWtzIExhYnMsIEluYy4KClJlZGlzdHJpYnV0aW9uIGFuZCB1c2UgaW4gc291cmNlIGFuZCBiaW5hcnkgZm9ybXMsIHdpdGggb3Igd2l0aG91dCBtb2RpZmljYXRpb24sIGFyZSBwZXJtaXR0ZWQgcHJvdmlkZWQgdGhhdCB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnMgYXJlIG1ldDoKCjEuIFJlZGlzdHJpYnV0aW9ucyBvZiBzb3VyY2UgY29kZSBtdXN0IHJldGFpbiB0aGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSwgdGhpcyBsaXN0IG9mIGNvbmRpdGlvbnMgYW5kIHRoZSBmb2xsb3dpbmcgZGlzY2xhaW1lci4KCjIuIFJlZGlzdHJpYnV0aW9ucyBpbiBiaW5hcnkgZm9ybSBtdXN0IHJlcHJvZHVjZSB0aGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSwgdGhpcyBsaXN0IG9mIGNvbmRpdGlvbnMgYW5kIHRoZSBmb2xsb3dpbmcgZGlzY2xhaW1lciBpbiB0aGUgZG9jdW1lbnRhdGlvbiBhbmQvb3Igb3RoZXIgbWF0ZXJpYWxzIHByb3ZpZGVkIHdpdGggdGhlIGRpc3RyaWJ1dGlvbi4KCjMuIE5laXRoZXIgdGhlIG5hbWUgb2YgdGhlIGNvcHlyaWdodCBob2xkZXIgbm9yIHRoZSBuYW1lcyBvZiBpdHMgY29udHJpYnV0b3JzIG1heSBiZSB1c2VkIHRvIGVuZG9yc2Ugb3IgcHJvbW90ZSBwcm9kdWN0cyBkZXJpdmVkIGZyb20gdGhpcyBzb2Z0d2FyZSB3aXRob3V0IHNwZWNpZmljIHByaW9yIHdyaXR0ZW4gcGVybWlzc2lvbi4KClRISVMgU09GVFdBUkUgSVMgUFJPVklERUQgQlkgVEhFIENPUFlSSUdIVCBIT0xERVJTIEFORCBDT05UUklCVVRPUlMgIkFTIElTIiBBTkQgQU5ZIEVYUFJFU1MgT1IgSU1QTElFRCBXQVJSQU5USUVTLCBJTkNMVURJTkcsIEJVVCBOT1QgTElNSVRFRCBUTywgVEhFIElNUExJRUQgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFkgQU5EIEZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFSRSBESVNDTEFJTUVELiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUgQ09QWVJJR0hUIEhPTERFUiBPUiBDT05UUklCVVRPUlMgQkUgTElBQkxFIEZPUiBBTlkgRElSRUNULCBJTkRJUkVDVCwgSU5DSURFTlRBTCwgU1BFQ0lBTCwgRVhFTVBMQVJZLCBPUiBDT05TRVFVRU5USUFMIERBTUFHRVMgKElOQ0xVRElORywgQlVUIE5PVCBMSU1JVEVEIFRPLCBQUk9DVVJFTUVOVCBPRiBTVUJTVElUVVRFIEdPT0RTIE9SIFNFUlZJQ0VTOyBMT1NTIE9GIFVTRSwgREFUQSwgT1IgUFJPRklUUzsgT1IgQlVTSU5FU1MgSU5URVJSVVBUSU9OKSBIT1dFVkVSIENBVVNFRCBBTkQgT04gQU5ZIFRIRU9SWSBPRiBMSUFCSUxJVFksIFdIRVRIRVIgSU4gQ09OVFJBQ1QsIFNUUklDVCBMSUFCSUxJVFksIE9SIFRPUlQgKElOQ0xVRElORyBORUdMSUdFTkNFIE9SIE9USEVSV0lTRSkgQVJJU0lORyBJTiBBTlkgV0FZIE9VVCBPRiBUSEUgVVNFIE9GIFRISVMgU09GVFdBUkUsIEVWRU4gSUYgQURWSVNFRCBPRiBUSEUgUE9TU0lCSUxJVFkgT0YgU1VDSCBEQU1BR0UuCg==",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "util-deprecate",
-      "version": "1.0.2",
-      "bom-ref": "19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5",
-      "author": "Nathan Rajlich",
-      "description": "The Node.js \`util.deprecate()\` function with browser support",
+      "name": "base64-js",
+      "version": "1.5.1",
+      "bom-ref": "base64-js@1.5.1#db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199",
+      "author": "T. Jameson Little",
+      "description": "Base64 encoding/decoding in pure JS",
       "licenses": [
         {
           "license": {
@@ -8798,20 +8750,20 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         }
       ],
-      "purl": "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git",
+      "purl": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git",
       "externalReferences": [
         {
-          "url": "https://github.com/TooTallNate/util-deprecate/issues",
+          "url": "https://github.com/beatgammit/base64-js/issues",
           "type": "issue-tracker",
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git://github.com/TooTallNate/util-deprecate.git",
+          "url": "git://github.com/beatgammit/base64-js.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\""
         },
         {
-          "url": "https://github.com/TooTallNate/util-deprecate",
+          "url": "https://github.com/beatgammit/base64-js",
           "type": "website",
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
@@ -8822,7 +8774,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
             "license": {
               "name": "file: LICENSE",
               "text": {
-                "content": "KFRoZSBNSVQgTGljZW5zZSkKCkNvcHlyaWdodCAoYykgMjAxNCBOYXRoYW4gUmFqbGljaCA8bmF0aGFuQHRvb3RhbGxuYXRlLm5ldD4KClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uCm9idGFpbmluZyBhIGNvcHkgb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uCmZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwgaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQKcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cyB0byB1c2UsCmNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZQpTb2Z0d2FyZSBpcyBmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZwpjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUKaW5jbHVkZWQgaW4gYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwKRVhQUkVTUyBPUiBJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTCk9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5ECk5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUlMgT1IgQ09QWVJJR0hUCkhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIgTElBQklMSVRZLApXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcKRlJPTSwgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUgpPVEhFUiBERUFMSU5HUyBJTiBUSEUgU09GVFdBUkUuCg==",
+                "content": "VGhlIE1JVCBMaWNlbnNlIChNSVQpCgpDb3B5cmlnaHQgKGMpIDIwMTQgSmFtZXNvbiBMaXR0bGUKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==",
                 "contentType": "text/plain",
                 "encoding": "base64"
               }
@@ -8833,32 +8785,33 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
     },
     {
       "type": "library",
-      "name": "inherits",
-      "version": "2.0.4",
-      "bom-ref": "300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d",
-      "description": "Browser-friendly inheritance fully compatible with standard node.js inherits()",
+      "name": "buffer",
+      "version": "6.0.3",
+      "bom-ref": "buffer@6.0.3#d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283",
+      "author": "Feross Aboukhadijeh",
+      "description": "Node.js Buffer API, for the browser",
       "licenses": [
         {
           "license": {
-            "id": "ISC",
+            "id": "MIT",
             "acknowledgement": "declared"
           }
         }
       ],
-      "purl": "pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git",
+      "purl": "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git",
       "externalReferences": [
         {
-          "url": "https://github.com/isaacs/inherits/issues",
+          "url": "https://github.com/feross/buffer/issues",
           "type": "issue-tracker",
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git://github.com/isaacs/inherits.git",
+          "url": "git://github.com/feross/buffer.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\""
         },
         {
-          "url": "https://github.com/isaacs/inherits#readme",
+          "url": "https://github.com/feross/buffer",
           "type": "website",
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
@@ -8869,7 +8822,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
             "license": {
               "name": "file: LICENSE",
               "text": {
-                "content": "VGhlIElTQyBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIElzYWFjIFouIFNjaGx1ZXRlcgoKUGVybWlzc2lvbiB0byB1c2UsIGNvcHksIG1vZGlmeSwgYW5kL29yIGRpc3RyaWJ1dGUgdGhpcyBzb2Z0d2FyZSBmb3IgYW55CnB1cnBvc2Ugd2l0aCBvciB3aXRob3V0IGZlZSBpcyBoZXJlYnkgZ3JhbnRlZCwgcHJvdmlkZWQgdGhhdCB0aGUgYWJvdmUKY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBhcHBlYXIgaW4gYWxsIGNvcGllcy4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiIEFORCBUSEUgQVVUSE9SIERJU0NMQUlNUyBBTEwgV0FSUkFOVElFUyBXSVRIClJFR0FSRCBUTyBUSElTIFNPRlRXQVJFIElOQ0xVRElORyBBTEwgSU1QTElFRCBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSBBTkQKRklUTkVTUy4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUiBCRSBMSUFCTEUgRk9SIEFOWSBTUEVDSUFMLCBESVJFQ1QsCklORElSRUNULCBPUiBDT05TRVFVRU5USUFMIERBTUFHRVMgT1IgQU5ZIERBTUFHRVMgV0hBVFNPRVZFUiBSRVNVTFRJTkcgRlJPTQpMT1NTIE9GIFVTRSwgREFUQSBPUiBQUk9GSVRTLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgTkVHTElHRU5DRSBPUgpPVEhFUiBUT1JUSU9VUyBBQ1RJT04sIEFSSVNJTkcgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgVVNFIE9SClBFUkZPUk1BTkNFIE9GIFRISVMgU09GVFdBUkUuCgo=",
+                "content": "VGhlIE1JVCBMaWNlbnNlIChNSVQpCgpDb3B5cmlnaHQgKGMpIEZlcm9zcyBBYm91a2hhZGlqZWgsIGFuZCBvdGhlciBjb250cmlidXRvcnMuCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcgYSBjb3B5Cm9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlICJTb2Z0d2FyZSIpLCB0byBkZWFsCmluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgd2l0aG91dCBsaW1pdGF0aW9uIHRoZSByaWdodHMKdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLCBkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3Igc2VsbApjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMKZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvIHRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlIGluY2x1ZGVkIGluCmFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIEVYUFJFU1MgT1IKSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFksCkZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORCBOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRQpBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSCkxJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04gT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HIEZST00sCk9VVCBPRiBPUiBJTiBDT05ORUNUSU9OIFdJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4KVEhFIFNPRlRXQVJFLgo=",
                 "contentType": "text/plain",
                 "encoding": "base64"
               }
@@ -8882,7 +8835,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "esprima",
       "version": "4.0.1",
-      "bom-ref": "340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00",
+      "bom-ref": "esprima@4.0.1#340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00",
       "author": "Ariya Hidayat",
       "description": "ECMAScript parsing infrastructure for multipurpose analysis",
       "licenses": [
@@ -8930,7 +8883,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "events",
       "version": "3.3.0",
-      "bom-ref": "9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c",
+      "bom-ref": "events@3.3.0#9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c",
       "author": "Irakli Gozalishvili",
       "description": "Node's event emitter for all engines.",
       "licenses": [
@@ -8976,81 +8929,33 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
     },
     {
       "type": "library",
-      "name": "through",
-      "version": "2.3.8",
-      "bom-ref": "abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355",
-      "author": "Dominic Tarr",
-      "description": "simplified stream construction",
+      "name": "ieee754",
+      "version": "1.2.1",
+      "bom-ref": "ieee754@1.2.1#0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2",
+      "author": "Feross Aboukhadijeh",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
       "licenses": [
         {
           "license": {
-            "id": "MIT",
+            "id": "BSD-3-Clause",
             "acknowledgement": "declared"
           }
         }
       ],
-      "purl": "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git",
+      "purl": "pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git",
       "externalReferences": [
         {
-          "url": "https://github.com/dominictarr/through/issues",
+          "url": "https://github.com/feross/ieee754/issues",
           "type": "issue-tracker",
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git+https://github.com/dominictarr/through.git",
+          "url": "git://github.com/feross/ieee754.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\""
         },
         {
-          "url": "https://github.com/dominictarr/through",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE.MIT",
-              "text": {
-                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTEgRG9taW5pYyBUYXJyCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgCnRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weSBvZiB0aGlzIHNvZnR3YXJlIGFuZCAKYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIApkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgCndpdGhvdXQgbGltaXRhdGlvbiB0aGUgcmlnaHRzIHRvIHVzZSwgY29weSwgbW9kaWZ5LCAKbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsIApjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSAKdGhlIFNvZnR3YXJlIGlzIGZ1cm5pc2hlZCB0byBkbyBzbywgCnN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2UgCnNoYWxsIGJlIGluY2x1ZGVkIGluIGFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIApFWFBSRVNTIE9SIElNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgCk9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gCklOIE5PIEVWRU5UIFNIQUxMIFRIRSBBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgCkFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUiBMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCAKVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgClNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4gVEhFIFNPRlRXQVJFLgo=",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "stream-browserify",
-      "version": "3.0.0",
-      "bom-ref": "add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931",
-      "author": "James Halliday",
-      "description": "the stream module from node core for browsers",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/browserify/stream-browserify/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/browserify/stream-browserify.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/browserify/stream-browserify",
+          "url": "https://github.com/feross/ieee754#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
@@ -9061,7 +8966,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
             "license": {
               "name": "file: LICENSE",
               "text": {
-                "content": "TUlUIExpY2Vuc2UKCkNvcHlyaWdodCAoYykgSmFtZXMgSGFsbGlkYXkKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkgb2YKdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwgaW4KdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cyB0bwp1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsIGNvcGllcyBvZgp0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcyBmdXJuaXNoZWQgdG8gZG8gc28sCnN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4gYWxsCmNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUwpGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUlMgT1IKQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIgTElBQklMSVRZLCBXSEVUSEVSCklOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwgT1VUIE9GIE9SIElOCkNPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTiBUSEUgU09GVFdBUkUuCg==",
+                "content": "Q29weXJpZ2h0IDIwMDggRmFpciBPYWtzIExhYnMsIEluYy4KClJlZGlzdHJpYnV0aW9uIGFuZCB1c2UgaW4gc291cmNlIGFuZCBiaW5hcnkgZm9ybXMsIHdpdGggb3Igd2l0aG91dCBtb2RpZmljYXRpb24sIGFyZSBwZXJtaXR0ZWQgcHJvdmlkZWQgdGhhdCB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnMgYXJlIG1ldDoKCjEuIFJlZGlzdHJpYnV0aW9ucyBvZiBzb3VyY2UgY29kZSBtdXN0IHJldGFpbiB0aGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSwgdGhpcyBsaXN0IG9mIGNvbmRpdGlvbnMgYW5kIHRoZSBmb2xsb3dpbmcgZGlzY2xhaW1lci4KCjIuIFJlZGlzdHJpYnV0aW9ucyBpbiBiaW5hcnkgZm9ybSBtdXN0IHJlcHJvZHVjZSB0aGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSwgdGhpcyBsaXN0IG9mIGNvbmRpdGlvbnMgYW5kIHRoZSBmb2xsb3dpbmcgZGlzY2xhaW1lciBpbiB0aGUgZG9jdW1lbnRhdGlvbiBhbmQvb3Igb3RoZXIgbWF0ZXJpYWxzIHByb3ZpZGVkIHdpdGggdGhlIGRpc3RyaWJ1dGlvbi4KCjMuIE5laXRoZXIgdGhlIG5hbWUgb2YgdGhlIGNvcHlyaWdodCBob2xkZXIgbm9yIHRoZSBuYW1lcyBvZiBpdHMgY29udHJpYnV0b3JzIG1heSBiZSB1c2VkIHRvIGVuZG9yc2Ugb3IgcHJvbW90ZSBwcm9kdWN0cyBkZXJpdmVkIGZyb20gdGhpcyBzb2Z0d2FyZSB3aXRob3V0IHNwZWNpZmljIHByaW9yIHdyaXR0ZW4gcGVybWlzc2lvbi4KClRISVMgU09GVFdBUkUgSVMgUFJPVklERUQgQlkgVEhFIENPUFlSSUdIVCBIT0xERVJTIEFORCBDT05UUklCVVRPUlMgIkFTIElTIiBBTkQgQU5ZIEVYUFJFU1MgT1IgSU1QTElFRCBXQVJSQU5USUVTLCBJTkNMVURJTkcsIEJVVCBOT1QgTElNSVRFRCBUTywgVEhFIElNUExJRUQgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFkgQU5EIEZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFSRSBESVNDTEFJTUVELiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUgQ09QWVJJR0hUIEhPTERFUiBPUiBDT05UUklCVVRPUlMgQkUgTElBQkxFIEZPUiBBTlkgRElSRUNULCBJTkRJUkVDVCwgSU5DSURFTlRBTCwgU1BFQ0lBTCwgRVhFTVBMQVJZLCBPUiBDT05TRVFVRU5USUFMIERBTUFHRVMgKElOQ0xVRElORywgQlVUIE5PVCBMSU1JVEVEIFRPLCBQUk9DVVJFTUVOVCBPRiBTVUJTVElUVVRFIEdPT0RTIE9SIFNFUlZJQ0VTOyBMT1NTIE9GIFVTRSwgREFUQSwgT1IgUFJPRklUUzsgT1IgQlVTSU5FU1MgSU5URVJSVVBUSU9OKSBIT1dFVkVSIENBVVNFRCBBTkQgT04gQU5ZIFRIRU9SWSBPRiBMSUFCSUxJVFksIFdIRVRIRVIgSU4gQ09OVFJBQ1QsIFNUUklDVCBMSUFCSUxJVFksIE9SIFRPUlQgKElOQ0xVRElORyBORUdMSUdFTkNFIE9SIE9USEVSV0lTRSkgQVJJU0lORyBJTiBBTlkgV0FZIE9VVCBPRiBUSEUgVVNFIE9GIFRISVMgU09GVFdBUkUsIEVWRU4gSUYgQURWSVNFRCBPRiBUSEUgUE9TU0lCSUxJVFkgT0YgU1VDSCBEQU1BR0UuCg==",
                 "contentType": "text/plain",
                 "encoding": "base64"
               }
@@ -9072,32 +8977,32 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
     },
     {
       "type": "library",
-      "name": "string_decoder",
-      "version": "1.3.0",
-      "bom-ref": "c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef",
-      "description": "The string_decoder module from Node core",
+      "name": "inherits",
+      "version": "2.0.4",
+      "bom-ref": "inherits@2.0.4#300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d",
+      "description": "Browser-friendly inheritance fully compatible with standard node.js inherits()",
       "licenses": [
         {
           "license": {
-            "id": "MIT",
+            "id": "ISC",
             "acknowledgement": "declared"
           }
         }
       ],
-      "purl": "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git",
+      "purl": "pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git",
       "externalReferences": [
         {
-          "url": "https://github.com/nodejs/string_decoder/issues",
+          "url": "https://github.com/isaacs/inherits/issues",
           "type": "issue-tracker",
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git://github.com/nodejs/string_decoder.git",
+          "url": "git://github.com/isaacs/inherits.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\""
         },
         {
-          "url": "https://github.com/nodejs/string_decoder",
+          "url": "https://github.com/isaacs/inherits#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
@@ -9108,7 +9013,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
             "license": {
               "name": "file: LICENSE",
               "text": {
-                "content": "Tm9kZS5qcyBpcyBsaWNlbnNlZCBmb3IgdXNlIGFzIGZvbGxvd3M6CgoiIiIKQ29weXJpZ2h0IE5vZGUuanMgY29udHJpYnV0b3JzLiBBbGwgcmlnaHRzIHJlc2VydmVkLgoKUGVybWlzc2lvbiBpcyBoZXJlYnkgZ3JhbnRlZCwgZnJlZSBvZiBjaGFyZ2UsIHRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weQpvZiB0aGlzIHNvZnR3YXJlIGFuZCBhc3NvY2lhdGVkIGRvY3VtZW50YXRpb24gZmlsZXMgKHRoZSAiU29mdHdhcmUiKSwgdG8KZGVhbCBpbiB0aGUgU29mdHdhcmUgd2l0aG91dCByZXN0cmljdGlvbiwgaW5jbHVkaW5nIHdpdGhvdXQgbGltaXRhdGlvbiB0aGUKcmlnaHRzIHRvIHVzZSwgY29weSwgbW9kaWZ5LCBtZXJnZSwgcHVibGlzaCwgZGlzdHJpYnV0ZSwgc3VibGljZW5zZSwgYW5kL29yCnNlbGwgY29waWVzIG9mIHRoZSBTb2Z0d2FyZSwgYW5kIHRvIHBlcm1pdCBwZXJzb25zIHRvIHdob20gdGhlIFNvZnR3YXJlIGlzCmZ1cm5pc2hlZCB0byBkbyBzbywgc3ViamVjdCB0byB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnM6CgpUaGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBzaGFsbCBiZSBpbmNsdWRlZCBpbgphbGwgY29waWVzIG9yIHN1YnN0YW50aWFsIHBvcnRpb25zIG9mIHRoZSBTb2Z0d2FyZS4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiLCBXSVRIT1VUIFdBUlJBTlRZIE9GIEFOWSBLSU5ELCBFWFBSRVNTIE9SCklNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZLApGSVRORVNTIEZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRSBBTkQgTk9OSU5GUklOR0VNRU5ULiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUKQVVUSE9SUyBPUiBDT1BZUklHSFQgSE9MREVSUyBCRSBMSUFCTEUgRk9SIEFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUgpMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBUT1JUIE9SIE9USEVSV0lTRSwgQVJJU0lORwpGUk9NLCBPVVQgT0YgT1IgSU4gQ09OTkVDVElPTiBXSVRIIFRIRSBTT0ZUV0FSRSBPUiBUSEUgVVNFIE9SIE9USEVSIERFQUxJTkdTCklOIFRIRSBTT0ZUV0FSRS4KIiIiCgpUaGlzIGxpY2Vuc2UgYXBwbGllcyB0byBwYXJ0cyBvZiBOb2RlLmpzIG9yaWdpbmF0aW5nIGZyb20gdGhlCmh0dHBzOi8vZ2l0aHViLmNvbS9qb3llbnQvbm9kZSByZXBvc2l0b3J5OgoKIiIiCkNvcHlyaWdodCBKb3llbnQsIEluYy4gYW5kIG90aGVyIE5vZGUgY29udHJpYnV0b3JzLiBBbGwgcmlnaHRzIHJlc2VydmVkLgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcgYSBjb3B5Cm9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlICJTb2Z0d2FyZSIpLCB0bwpkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgd2l0aG91dCBsaW1pdGF0aW9uIHRoZQpyaWdodHMgdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLCBkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3IKc2VsbCBjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMKZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvIHRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlIGluY2x1ZGVkIGluCmFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIEVYUFJFU1MgT1IKSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFksCkZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORCBOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRQpBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSCkxJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04gT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HCkZST00sIE9VVCBPRiBPUiBJTiBDT05ORUNUSU9OIFdJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MKSU4gVEhFIFNPRlRXQVJFLgoiIiIKCg==",
+                "content": "VGhlIElTQyBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIElzYWFjIFouIFNjaGx1ZXRlcgoKUGVybWlzc2lvbiB0byB1c2UsIGNvcHksIG1vZGlmeSwgYW5kL29yIGRpc3RyaWJ1dGUgdGhpcyBzb2Z0d2FyZSBmb3IgYW55CnB1cnBvc2Ugd2l0aCBvciB3aXRob3V0IGZlZSBpcyBoZXJlYnkgZ3JhbnRlZCwgcHJvdmlkZWQgdGhhdCB0aGUgYWJvdmUKY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBhcHBlYXIgaW4gYWxsIGNvcGllcy4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiIEFORCBUSEUgQVVUSE9SIERJU0NMQUlNUyBBTEwgV0FSUkFOVElFUyBXSVRIClJFR0FSRCBUTyBUSElTIFNPRlRXQVJFIElOQ0xVRElORyBBTEwgSU1QTElFRCBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSBBTkQKRklUTkVTUy4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUiBCRSBMSUFCTEUgRk9SIEFOWSBTUEVDSUFMLCBESVJFQ1QsCklORElSRUNULCBPUiBDT05TRVFVRU5USUFMIERBTUFHRVMgT1IgQU5ZIERBTUFHRVMgV0hBVFNPRVZFUiBSRVNVTFRJTkcgRlJPTQpMT1NTIE9GIFVTRSwgREFUQSBPUiBQUk9GSVRTLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgTkVHTElHRU5DRSBPUgpPVEhFUiBUT1JUSU9VUyBBQ1RJT04sIEFSSVNJTkcgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgVVNFIE9SClBFUkZPUk1BTkNFIE9GIFRISVMgU09GVFdBUkUuCgo=",
                 "contentType": "text/plain",
                 "encoding": "base64"
               }
@@ -9121,7 +9026,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "libphonenumber-js",
       "version": "1.11.16",
-      "bom-ref": "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725",
+      "bom-ref": "libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725",
       "author": "catamphetamine",
       "description": "A simpler (and smaller) rewrite of Google Android's libphonenumber library in javascript",
       "licenses": [
@@ -9179,7 +9084,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
       "type": "library",
       "name": "readable-stream",
       "version": "3.6.2",
-      "bom-ref": "d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb",
+      "bom-ref": "readable-stream@3.6.2#d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb",
       "description": "Streams3, a user-land copy of the stream library from Node.js",
       "licenses": [
         {
@@ -9224,105 +9129,9 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
     },
     {
       "type": "library",
-      "name": "buffer",
-      "version": "6.0.3",
-      "bom-ref": "d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283",
-      "author": "Feross Aboukhadijeh",
-      "description": "Node.js Buffer API, for the browser",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/feross/buffer/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/feross/buffer.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/feross/buffer",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "VGhlIE1JVCBMaWNlbnNlIChNSVQpCgpDb3B5cmlnaHQgKGMpIEZlcm9zcyBBYm91a2hhZGlqZWgsIGFuZCBvdGhlciBjb250cmlidXRvcnMuCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcgYSBjb3B5Cm9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlICJTb2Z0d2FyZSIpLCB0byBkZWFsCmluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgd2l0aG91dCBsaW1pdGF0aW9uIHRoZSByaWdodHMKdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLCBkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3Igc2VsbApjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMKZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvIHRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlIGluY2x1ZGVkIGluCmFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIEVYUFJFU1MgT1IKSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFksCkZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORCBOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRQpBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSCkxJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04gT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HIEZST00sCk9VVCBPRiBPUiBJTiBDT05ORUNUSU9OIFdJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4KVEhFIFNPRlRXQVJFLgo=",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
-      "name": "base64-js",
-      "version": "1.5.1",
-      "bom-ref": "db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199",
-      "author": "T. Jameson Little",
-      "description": "Base64 encoding/decoding in pure JS",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/beatgammit/base64-js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git://github.com/beatgammit/base64-js.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/beatgammit/base64-js",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ],
-      "evidence": {
-        "licenses": [
-          {
-            "license": {
-              "name": "file: LICENSE",
-              "text": {
-                "content": "VGhlIE1JVCBMaWNlbnNlIChNSVQpCgpDb3B5cmlnaHQgKGMpIDIwMTQgSmFtZXNvbiBMaXR0bGUKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==",
-                "contentType": "text/plain",
-                "encoding": "base64"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "library",
       "name": "safe-buffer",
       "version": "5.2.1",
-      "bom-ref": "e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884",
+      "bom-ref": "safe-buffer@5.2.1#e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884",
       "author": "Feross Aboukhadijeh",
       "description": "Safer Node.js Buffer API",
       "licenses": [
@@ -9365,80 +9174,271 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
           }
         ]
       }
+    },
+    {
+      "type": "library",
+      "name": "stream-browserify",
+      "version": "3.0.0",
+      "bom-ref": "stream-browserify@3.0.0#add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931",
+      "author": "James Halliday",
+      "description": "the stream module from node core for browsers",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/browserify/stream-browserify/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/browserify/stream-browserify.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/browserify/stream-browserify",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "TUlUIExpY2Vuc2UKCkNvcHlyaWdodCAoYykgSmFtZXMgSGFsbGlkYXkKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkgb2YKdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwgaW4KdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cyB0bwp1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsIGNvcGllcyBvZgp0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcyBmdXJuaXNoZWQgdG8gZG8gc28sCnN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4gYWxsCmNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUwpGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUlMgT1IKQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIgTElBQklMSVRZLCBXSEVUSEVSCklOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwgT1VUIE9GIE9SIElOCkNPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTiBUSEUgU09GVFdBUkUuCg==",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "string_decoder",
+      "version": "1.3.0",
+      "bom-ref": "string_decoder@1.3.0#c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef",
+      "description": "The string_decoder module from Node core",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/nodejs/string_decoder/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/nodejs/string_decoder.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/nodejs/string_decoder",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "Tm9kZS5qcyBpcyBsaWNlbnNlZCBmb3IgdXNlIGFzIGZvbGxvd3M6CgoiIiIKQ29weXJpZ2h0IE5vZGUuanMgY29udHJpYnV0b3JzLiBBbGwgcmlnaHRzIHJlc2VydmVkLgoKUGVybWlzc2lvbiBpcyBoZXJlYnkgZ3JhbnRlZCwgZnJlZSBvZiBjaGFyZ2UsIHRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weQpvZiB0aGlzIHNvZnR3YXJlIGFuZCBhc3NvY2lhdGVkIGRvY3VtZW50YXRpb24gZmlsZXMgKHRoZSAiU29mdHdhcmUiKSwgdG8KZGVhbCBpbiB0aGUgU29mdHdhcmUgd2l0aG91dCByZXN0cmljdGlvbiwgaW5jbHVkaW5nIHdpdGhvdXQgbGltaXRhdGlvbiB0aGUKcmlnaHRzIHRvIHVzZSwgY29weSwgbW9kaWZ5LCBtZXJnZSwgcHVibGlzaCwgZGlzdHJpYnV0ZSwgc3VibGljZW5zZSwgYW5kL29yCnNlbGwgY29waWVzIG9mIHRoZSBTb2Z0d2FyZSwgYW5kIHRvIHBlcm1pdCBwZXJzb25zIHRvIHdob20gdGhlIFNvZnR3YXJlIGlzCmZ1cm5pc2hlZCB0byBkbyBzbywgc3ViamVjdCB0byB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnM6CgpUaGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBzaGFsbCBiZSBpbmNsdWRlZCBpbgphbGwgY29waWVzIG9yIHN1YnN0YW50aWFsIHBvcnRpb25zIG9mIHRoZSBTb2Z0d2FyZS4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiLCBXSVRIT1VUIFdBUlJBTlRZIE9GIEFOWSBLSU5ELCBFWFBSRVNTIE9SCklNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZLApGSVRORVNTIEZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRSBBTkQgTk9OSU5GUklOR0VNRU5ULiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUKQVVUSE9SUyBPUiBDT1BZUklHSFQgSE9MREVSUyBCRSBMSUFCTEUgRk9SIEFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUgpMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBUT1JUIE9SIE9USEVSV0lTRSwgQVJJU0lORwpGUk9NLCBPVVQgT0YgT1IgSU4gQ09OTkVDVElPTiBXSVRIIFRIRSBTT0ZUV0FSRSBPUiBUSEUgVVNFIE9SIE9USEVSIERFQUxJTkdTCklOIFRIRSBTT0ZUV0FSRS4KIiIiCgpUaGlzIGxpY2Vuc2UgYXBwbGllcyB0byBwYXJ0cyBvZiBOb2RlLmpzIG9yaWdpbmF0aW5nIGZyb20gdGhlCmh0dHBzOi8vZ2l0aHViLmNvbS9qb3llbnQvbm9kZSByZXBvc2l0b3J5OgoKIiIiCkNvcHlyaWdodCBKb3llbnQsIEluYy4gYW5kIG90aGVyIE5vZGUgY29udHJpYnV0b3JzLiBBbGwgcmlnaHRzIHJlc2VydmVkLgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcgYSBjb3B5Cm9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlICJTb2Z0d2FyZSIpLCB0bwpkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgd2l0aG91dCBsaW1pdGF0aW9uIHRoZQpyaWdodHMgdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLCBkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3IKc2VsbCBjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMKZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvIHRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlIGluY2x1ZGVkIGluCmFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIEVYUFJFU1MgT1IKSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFksCkZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORCBOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRQpBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSCkxJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04gT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HCkZST00sIE9VVCBPRiBPUiBJTiBDT05ORUNUSU9OIFdJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MKSU4gVEhFIFNPRlRXQVJFLgoiIiIKCg==",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "through",
+      "version": "2.3.8",
+      "bom-ref": "through@2.3.8#abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355",
+      "author": "Dominic Tarr",
+      "description": "simplified stream construction",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/dominictarr/through/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/dominictarr/through.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/dominictarr/through",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE.MIT",
+              "text": {
+                "content": "VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTEgRG9taW5pYyBUYXJyCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgCnRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weSBvZiB0aGlzIHNvZnR3YXJlIGFuZCAKYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIApkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgCndpdGhvdXQgbGltaXRhdGlvbiB0aGUgcmlnaHRzIHRvIHVzZSwgY29weSwgbW9kaWZ5LCAKbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsIApjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSAKdGhlIFNvZnR3YXJlIGlzIGZ1cm5pc2hlZCB0byBkbyBzbywgCnN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2UgCnNoYWxsIGJlIGluY2x1ZGVkIGluIGFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIApFWFBSRVNTIE9SIElNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgCk9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gCklOIE5PIEVWRU5UIFNIQUxMIFRIRSBBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgCkFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUiBMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCAKVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgClNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4gVEhFIFNPRlRXQVJFLgo=",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "library",
+      "name": "util-deprecate",
+      "version": "1.0.2",
+      "bom-ref": "util-deprecate@1.0.2#19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5",
+      "author": "Nathan Rajlich",
+      "description": "The Node.js \`util.deprecate()\` function with browser support",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/TooTallNate/util-deprecate/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git://github.com/TooTallNate/util-deprecate.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/TooTallNate/util-deprecate",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ],
+      "evidence": {
+        "licenses": [
+          {
+            "license": {
+              "name": "file: LICENSE",
+              "text": {
+                "content": "KFRoZSBNSVQgTGljZW5zZSkKCkNvcHlyaWdodCAoYykgMjAxNCBOYXRoYW4gUmFqbGljaCA8bmF0aGFuQHRvb3RhbGxuYXRlLm5ldD4KClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uCm9idGFpbmluZyBhIGNvcHkgb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uCmZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwgaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQKcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cyB0byB1c2UsCmNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZQpTb2Z0d2FyZSBpcyBmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZwpjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUKaW5jbHVkZWQgaW4gYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwKRVhQUkVTUyBPUiBJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTCk9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5ECk5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUlMgT1IgQ09QWVJJR0hUCkhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIgTElBQklMSVRZLApXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcKRlJPTSwgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUgpPVEhFUiBERUFMSU5HUyBJTiBUSEUgU09GVFdBUkUuCg==",
+                "contentType": "text/plain",
+                "encoding": "base64"
+              }
+            }
+          }
+        ]
+      }
     }
   ],
   "dependencies": [
     {
-      "ref": "0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2"
-    },
-    {
-      "ref": "19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5"
-    },
-    {
-      "ref": "300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d"
-    },
-    {
-      "ref": "340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00"
-    },
-    {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@cyclonedx-webpack-plugin-tests/regression-issue1337@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00",
-        "abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355",
-        "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
+        "esprima@4.0.1#340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00",
+        "libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725",
+        "through@2.3.8#abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355"
       ]
     },
     {
-      "ref": "9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c"
+      "ref": "base64-js@1.5.1#db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199"
     },
     {
-      "ref": "abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355",
+      "ref": "buffer@6.0.3#d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283",
       "dependsOn": [
-        "add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931"
+        "base64-js@1.5.1#db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199",
+        "ieee754@1.2.1#0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2"
       ]
     },
     {
-      "ref": "add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931",
+      "ref": "esprima@4.0.1#340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00"
+    },
+    {
+      "ref": "events@3.3.0#9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c"
+    },
+    {
+      "ref": "ieee754@1.2.1#0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2"
+    },
+    {
+      "ref": "inherits@2.0.4#300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d"
+    },
+    {
+      "ref": "libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
+    },
+    {
+      "ref": "readable-stream@3.6.2#d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb",
       "dependsOn": [
-        "300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d",
-        "9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c",
-        "d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb"
+        "buffer@6.0.3#d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283",
+        "events@3.3.0#9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c",
+        "inherits@2.0.4#300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d",
+        "string_decoder@1.3.0#c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef",
+        "util-deprecate@1.0.2#19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5"
       ]
     },
     {
-      "ref": "c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef",
+      "ref": "safe-buffer@5.2.1#e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884",
       "dependsOn": [
-        "e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884"
+        "buffer@6.0.3#d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283"
       ]
     },
     {
-      "ref": "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
-    },
-    {
-      "ref": "d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb",
+      "ref": "stream-browserify@3.0.0#add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931",
       "dependsOn": [
-        "19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5",
-        "300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d",
-        "9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c",
-        "c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef",
-        "d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283"
+        "events@3.3.0#9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c",
+        "inherits@2.0.4#300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d",
+        "readable-stream@3.6.2#d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb"
       ]
     },
     {
-      "ref": "d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283",
+      "ref": "string_decoder@1.3.0#c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef",
       "dependsOn": [
-        "0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2",
-        "db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199"
+        "safe-buffer@5.2.1#e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884"
       ]
     },
     {
-      "ref": "db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199"
+      "ref": "through@2.3.8#abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355",
+      "dependsOn": [
+        "stream-browserify@3.0.0#add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931"
+      ]
     },
     {
-      "ref": "e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884",
-      "dependsOn": [
-        "d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283"
-      ]
+      "ref": "util-deprecate@1.0.2#19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5"
     }
   ]
 }"
@@ -9513,7 +9513,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </component>
       </components>
     </tools>
-    <component type="application" bom-ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+    <component type="application" bom-ref="@cyclonedx-webpack-plugin-tests/regression-issue1337@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
       <author>Jan Kowalleck</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>regression-issue1337</name>
@@ -9542,62 +9542,28 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2">
-      <author>Feross Aboukhadijeh</author>
-      <name>ieee754</name>
-      <version>1.2.1</version>
-      <description>Read/write IEEE754 floating point numbers from/to a Buffer or array-like object</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>BSD-3-Clause</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/feross/ieee754/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git://github.com/feross/ieee754.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/feross/ieee754#readme</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-      <evidence>
-        <licenses>
-          <license>
-            <name>file: LICENSE</name>
-            <text content-type="text/plain" encoding="base64">Q29weXJpZ2h0IDIwMDggRmFpciBPYWtzIExhYnMsIEluYy4KClJlZGlzdHJpYnV0aW9uIGFuZCB1c2UgaW4gc291cmNlIGFuZCBiaW5hcnkgZm9ybXMsIHdpdGggb3Igd2l0aG91dCBtb2RpZmljYXRpb24sIGFyZSBwZXJtaXR0ZWQgcHJvdmlkZWQgdGhhdCB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnMgYXJlIG1ldDoKCjEuIFJlZGlzdHJpYnV0aW9ucyBvZiBzb3VyY2UgY29kZSBtdXN0IHJldGFpbiB0aGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSwgdGhpcyBsaXN0IG9mIGNvbmRpdGlvbnMgYW5kIHRoZSBmb2xsb3dpbmcgZGlzY2xhaW1lci4KCjIuIFJlZGlzdHJpYnV0aW9ucyBpbiBiaW5hcnkgZm9ybSBtdXN0IHJlcHJvZHVjZSB0aGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSwgdGhpcyBsaXN0IG9mIGNvbmRpdGlvbnMgYW5kIHRoZSBmb2xsb3dpbmcgZGlzY2xhaW1lciBpbiB0aGUgZG9jdW1lbnRhdGlvbiBhbmQvb3Igb3RoZXIgbWF0ZXJpYWxzIHByb3ZpZGVkIHdpdGggdGhlIGRpc3RyaWJ1dGlvbi4KCjMuIE5laXRoZXIgdGhlIG5hbWUgb2YgdGhlIGNvcHlyaWdodCBob2xkZXIgbm9yIHRoZSBuYW1lcyBvZiBpdHMgY29udHJpYnV0b3JzIG1heSBiZSB1c2VkIHRvIGVuZG9yc2Ugb3IgcHJvbW90ZSBwcm9kdWN0cyBkZXJpdmVkIGZyb20gdGhpcyBzb2Z0d2FyZSB3aXRob3V0IHNwZWNpZmljIHByaW9yIHdyaXR0ZW4gcGVybWlzc2lvbi4KClRISVMgU09GVFdBUkUgSVMgUFJPVklERUQgQlkgVEhFIENPUFlSSUdIVCBIT0xERVJTIEFORCBDT05UUklCVVRPUlMgIkFTIElTIiBBTkQgQU5ZIEVYUFJFU1MgT1IgSU1QTElFRCBXQVJSQU5USUVTLCBJTkNMVURJTkcsIEJVVCBOT1QgTElNSVRFRCBUTywgVEhFIElNUExJRUQgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFkgQU5EIEZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFSRSBESVNDTEFJTUVELiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUgQ09QWVJJR0hUIEhPTERFUiBPUiBDT05UUklCVVRPUlMgQkUgTElBQkxFIEZPUiBBTlkgRElSRUNULCBJTkRJUkVDVCwgSU5DSURFTlRBTCwgU1BFQ0lBTCwgRVhFTVBMQVJZLCBPUiBDT05TRVFVRU5USUFMIERBTUFHRVMgKElOQ0xVRElORywgQlVUIE5PVCBMSU1JVEVEIFRPLCBQUk9DVVJFTUVOVCBPRiBTVUJTVElUVVRFIEdPT0RTIE9SIFNFUlZJQ0VTOyBMT1NTIE9GIFVTRSwgREFUQSwgT1IgUFJPRklUUzsgT1IgQlVTSU5FU1MgSU5URVJSVVBUSU9OKSBIT1dFVkVSIENBVVNFRCBBTkQgT04gQU5ZIFRIRU9SWSBPRiBMSUFCSUxJVFksIFdIRVRIRVIgSU4gQ09OVFJBQ1QsIFNUUklDVCBMSUFCSUxJVFksIE9SIFRPUlQgKElOQ0xVRElORyBORUdMSUdFTkNFIE9SIE9USEVSV0lTRSkgQVJJU0lORyBJTiBBTlkgV0FZIE9VVCBPRiBUSEUgVVNFIE9GIFRISVMgU09GVFdBUkUsIEVWRU4gSUYgQURWSVNFRCBPRiBUSEUgUE9TU0lCSUxJVFkgT0YgU1VDSCBEQU1BR0UuCg==</text>
-          </license>
-        </licenses>
-      </evidence>
-    </component>
-    <component type="library" bom-ref="19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5">
-      <author>Nathan Rajlich</author>
-      <name>util-deprecate</name>
-      <version>1.0.2</version>
-      <description>The Node.js \`util.deprecate()\` function with browser support</description>
+    <component type="library" bom-ref="base64-js@1.5.1#db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199">
+      <author>T. Jameson Little</author>
+      <name>base64-js</name>
+      <version>1.5.1</version>
+      <description>Base64 encoding/decoding in pure JS</description>
       <licenses>
         <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git</purl>
+      <purl>pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
-          <url>https://github.com/TooTallNate/util-deprecate/issues</url>
+          <url>https://github.com/beatgammit/base64-js/issues</url>
           <comment>as detected from PackageJson property "bugs.url"</comment>
         </reference>
         <reference type="vcs">
-          <url>git://github.com/TooTallNate/util-deprecate.git</url>
+          <url>git://github.com/beatgammit/base64-js.git</url>
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
         <reference type="website">
-          <url>https://github.com/TooTallNate/util-deprecate</url>
+          <url>https://github.com/beatgammit/base64-js</url>
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
@@ -9605,32 +9571,33 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         <licenses>
           <license>
             <name>file: LICENSE</name>
-            <text content-type="text/plain" encoding="base64">KFRoZSBNSVQgTGljZW5zZSkKCkNvcHlyaWdodCAoYykgMjAxNCBOYXRoYW4gUmFqbGljaCA8bmF0aGFuQHRvb3RhbGxuYXRlLm5ldD4KClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uCm9idGFpbmluZyBhIGNvcHkgb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uCmZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwgaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQKcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cyB0byB1c2UsCmNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZQpTb2Z0d2FyZSBpcyBmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZwpjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUKaW5jbHVkZWQgaW4gYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwKRVhQUkVTUyBPUiBJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTCk9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5ECk5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUlMgT1IgQ09QWVJJR0hUCkhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIgTElBQklMSVRZLApXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcKRlJPTSwgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUgpPVEhFUiBERUFMSU5HUyBJTiBUSEUgU09GVFdBUkUuCg==</text>
+            <text content-type="text/plain" encoding="base64">VGhlIE1JVCBMaWNlbnNlIChNSVQpCgpDb3B5cmlnaHQgKGMpIDIwMTQgSmFtZXNvbiBMaXR0bGUKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==</text>
           </license>
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d">
-      <name>inherits</name>
-      <version>2.0.4</version>
-      <description>Browser-friendly inheritance fully compatible with standard node.js inherits()</description>
+    <component type="library" bom-ref="buffer@6.0.3#d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283">
+      <author>Feross Aboukhadijeh</author>
+      <name>buffer</name>
+      <version>6.0.3</version>
+      <description>Node.js Buffer API, for the browser</description>
       <licenses>
         <license acknowledgement="declared">
-          <id>ISC</id>
+          <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git</purl>
+      <purl>pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
-          <url>https://github.com/isaacs/inherits/issues</url>
+          <url>https://github.com/feross/buffer/issues</url>
           <comment>as detected from PackageJson property "bugs.url"</comment>
         </reference>
         <reference type="vcs">
-          <url>git://github.com/isaacs/inherits.git</url>
+          <url>git://github.com/feross/buffer.git</url>
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
         <reference type="website">
-          <url>https://github.com/isaacs/inherits#readme</url>
+          <url>https://github.com/feross/buffer</url>
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
@@ -9638,12 +9605,12 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         <licenses>
           <license>
             <name>file: LICENSE</name>
-            <text content-type="text/plain" encoding="base64">VGhlIElTQyBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIElzYWFjIFouIFNjaGx1ZXRlcgoKUGVybWlzc2lvbiB0byB1c2UsIGNvcHksIG1vZGlmeSwgYW5kL29yIGRpc3RyaWJ1dGUgdGhpcyBzb2Z0d2FyZSBmb3IgYW55CnB1cnBvc2Ugd2l0aCBvciB3aXRob3V0IGZlZSBpcyBoZXJlYnkgZ3JhbnRlZCwgcHJvdmlkZWQgdGhhdCB0aGUgYWJvdmUKY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBhcHBlYXIgaW4gYWxsIGNvcGllcy4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiIEFORCBUSEUgQVVUSE9SIERJU0NMQUlNUyBBTEwgV0FSUkFOVElFUyBXSVRIClJFR0FSRCBUTyBUSElTIFNPRlRXQVJFIElOQ0xVRElORyBBTEwgSU1QTElFRCBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSBBTkQKRklUTkVTUy4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUiBCRSBMSUFCTEUgRk9SIEFOWSBTUEVDSUFMLCBESVJFQ1QsCklORElSRUNULCBPUiBDT05TRVFVRU5USUFMIERBTUFHRVMgT1IgQU5ZIERBTUFHRVMgV0hBVFNPRVZFUiBSRVNVTFRJTkcgRlJPTQpMT1NTIE9GIFVTRSwgREFUQSBPUiBQUk9GSVRTLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgTkVHTElHRU5DRSBPUgpPVEhFUiBUT1JUSU9VUyBBQ1RJT04sIEFSSVNJTkcgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgVVNFIE9SClBFUkZPUk1BTkNFIE9GIFRISVMgU09GVFdBUkUuCgo=</text>
+            <text content-type="text/plain" encoding="base64">VGhlIE1JVCBMaWNlbnNlIChNSVQpCgpDb3B5cmlnaHQgKGMpIEZlcm9zcyBBYm91a2hhZGlqZWgsIGFuZCBvdGhlciBjb250cmlidXRvcnMuCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcgYSBjb3B5Cm9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlICJTb2Z0d2FyZSIpLCB0byBkZWFsCmluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgd2l0aG91dCBsaW1pdGF0aW9uIHRoZSByaWdodHMKdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLCBkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3Igc2VsbApjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMKZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvIHRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlIGluY2x1ZGVkIGluCmFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIEVYUFJFU1MgT1IKSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFksCkZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORCBOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRQpBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSCkxJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04gT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HIEZST00sCk9VVCBPRiBPUiBJTiBDT05ORUNUSU9OIFdJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4KVEhFIFNPRlRXQVJFLgo=</text>
           </license>
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00">
+    <component type="library" bom-ref="esprima@4.0.1#340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00">
       <author>Ariya Hidayat</author>
       <name>esprima</name>
       <version>4.0.1</version>
@@ -9677,7 +9644,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c">
+    <component type="library" bom-ref="events@3.3.0#9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c">
       <author>Irakli Gozalishvili</author>
       <name>events</name>
       <version>3.3.0</version>
@@ -9711,62 +9678,28 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355">
-      <author>Dominic Tarr</author>
-      <name>through</name>
-      <version>2.3.8</version>
-      <description>simplified stream construction</description>
+    <component type="library" bom-ref="ieee754@1.2.1#0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2">
+      <author>Feross Aboukhadijeh</author>
+      <name>ieee754</name>
+      <version>1.2.1</version>
+      <description>Read/write IEEE754 floating point numbers from/to a Buffer or array-like object</description>
       <licenses>
         <license acknowledgement="declared">
-          <id>MIT</id>
+          <id>BSD-3-Clause</id>
         </license>
       </licenses>
-      <purl>pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git</purl>
+      <purl>pkg:npm/ieee754@1.2.1?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fieee754.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
-          <url>https://github.com/dominictarr/through/issues</url>
+          <url>https://github.com/feross/ieee754/issues</url>
           <comment>as detected from PackageJson property "bugs.url"</comment>
         </reference>
         <reference type="vcs">
-          <url>git+https://github.com/dominictarr/through.git</url>
+          <url>git://github.com/feross/ieee754.git</url>
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
         <reference type="website">
-          <url>https://github.com/dominictarr/through</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-      <evidence>
-        <licenses>
-          <license>
-            <name>file: LICENSE.MIT</name>
-            <text content-type="text/plain" encoding="base64">VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTEgRG9taW5pYyBUYXJyCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgCnRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weSBvZiB0aGlzIHNvZnR3YXJlIGFuZCAKYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIApkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgCndpdGhvdXQgbGltaXRhdGlvbiB0aGUgcmlnaHRzIHRvIHVzZSwgY29weSwgbW9kaWZ5LCAKbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsIApjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSAKdGhlIFNvZnR3YXJlIGlzIGZ1cm5pc2hlZCB0byBkbyBzbywgCnN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2UgCnNoYWxsIGJlIGluY2x1ZGVkIGluIGFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIApFWFBSRVNTIE9SIElNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgCk9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gCklOIE5PIEVWRU5UIFNIQUxMIFRIRSBBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgCkFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUiBMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCAKVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgClNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4gVEhFIFNPRlRXQVJFLgo=</text>
-          </license>
-        </licenses>
-      </evidence>
-    </component>
-    <component type="library" bom-ref="add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931">
-      <author>James Halliday</author>
-      <name>stream-browserify</name>
-      <version>3.0.0</version>
-      <description>the stream module from node core for browsers</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/browserify/stream-browserify/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git://github.com/browserify/stream-browserify.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/browserify/stream-browserify</url>
+          <url>https://github.com/feross/ieee754#readme</url>
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
@@ -9774,32 +9707,32 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         <licenses>
           <license>
             <name>file: LICENSE</name>
-            <text content-type="text/plain" encoding="base64">TUlUIExpY2Vuc2UKCkNvcHlyaWdodCAoYykgSmFtZXMgSGFsbGlkYXkKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkgb2YKdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwgaW4KdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cyB0bwp1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsIGNvcGllcyBvZgp0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcyBmdXJuaXNoZWQgdG8gZG8gc28sCnN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4gYWxsCmNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUwpGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUlMgT1IKQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIgTElBQklMSVRZLCBXSEVUSEVSCklOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwgT1VUIE9GIE9SIElOCkNPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTiBUSEUgU09GVFdBUkUuCg==</text>
+            <text content-type="text/plain" encoding="base64">Q29weXJpZ2h0IDIwMDggRmFpciBPYWtzIExhYnMsIEluYy4KClJlZGlzdHJpYnV0aW9uIGFuZCB1c2UgaW4gc291cmNlIGFuZCBiaW5hcnkgZm9ybXMsIHdpdGggb3Igd2l0aG91dCBtb2RpZmljYXRpb24sIGFyZSBwZXJtaXR0ZWQgcHJvdmlkZWQgdGhhdCB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnMgYXJlIG1ldDoKCjEuIFJlZGlzdHJpYnV0aW9ucyBvZiBzb3VyY2UgY29kZSBtdXN0IHJldGFpbiB0aGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSwgdGhpcyBsaXN0IG9mIGNvbmRpdGlvbnMgYW5kIHRoZSBmb2xsb3dpbmcgZGlzY2xhaW1lci4KCjIuIFJlZGlzdHJpYnV0aW9ucyBpbiBiaW5hcnkgZm9ybSBtdXN0IHJlcHJvZHVjZSB0aGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSwgdGhpcyBsaXN0IG9mIGNvbmRpdGlvbnMgYW5kIHRoZSBmb2xsb3dpbmcgZGlzY2xhaW1lciBpbiB0aGUgZG9jdW1lbnRhdGlvbiBhbmQvb3Igb3RoZXIgbWF0ZXJpYWxzIHByb3ZpZGVkIHdpdGggdGhlIGRpc3RyaWJ1dGlvbi4KCjMuIE5laXRoZXIgdGhlIG5hbWUgb2YgdGhlIGNvcHlyaWdodCBob2xkZXIgbm9yIHRoZSBuYW1lcyBvZiBpdHMgY29udHJpYnV0b3JzIG1heSBiZSB1c2VkIHRvIGVuZG9yc2Ugb3IgcHJvbW90ZSBwcm9kdWN0cyBkZXJpdmVkIGZyb20gdGhpcyBzb2Z0d2FyZSB3aXRob3V0IHNwZWNpZmljIHByaW9yIHdyaXR0ZW4gcGVybWlzc2lvbi4KClRISVMgU09GVFdBUkUgSVMgUFJPVklERUQgQlkgVEhFIENPUFlSSUdIVCBIT0xERVJTIEFORCBDT05UUklCVVRPUlMgIkFTIElTIiBBTkQgQU5ZIEVYUFJFU1MgT1IgSU1QTElFRCBXQVJSQU5USUVTLCBJTkNMVURJTkcsIEJVVCBOT1QgTElNSVRFRCBUTywgVEhFIElNUExJRUQgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFkgQU5EIEZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFSRSBESVNDTEFJTUVELiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUgQ09QWVJJR0hUIEhPTERFUiBPUiBDT05UUklCVVRPUlMgQkUgTElBQkxFIEZPUiBBTlkgRElSRUNULCBJTkRJUkVDVCwgSU5DSURFTlRBTCwgU1BFQ0lBTCwgRVhFTVBMQVJZLCBPUiBDT05TRVFVRU5USUFMIERBTUFHRVMgKElOQ0xVRElORywgQlVUIE5PVCBMSU1JVEVEIFRPLCBQUk9DVVJFTUVOVCBPRiBTVUJTVElUVVRFIEdPT0RTIE9SIFNFUlZJQ0VTOyBMT1NTIE9GIFVTRSwgREFUQSwgT1IgUFJPRklUUzsgT1IgQlVTSU5FU1MgSU5URVJSVVBUSU9OKSBIT1dFVkVSIENBVVNFRCBBTkQgT04gQU5ZIFRIRU9SWSBPRiBMSUFCSUxJVFksIFdIRVRIRVIgSU4gQ09OVFJBQ1QsIFNUUklDVCBMSUFCSUxJVFksIE9SIFRPUlQgKElOQ0xVRElORyBORUdMSUdFTkNFIE9SIE9USEVSV0lTRSkgQVJJU0lORyBJTiBBTlkgV0FZIE9VVCBPRiBUSEUgVVNFIE9GIFRISVMgU09GVFdBUkUsIEVWRU4gSUYgQURWSVNFRCBPRiBUSEUgUE9TU0lCSUxJVFkgT0YgU1VDSCBEQU1BR0UuCg==</text>
           </license>
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef">
-      <name>string_decoder</name>
-      <version>1.3.0</version>
-      <description>The string_decoder module from Node core</description>
+    <component type="library" bom-ref="inherits@2.0.4#300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d">
+      <name>inherits</name>
+      <version>2.0.4</version>
+      <description>Browser-friendly inheritance fully compatible with standard node.js inherits()</description>
       <licenses>
         <license acknowledgement="declared">
-          <id>MIT</id>
+          <id>ISC</id>
         </license>
       </licenses>
-      <purl>pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git</purl>
+      <purl>pkg:npm/inherits@2.0.4?vcs_url=git%3A%2F%2Fgithub.com%2Fisaacs%2Finherits.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
-          <url>https://github.com/nodejs/string_decoder/issues</url>
+          <url>https://github.com/isaacs/inherits/issues</url>
           <comment>as detected from PackageJson property "bugs.url"</comment>
         </reference>
         <reference type="vcs">
-          <url>git://github.com/nodejs/string_decoder.git</url>
+          <url>git://github.com/isaacs/inherits.git</url>
           <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
         <reference type="website">
-          <url>https://github.com/nodejs/string_decoder</url>
+          <url>https://github.com/isaacs/inherits#readme</url>
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
@@ -9807,12 +9740,12 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         <licenses>
           <license>
             <name>file: LICENSE</name>
-            <text content-type="text/plain" encoding="base64">Tm9kZS5qcyBpcyBsaWNlbnNlZCBmb3IgdXNlIGFzIGZvbGxvd3M6CgoiIiIKQ29weXJpZ2h0IE5vZGUuanMgY29udHJpYnV0b3JzLiBBbGwgcmlnaHRzIHJlc2VydmVkLgoKUGVybWlzc2lvbiBpcyBoZXJlYnkgZ3JhbnRlZCwgZnJlZSBvZiBjaGFyZ2UsIHRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weQpvZiB0aGlzIHNvZnR3YXJlIGFuZCBhc3NvY2lhdGVkIGRvY3VtZW50YXRpb24gZmlsZXMgKHRoZSAiU29mdHdhcmUiKSwgdG8KZGVhbCBpbiB0aGUgU29mdHdhcmUgd2l0aG91dCByZXN0cmljdGlvbiwgaW5jbHVkaW5nIHdpdGhvdXQgbGltaXRhdGlvbiB0aGUKcmlnaHRzIHRvIHVzZSwgY29weSwgbW9kaWZ5LCBtZXJnZSwgcHVibGlzaCwgZGlzdHJpYnV0ZSwgc3VibGljZW5zZSwgYW5kL29yCnNlbGwgY29waWVzIG9mIHRoZSBTb2Z0d2FyZSwgYW5kIHRvIHBlcm1pdCBwZXJzb25zIHRvIHdob20gdGhlIFNvZnR3YXJlIGlzCmZ1cm5pc2hlZCB0byBkbyBzbywgc3ViamVjdCB0byB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnM6CgpUaGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBzaGFsbCBiZSBpbmNsdWRlZCBpbgphbGwgY29waWVzIG9yIHN1YnN0YW50aWFsIHBvcnRpb25zIG9mIHRoZSBTb2Z0d2FyZS4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiLCBXSVRIT1VUIFdBUlJBTlRZIE9GIEFOWSBLSU5ELCBFWFBSRVNTIE9SCklNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZLApGSVRORVNTIEZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRSBBTkQgTk9OSU5GUklOR0VNRU5ULiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUKQVVUSE9SUyBPUiBDT1BZUklHSFQgSE9MREVSUyBCRSBMSUFCTEUgRk9SIEFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUgpMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBUT1JUIE9SIE9USEVSV0lTRSwgQVJJU0lORwpGUk9NLCBPVVQgT0YgT1IgSU4gQ09OTkVDVElPTiBXSVRIIFRIRSBTT0ZUV0FSRSBPUiBUSEUgVVNFIE9SIE9USEVSIERFQUxJTkdTCklOIFRIRSBTT0ZUV0FSRS4KIiIiCgpUaGlzIGxpY2Vuc2UgYXBwbGllcyB0byBwYXJ0cyBvZiBOb2RlLmpzIG9yaWdpbmF0aW5nIGZyb20gdGhlCmh0dHBzOi8vZ2l0aHViLmNvbS9qb3llbnQvbm9kZSByZXBvc2l0b3J5OgoKIiIiCkNvcHlyaWdodCBKb3llbnQsIEluYy4gYW5kIG90aGVyIE5vZGUgY29udHJpYnV0b3JzLiBBbGwgcmlnaHRzIHJlc2VydmVkLgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcgYSBjb3B5Cm9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlICJTb2Z0d2FyZSIpLCB0bwpkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgd2l0aG91dCBsaW1pdGF0aW9uIHRoZQpyaWdodHMgdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLCBkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3IKc2VsbCBjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMKZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvIHRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlIGluY2x1ZGVkIGluCmFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIEVYUFJFU1MgT1IKSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFksCkZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORCBOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRQpBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSCkxJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04gT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HCkZST00sIE9VVCBPRiBPUiBJTiBDT05ORUNUSU9OIFdJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MKSU4gVEhFIFNPRlRXQVJFLgoiIiIKCg==</text>
+            <text content-type="text/plain" encoding="base64">VGhlIElTQyBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIElzYWFjIFouIFNjaGx1ZXRlcgoKUGVybWlzc2lvbiB0byB1c2UsIGNvcHksIG1vZGlmeSwgYW5kL29yIGRpc3RyaWJ1dGUgdGhpcyBzb2Z0d2FyZSBmb3IgYW55CnB1cnBvc2Ugd2l0aCBvciB3aXRob3V0IGZlZSBpcyBoZXJlYnkgZ3JhbnRlZCwgcHJvdmlkZWQgdGhhdCB0aGUgYWJvdmUKY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBhcHBlYXIgaW4gYWxsIGNvcGllcy4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiIEFORCBUSEUgQVVUSE9SIERJU0NMQUlNUyBBTEwgV0FSUkFOVElFUyBXSVRIClJFR0FSRCBUTyBUSElTIFNPRlRXQVJFIElOQ0xVRElORyBBTEwgSU1QTElFRCBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSBBTkQKRklUTkVTUy4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUiBCRSBMSUFCTEUgRk9SIEFOWSBTUEVDSUFMLCBESVJFQ1QsCklORElSRUNULCBPUiBDT05TRVFVRU5USUFMIERBTUFHRVMgT1IgQU5ZIERBTUFHRVMgV0hBVFNPRVZFUiBSRVNVTFRJTkcgRlJPTQpMT1NTIE9GIFVTRSwgREFUQSBPUiBQUk9GSVRTLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgTkVHTElHRU5DRSBPUgpPVEhFUiBUT1JUSU9VUyBBQ1RJT04sIEFSSVNJTkcgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgVVNFIE9SClBFUkZPUk1BTkNFIE9GIFRISVMgU09GVFdBUkUuCgo=</text>
           </license>
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725">
+    <component type="library" bom-ref="libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725">
       <author>catamphetamine</author>
       <name>libphonenumber-js</name>
       <version>1.11.16</version>
@@ -9850,7 +9783,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb">
+    <component type="library" bom-ref="readable-stream@3.6.2#d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb">
       <name>readable-stream</name>
       <version>3.6.2</version>
       <description>Streams3, a user-land copy of the stream library from Node.js</description>
@@ -9883,75 +9816,7 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
-    <component type="library" bom-ref="d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283">
-      <author>Feross Aboukhadijeh</author>
-      <name>buffer</name>
-      <version>6.0.3</version>
-      <description>Node.js Buffer API, for the browser</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/buffer@6.0.3?vcs_url=git%3A%2F%2Fgithub.com%2Ffeross%2Fbuffer.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/feross/buffer/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git://github.com/feross/buffer.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/feross/buffer</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-      <evidence>
-        <licenses>
-          <license>
-            <name>file: LICENSE</name>
-            <text content-type="text/plain" encoding="base64">VGhlIE1JVCBMaWNlbnNlIChNSVQpCgpDb3B5cmlnaHQgKGMpIEZlcm9zcyBBYm91a2hhZGlqZWgsIGFuZCBvdGhlciBjb250cmlidXRvcnMuCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcgYSBjb3B5Cm9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlICJTb2Z0d2FyZSIpLCB0byBkZWFsCmluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgd2l0aG91dCBsaW1pdGF0aW9uIHRoZSByaWdodHMKdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLCBkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3Igc2VsbApjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMKZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvIHRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlIGluY2x1ZGVkIGluCmFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIEVYUFJFU1MgT1IKSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFksCkZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORCBOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRQpBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSCkxJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04gT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HIEZST00sCk9VVCBPRiBPUiBJTiBDT05ORUNUSU9OIFdJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4KVEhFIFNPRlRXQVJFLgo=</text>
-          </license>
-        </licenses>
-      </evidence>
-    </component>
-    <component type="library" bom-ref="db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199">
-      <author>T. Jameson Little</author>
-      <name>base64-js</name>
-      <version>1.5.1</version>
-      <description>Base64 encoding/decoding in pure JS</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/base64-js@1.5.1?vcs_url=git%3A%2F%2Fgithub.com%2Fbeatgammit%2Fbase64-js.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/beatgammit/base64-js/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git://github.com/beatgammit/base64-js.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/beatgammit/base64-js</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-      <evidence>
-        <licenses>
-          <license>
-            <name>file: LICENSE</name>
-            <text content-type="text/plain" encoding="base64">VGhlIE1JVCBMaWNlbnNlIChNSVQpCgpDb3B5cmlnaHQgKGMpIDIwMTQgSmFtZXNvbiBMaXR0bGUKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkKb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwKaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cwp0byB1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcwpmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4KYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwKRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFCkFVVEhPUlMgT1IgQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIKTElBQklMSVRZLCBXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwKT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTgpUSEUgU09GVFdBUkUuCg==</text>
-          </license>
-        </licenses>
-      </evidence>
-    </component>
-    <component type="library" bom-ref="e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884">
+    <component type="library" bom-ref="safe-buffer@5.2.1#e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884">
       <author>Feross Aboukhadijeh</author>
       <name>safe-buffer</name>
       <version>5.2.1</version>
@@ -9985,45 +9850,180 @@ exports[`integration regression: find license evidence like \`LICENSE.MIT\` gene
         </licenses>
       </evidence>
     </component>
+    <component type="library" bom-ref="stream-browserify@3.0.0#add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931">
+      <author>James Halliday</author>
+      <name>stream-browserify</name>
+      <version>3.0.0</version>
+      <description>the stream module from node core for browsers</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/stream-browserify@3.0.0?vcs_url=git%3A%2F%2Fgithub.com%2Fbrowserify%2Fstream-browserify.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/browserify/stream-browserify/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git://github.com/browserify/stream-browserify.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/browserify/stream-browserify</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+      <evidence>
+        <licenses>
+          <license>
+            <name>file: LICENSE</name>
+            <text content-type="text/plain" encoding="base64">TUlUIExpY2Vuc2UKCkNvcHlyaWdodCAoYykgSmFtZXMgSGFsbGlkYXkKClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uIG9idGFpbmluZyBhIGNvcHkgb2YKdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwgaW4KdGhlIFNvZnR3YXJlIHdpdGhvdXQgcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cyB0bwp1c2UsIGNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsIGNvcGllcyBvZgp0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZSBTb2Z0d2FyZSBpcyBmdXJuaXNoZWQgdG8gZG8gc28sCnN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUgaW5jbHVkZWQgaW4gYWxsCmNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwgRVhQUkVTUyBPUgpJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTIE9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUwpGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUlMgT1IKQ09QWVJJR0hUIEhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIgTElBQklMSVRZLCBXSEVUSEVSCklOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwgT1VUIE9GIE9SIElOCkNPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUiBPVEhFUiBERUFMSU5HUyBJTiBUSEUgU09GVFdBUkUuCg==</text>
+          </license>
+        </licenses>
+      </evidence>
+    </component>
+    <component type="library" bom-ref="string_decoder@1.3.0#c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef">
+      <name>string_decoder</name>
+      <version>1.3.0</version>
+      <description>The string_decoder module from Node core</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/string_decoder@1.3.0?vcs_url=git%3A%2F%2Fgithub.com%2Fnodejs%2Fstring_decoder.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/nodejs/string_decoder/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git://github.com/nodejs/string_decoder.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/nodejs/string_decoder</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+      <evidence>
+        <licenses>
+          <license>
+            <name>file: LICENSE</name>
+            <text content-type="text/plain" encoding="base64">Tm9kZS5qcyBpcyBsaWNlbnNlZCBmb3IgdXNlIGFzIGZvbGxvd3M6CgoiIiIKQ29weXJpZ2h0IE5vZGUuanMgY29udHJpYnV0b3JzLiBBbGwgcmlnaHRzIHJlc2VydmVkLgoKUGVybWlzc2lvbiBpcyBoZXJlYnkgZ3JhbnRlZCwgZnJlZSBvZiBjaGFyZ2UsIHRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weQpvZiB0aGlzIHNvZnR3YXJlIGFuZCBhc3NvY2lhdGVkIGRvY3VtZW50YXRpb24gZmlsZXMgKHRoZSAiU29mdHdhcmUiKSwgdG8KZGVhbCBpbiB0aGUgU29mdHdhcmUgd2l0aG91dCByZXN0cmljdGlvbiwgaW5jbHVkaW5nIHdpdGhvdXQgbGltaXRhdGlvbiB0aGUKcmlnaHRzIHRvIHVzZSwgY29weSwgbW9kaWZ5LCBtZXJnZSwgcHVibGlzaCwgZGlzdHJpYnV0ZSwgc3VibGljZW5zZSwgYW5kL29yCnNlbGwgY29waWVzIG9mIHRoZSBTb2Z0d2FyZSwgYW5kIHRvIHBlcm1pdCBwZXJzb25zIHRvIHdob20gdGhlIFNvZnR3YXJlIGlzCmZ1cm5pc2hlZCB0byBkbyBzbywgc3ViamVjdCB0byB0aGUgZm9sbG93aW5nIGNvbmRpdGlvbnM6CgpUaGUgYWJvdmUgY29weXJpZ2h0IG5vdGljZSBhbmQgdGhpcyBwZXJtaXNzaW9uIG5vdGljZSBzaGFsbCBiZSBpbmNsdWRlZCBpbgphbGwgY29waWVzIG9yIHN1YnN0YW50aWFsIHBvcnRpb25zIG9mIHRoZSBTb2Z0d2FyZS4KClRIRSBTT0ZUV0FSRSBJUyBQUk9WSURFRCAiQVMgSVMiLCBXSVRIT1VUIFdBUlJBTlRZIE9GIEFOWSBLSU5ELCBFWFBSRVNTIE9SCklNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgT0YgTUVSQ0hBTlRBQklMSVRZLApGSVRORVNTIEZPUiBBIFBBUlRJQ1VMQVIgUFVSUE9TRSBBTkQgTk9OSU5GUklOR0VNRU5ULiBJTiBOTyBFVkVOVCBTSEFMTCBUSEUKQVVUSE9SUyBPUiBDT1BZUklHSFQgSE9MREVSUyBCRSBMSUFCTEUgRk9SIEFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUgpMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCBUT1JUIE9SIE9USEVSV0lTRSwgQVJJU0lORwpGUk9NLCBPVVQgT0YgT1IgSU4gQ09OTkVDVElPTiBXSVRIIFRIRSBTT0ZUV0FSRSBPUiBUSEUgVVNFIE9SIE9USEVSIERFQUxJTkdTCklOIFRIRSBTT0ZUV0FSRS4KIiIiCgpUaGlzIGxpY2Vuc2UgYXBwbGllcyB0byBwYXJ0cyBvZiBOb2RlLmpzIG9yaWdpbmF0aW5nIGZyb20gdGhlCmh0dHBzOi8vZ2l0aHViLmNvbS9qb3llbnQvbm9kZSByZXBvc2l0b3J5OgoKIiIiCkNvcHlyaWdodCBKb3llbnQsIEluYy4gYW5kIG90aGVyIE5vZGUgY29udHJpYnV0b3JzLiBBbGwgcmlnaHRzIHJlc2VydmVkLgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgdG8gYW55IHBlcnNvbiBvYnRhaW5pbmcgYSBjb3B5Cm9mIHRoaXMgc29mdHdhcmUgYW5kIGFzc29jaWF0ZWQgZG9jdW1lbnRhdGlvbiBmaWxlcyAodGhlICJTb2Z0d2FyZSIpLCB0bwpkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgd2l0aG91dCBsaW1pdGF0aW9uIHRoZQpyaWdodHMgdG8gdXNlLCBjb3B5LCBtb2RpZnksIG1lcmdlLCBwdWJsaXNoLCBkaXN0cmlidXRlLCBzdWJsaWNlbnNlLCBhbmQvb3IKc2VsbCBjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSB0aGUgU29mdHdhcmUgaXMKZnVybmlzaGVkIHRvIGRvIHNvLCBzdWJqZWN0IHRvIHRoZSBmb2xsb3dpbmcgY29uZGl0aW9uczoKClRoZSBhYm92ZSBjb3B5cmlnaHQgbm90aWNlIGFuZCB0aGlzIHBlcm1pc3Npb24gbm90aWNlIHNoYWxsIGJlIGluY2x1ZGVkIGluCmFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIEVYUFJFU1MgT1IKSU1QTElFRCwgSU5DTFVESU5HIEJVVCBOT1QgTElNSVRFRCBUTyBUSEUgV0FSUkFOVElFUyBPRiBNRVJDSEFOVEFCSUxJVFksCkZJVE5FU1MgRk9SIEEgUEFSVElDVUxBUiBQVVJQT1NFIEFORCBOT05JTkZSSU5HRU1FTlQuIElOIE5PIEVWRU5UIFNIQUxMIFRIRQpBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgQU5ZIENMQUlNLCBEQU1BR0VTIE9SIE9USEVSCkxJQUJJTElUWSwgV0hFVEhFUiBJTiBBTiBBQ1RJT04gT0YgQ09OVFJBQ1QsIFRPUlQgT1IgT1RIRVJXSVNFLCBBUklTSU5HCkZST00sIE9VVCBPRiBPUiBJTiBDT05ORUNUSU9OIFdJVEggVEhFIFNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MKSU4gVEhFIFNPRlRXQVJFLgoiIiIKCg==</text>
+          </license>
+        </licenses>
+      </evidence>
+    </component>
+    <component type="library" bom-ref="through@2.3.8#abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355">
+      <author>Dominic Tarr</author>
+      <name>through</name>
+      <version>2.3.8</version>
+      <description>simplified stream construction</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/through@2.3.8?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fdominictarr%2Fthrough.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/dominictarr/through/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/dominictarr/through.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/dominictarr/through</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+      <evidence>
+        <licenses>
+          <license>
+            <name>file: LICENSE.MIT</name>
+            <text content-type="text/plain" encoding="base64">VGhlIE1JVCBMaWNlbnNlCgpDb3B5cmlnaHQgKGMpIDIwMTEgRG9taW5pYyBUYXJyCgpQZXJtaXNzaW9uIGlzIGhlcmVieSBncmFudGVkLCBmcmVlIG9mIGNoYXJnZSwgCnRvIGFueSBwZXJzb24gb2J0YWluaW5nIGEgY29weSBvZiB0aGlzIHNvZnR3YXJlIGFuZCAKYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uIGZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIApkZWFsIGluIHRoZSBTb2Z0d2FyZSB3aXRob3V0IHJlc3RyaWN0aW9uLCBpbmNsdWRpbmcgCndpdGhvdXQgbGltaXRhdGlvbiB0aGUgcmlnaHRzIHRvIHVzZSwgY29weSwgbW9kaWZ5LCAKbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsIApjb3BpZXMgb2YgdGhlIFNvZnR3YXJlLCBhbmQgdG8gcGVybWl0IHBlcnNvbnMgdG8gd2hvbSAKdGhlIFNvZnR3YXJlIGlzIGZ1cm5pc2hlZCB0byBkbyBzbywgCnN1YmplY3QgdG8gdGhlIGZvbGxvd2luZyBjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2UgCnNoYWxsIGJlIGluY2x1ZGVkIGluIGFsbCBjb3BpZXMgb3Igc3Vic3RhbnRpYWwgcG9ydGlvbnMgb2YgdGhlIFNvZnR3YXJlLgoKVEhFIFNPRlRXQVJFIElTIFBST1ZJREVEICJBUyBJUyIsIFdJVEhPVVQgV0FSUkFOVFkgT0YgQU5ZIEtJTkQsIApFWFBSRVNTIE9SIElNUExJRUQsIElOQ0xVRElORyBCVVQgTk9UIExJTUlURUQgVE8gVEhFIFdBUlJBTlRJRVMgCk9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5EIE5PTklORlJJTkdFTUVOVC4gCklOIE5PIEVWRU5UIFNIQUxMIFRIRSBBVVRIT1JTIE9SIENPUFlSSUdIVCBIT0xERVJTIEJFIExJQUJMRSBGT1IgCkFOWSBDTEFJTSwgREFNQUdFUyBPUiBPVEhFUiBMSUFCSUxJVFksIFdIRVRIRVIgSU4gQU4gQUNUSU9OIE9GIENPTlRSQUNULCAKVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcgRlJPTSwgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgClNPRlRXQVJFIE9SIFRIRSBVU0UgT1IgT1RIRVIgREVBTElOR1MgSU4gVEhFIFNPRlRXQVJFLgo=</text>
+          </license>
+        </licenses>
+      </evidence>
+    </component>
+    <component type="library" bom-ref="util-deprecate@1.0.2#19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5">
+      <author>Nathan Rajlich</author>
+      <name>util-deprecate</name>
+      <version>1.0.2</version>
+      <description>The Node.js \`util.deprecate()\` function with browser support</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/util-deprecate@1.0.2?vcs_url=git%3A%2F%2Fgithub.com%2FTooTallNate%2Futil-deprecate.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/TooTallNate/util-deprecate/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git://github.com/TooTallNate/util-deprecate.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/TooTallNate/util-deprecate</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+      <evidence>
+        <licenses>
+          <license>
+            <name>file: LICENSE</name>
+            <text content-type="text/plain" encoding="base64">KFRoZSBNSVQgTGljZW5zZSkKCkNvcHlyaWdodCAoYykgMjAxNCBOYXRoYW4gUmFqbGljaCA8bmF0aGFuQHRvb3RhbGxuYXRlLm5ldD4KClBlcm1pc3Npb24gaXMgaGVyZWJ5IGdyYW50ZWQsIGZyZWUgb2YgY2hhcmdlLCB0byBhbnkgcGVyc29uCm9idGFpbmluZyBhIGNvcHkgb2YgdGhpcyBzb2Z0d2FyZSBhbmQgYXNzb2NpYXRlZCBkb2N1bWVudGF0aW9uCmZpbGVzICh0aGUgIlNvZnR3YXJlIiksIHRvIGRlYWwgaW4gdGhlIFNvZnR3YXJlIHdpdGhvdXQKcmVzdHJpY3Rpb24sIGluY2x1ZGluZyB3aXRob3V0IGxpbWl0YXRpb24gdGhlIHJpZ2h0cyB0byB1c2UsCmNvcHksIG1vZGlmeSwgbWVyZ2UsIHB1Ymxpc2gsIGRpc3RyaWJ1dGUsIHN1YmxpY2Vuc2UsIGFuZC9vciBzZWxsCmNvcGllcyBvZiB0aGUgU29mdHdhcmUsIGFuZCB0byBwZXJtaXQgcGVyc29ucyB0byB3aG9tIHRoZQpTb2Z0d2FyZSBpcyBmdXJuaXNoZWQgdG8gZG8gc28sIHN1YmplY3QgdG8gdGhlIGZvbGxvd2luZwpjb25kaXRpb25zOgoKVGhlIGFib3ZlIGNvcHlyaWdodCBub3RpY2UgYW5kIHRoaXMgcGVybWlzc2lvbiBub3RpY2Ugc2hhbGwgYmUKaW5jbHVkZWQgaW4gYWxsIGNvcGllcyBvciBzdWJzdGFudGlhbCBwb3J0aW9ucyBvZiB0aGUgU29mdHdhcmUuCgpUSEUgU09GVFdBUkUgSVMgUFJPVklERUQgIkFTIElTIiwgV0lUSE9VVCBXQVJSQU5UWSBPRiBBTlkgS0lORCwKRVhQUkVTUyBPUiBJTVBMSUVELCBJTkNMVURJTkcgQlVUIE5PVCBMSU1JVEVEIFRPIFRIRSBXQVJSQU5USUVTCk9GIE1FUkNIQU5UQUJJTElUWSwgRklUTkVTUyBGT1IgQSBQQVJUSUNVTEFSIFBVUlBPU0UgQU5ECk5PTklORlJJTkdFTUVOVC4gSU4gTk8gRVZFTlQgU0hBTEwgVEhFIEFVVEhPUlMgT1IgQ09QWVJJR0hUCkhPTERFUlMgQkUgTElBQkxFIEZPUiBBTlkgQ0xBSU0sIERBTUFHRVMgT1IgT1RIRVIgTElBQklMSVRZLApXSEVUSEVSIElOIEFOIEFDVElPTiBPRiBDT05UUkFDVCwgVE9SVCBPUiBPVEhFUldJU0UsIEFSSVNJTkcKRlJPTSwgT1VUIE9GIE9SIElOIENPTk5FQ1RJT04gV0lUSCBUSEUgU09GVFdBUkUgT1IgVEhFIFVTRSBPUgpPVEhFUiBERUFMSU5HUyBJTiBUSEUgU09GVFdBUkUuCg==</text>
+          </license>
+        </licenses>
+      </evidence>
+    </component>
   </components>
   <dependencies>
-    <dependency ref="0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2"/>
-    <dependency ref="19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5"/>
-    <dependency ref="300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d"/>
-    <dependency ref="340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00"/>
-    <dependency ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
-      <dependency ref="340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00"/>
-      <dependency ref="abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355"/>
-      <dependency ref="c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"/>
+    <dependency ref="@cyclonedx-webpack-plugin-tests/regression-issue1337@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+      <dependency ref="esprima@4.0.1#340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00"/>
+      <dependency ref="libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"/>
+      <dependency ref="through@2.3.8#abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355"/>
     </dependency>
-    <dependency ref="9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c"/>
-    <dependency ref="abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355">
-      <dependency ref="add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931"/>
+    <dependency ref="base64-js@1.5.1#db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199"/>
+    <dependency ref="buffer@6.0.3#d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283">
+      <dependency ref="base64-js@1.5.1#db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199"/>
+      <dependency ref="ieee754@1.2.1#0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2"/>
     </dependency>
-    <dependency ref="add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931">
-      <dependency ref="300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d"/>
-      <dependency ref="9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c"/>
-      <dependency ref="d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb"/>
+    <dependency ref="esprima@4.0.1#340eff2020a81ec5bb6e3368975a8db5ee9a1e5a02c03693f8b0775f5fde5d00"/>
+    <dependency ref="events@3.3.0#9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c"/>
+    <dependency ref="ieee754@1.2.1#0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2"/>
+    <dependency ref="inherits@2.0.4#300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d"/>
+    <dependency ref="libphonenumber-js@1.11.16#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"/>
+    <dependency ref="readable-stream@3.6.2#d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb">
+      <dependency ref="buffer@6.0.3#d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283"/>
+      <dependency ref="events@3.3.0#9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c"/>
+      <dependency ref="inherits@2.0.4#300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d"/>
+      <dependency ref="string_decoder@1.3.0#c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef"/>
+      <dependency ref="util-deprecate@1.0.2#19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5"/>
     </dependency>
-    <dependency ref="c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef">
-      <dependency ref="e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884"/>
+    <dependency ref="safe-buffer@5.2.1#e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884">
+      <dependency ref="buffer@6.0.3#d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283"/>
     </dependency>
-    <dependency ref="c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"/>
-    <dependency ref="d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb">
-      <dependency ref="19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5"/>
-      <dependency ref="300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d"/>
-      <dependency ref="9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c"/>
-      <dependency ref="c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef"/>
-      <dependency ref="d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283"/>
+    <dependency ref="stream-browserify@3.0.0#add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931">
+      <dependency ref="events@3.3.0#9c9ffc3460afa3205cedf72e98ac72262b62975ebf76005116910856373bcc1c"/>
+      <dependency ref="inherits@2.0.4#300b86475e3f3e4256117add7926cbafa51c1129115279c84f93649317ba5e3d"/>
+      <dependency ref="readable-stream@3.6.2#d6f029d8f8c3251819c598c21cbea8376bc83033a85087f2da57411c35e857fb"/>
     </dependency>
-    <dependency ref="d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283">
-      <dependency ref="0e4da667090186a22b46d1732e29562886e3860f16012c91689526a822c2bca2"/>
-      <dependency ref="db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199"/>
+    <dependency ref="string_decoder@1.3.0#c197f2270e47944f4a4bbd659f7e3fa363633ab5d21a57988a5eb53cd94418ef">
+      <dependency ref="safe-buffer@5.2.1#e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884"/>
     </dependency>
-    <dependency ref="db8078ec9f38ab7b1d0cbd7f4d5d475809e918e97938256840ba659f8852a199"/>
-    <dependency ref="e49a14524a01f800f9c9e5044f904c15036302d7531deba613b80bdb496d2884">
-      <dependency ref="d7beda6eeb8fedd91be7701b560233a57e607c1b48b34e0e2beb934a5de15283"/>
+    <dependency ref="through@2.3.8#abfe6bb23f1ba22984252b069e2df5ec1a31368311bc9c870343597c8b561355">
+      <dependency ref="stream-browserify@3.0.0#add04fe2138b344542e8acc37b5af5de7096d785e793f950b8fd68d5cfcbf931"/>
     </dependency>
+    <dependency ref="util-deprecate@1.0.2#19a87651a9e9f85c9e5bb42647a9fe8b19f24dffd9907415e87ff239f9013fa5"/>
   </dependencies>
 </bom>"
 `;
@@ -10117,7 +10117,7 @@ exports[`integration regression: ignore folder \`LICENSES\` generated json file:
       "type": "application",
       "name": "regression-issue1384",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/regression-issue1384@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "example setup with properly configured \`rootComponentBuildSystem\`",
       "licenses": [
         {
@@ -10167,7 +10167,7 @@ exports[`integration regression: ignore folder \`LICENSES\` generated json file:
       "name": "base",
       "group": "@db-ui",
       "version": "0.29.2",
-      "bom-ref": "fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57",
+      "bom-ref": "@db-ui/base@0.29.2#fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57",
       "author": "Maximilian Franzke",
       "description": "Provides basic tokens and assets based on the DB Design System.",
       "licenses": [
@@ -10214,13 +10214,13 @@ exports[`integration regression: ignore folder \`LICENSES\` generated json file:
   ],
   "dependencies": [
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@cyclonedx-webpack-plugin-tests/regression-issue1384@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57"
+        "@db-ui/base@0.29.2#fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57"
       ]
     },
     {
-      "ref": "fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57"
+      "ref": "@db-ui/base@0.29.2#fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57"
     }
   ]
 }"
@@ -10315,7 +10315,7 @@ exports[`integration regression: ignore folder \`LICENSES\` generated json file:
       "type": "application",
       "name": "regression-issue1384",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/regression-issue1384@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "example setup with properly configured \`rootComponentBuildSystem\`",
       "licenses": [
         {
@@ -10365,7 +10365,7 @@ exports[`integration regression: ignore folder \`LICENSES\` generated json file:
       "name": "base",
       "group": "@db-ui",
       "version": "0.29.2",
-      "bom-ref": "fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57",
+      "bom-ref": "@db-ui/base@0.29.2#fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57",
       "author": "Maximilian Franzke",
       "description": "Provides basic tokens and assets based on the DB Design System.",
       "licenses": [
@@ -10412,13 +10412,13 @@ exports[`integration regression: ignore folder \`LICENSES\` generated json file:
   ],
   "dependencies": [
     {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@cyclonedx-webpack-plugin-tests/regression-issue1384@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57"
+        "@db-ui/base@0.29.2#fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57"
       ]
     },
     {
-      "ref": "fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57"
+      "ref": "@db-ui/base@0.29.2#fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57"
     }
   ]
 }"
@@ -10493,7 +10493,7 @@ exports[`integration regression: ignore folder \`LICENSES\` generated xml file: 
         </component>
       </components>
     </tools>
-    <component type="application" bom-ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+    <component type="application" bom-ref="@cyclonedx-webpack-plugin-tests/regression-issue1384@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>regression-issue1384</name>
       <description>example setup with properly configured \`rootComponentBuildSystem\`</description>
@@ -10528,7 +10528,7 @@ exports[`integration regression: ignore folder \`LICENSES\` generated xml file: 
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57">
+    <component type="library" bom-ref="@db-ui/base@0.29.2#fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57">
       <author>Maximilian Franzke</author>
       <group>@db-ui</group>
       <name>base</name>
@@ -10565,10 +10565,10 @@ exports[`integration regression: ignore folder \`LICENSES\` generated xml file: 
     </component>
   </components>
   <dependencies>
-    <dependency ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
-      <dependency ref="fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57"/>
+    <dependency ref="@cyclonedx-webpack-plugin-tests/regression-issue1384@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+      <dependency ref="@db-ui/base@0.29.2#fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57"/>
     </dependency>
-    <dependency ref="fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57"/>
+    <dependency ref="@db-ui/base@0.29.2#fa8d5ce745830e74fa560199e4d8eccca30d64da711b7aeb9b0de6744ae24c57"/>
   </dependencies>
 </bom>"
 `;
@@ -10662,7 +10662,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
       "type": "application",
       "name": "regression-issue745",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/regression-issue745@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jan Kowalleck",
       "description": "example setup for issue#745",
       "licenses": [
@@ -10696,112 +10696,10 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
   "components": [
     {
       "type": "library",
-      "name": "graphql-tag",
-      "version": "2.12.6",
-      "bom-ref": "03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577",
-      "description": "A JavaScript template literal tag that parses GraphQL queries",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/apollographql/graphql-tag/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/apollographql/graphql-tag.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/apollographql/graphql-tag#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "ts-invariant",
-      "version": "0.10.3",
-      "bom-ref": "078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5",
-      "author": "Ben Newman",
-      "description": "TypeScript implementation of invariant(condition, message)",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/apollographql/invariant-packages/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/apollographql/invariant-packages.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/apollographql/invariant-packages",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "context",
-      "group": "@wry",
-      "version": "0.7.0",
-      "bom-ref": "1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e",
-      "author": "Ben Newman",
-      "description": "Manage contextual information needed by (a)synchronous tasks without explicitly passing objects around",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/benjamn/wryware/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/benjamn/wryware.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/benjamn/wryware",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "client",
       "group": "@apollo",
       "version": "3.7.10",
-      "bom-ref": "28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06",
+      "bom-ref": "@apollo/client@3.7.10#28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06",
       "author": "packages@apollographql.com",
       "description": "A fully-featured caching GraphQL client.",
       "licenses": [
@@ -10833,12 +10731,12 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
     },
     {
       "type": "library",
-      "name": "trie",
+      "name": "context",
       "group": "@wry",
-      "version": "0.3.2",
-      "bom-ref": "6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3",
+      "version": "0.7.0",
+      "bom-ref": "@wry/context@0.7.0#1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e",
       "author": "Ben Newman",
-      "description": "https://en.wikipedia.org/wiki/Trie",
+      "description": "Manage contextual information needed by (a)synchronous tasks without explicitly passing objects around",
       "licenses": [
         {
           "license": {
@@ -10847,7 +10745,7 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
+      "purl": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
       "externalReferences": [
         {
           "url": "https://github.com/benjamn/wryware/issues",
@@ -10868,144 +10766,10 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
     },
     {
       "type": "library",
-      "name": "symbol-observable",
-      "version": "4.0.0",
-      "bom-ref": "706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479",
-      "author": "Ben Lesh",
-      "description": "Symbol.observable ponyfill",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/blesh/symbol-observable/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/blesh/symbol-observable.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/blesh/symbol-observable#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "zen-observable-ts",
-      "version": "1.2.5",
-      "bom-ref": "9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59",
-      "description": "Thin wrapper around zen-observable and @types/zen-observable, to support ESM exports as well as CommonJS exports",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/apollographql/zen-observable-ts/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/apollographql/zen-observable-ts.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/apollographql/zen-observable-ts#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "graphql",
-      "version": "16.6.0",
-      "bom-ref": "a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71",
-      "description": "A Query Language and Runtime which can target any service.",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/graphql/graphql-js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/graphql/graphql-js.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/graphql/graphql-js",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "tslib",
-      "version": "2.5.0",
-      "bom-ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
-      "author": "Microsoft Corp.",
-      "description": "Runtime library for TypeScript helper functions",
-      "licenses": [
-        {
-          "license": {
-            "id": "0BSD",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/Microsoft/TypeScript/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/Microsoft/tslib.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://www.typescriptlang.org/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "equality",
       "group": "@wry",
       "version": "0.5.3",
-      "bom-ref": "d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722",
+      "bom-ref": "@wry/equality@0.5.3#d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722",
       "author": "Ben Newman",
       "description": "Structural equality checking for JavaScript values",
       "licenses": [
@@ -11037,9 +10801,144 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
     },
     {
       "type": "library",
+      "name": "trie",
+      "group": "@wry",
+      "version": "0.3.2",
+      "bom-ref": "@wry/trie@0.3.2#6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3",
+      "author": "Ben Newman",
+      "description": "https://en.wikipedia.org/wiki/Trie",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/benjamn/wryware/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/benjamn/wryware.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/benjamn/wryware",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "graphql-tag",
+      "version": "2.12.6",
+      "bom-ref": "graphql-tag@2.12.6#03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577",
+      "description": "A JavaScript template literal tag that parses GraphQL queries",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/apollographql/graphql-tag/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/apollographql/graphql-tag.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/apollographql/graphql-tag#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "graphql",
+      "version": "16.6.0",
+      "bom-ref": "graphql@16.6.0#a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71",
+      "description": "A Query Language and Runtime which can target any service.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/graphql/graphql-js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/graphql/graphql-js.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/graphql/graphql-js",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "optimism",
+      "version": "0.16.2",
+      "bom-ref": "optimism@0.16.2#f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5",
+      "author": "Ben Newman",
+      "description": "Composable reactive caching with efficient invalidation.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Foptimism.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/benjamn/optimism/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/benjamn/optimism.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/benjamn/optimism#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
       "name": "react",
       "version": "18.2.0",
-      "bom-ref": "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
+      "bom-ref": "react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
       "description": "React is a JavaScript library for building user interfaces.",
       "licenses": [
         {
@@ -11070,11 +10969,11 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
     },
     {
       "type": "library",
-      "name": "optimism",
-      "version": "0.16.2",
-      "bom-ref": "f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5",
-      "author": "Ben Newman",
-      "description": "Composable reactive caching with efficient invalidation.",
+      "name": "symbol-observable",
+      "version": "4.0.0",
+      "bom-ref": "symbol-observable@4.0.0#706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479",
+      "author": "Ben Lesh",
+      "description": "Symbol.observable ponyfill",
       "licenses": [
         {
           "license": {
@@ -11083,20 +10982,121 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
           }
         }
       ],
-      "purl": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Foptimism.git",
+      "purl": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git",
       "externalReferences": [
         {
-          "url": "https://github.com/benjamn/optimism/issues",
+          "url": "https://github.com/blesh/symbol-observable/issues",
           "type": "issue-tracker",
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git+https://github.com/benjamn/optimism.git",
+          "url": "git+https://github.com/blesh/symbol-observable.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\""
         },
         {
-          "url": "https://github.com/benjamn/optimism#readme",
+          "url": "https://github.com/blesh/symbol-observable#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "ts-invariant",
+      "version": "0.10.3",
+      "bom-ref": "ts-invariant@0.10.3#078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5",
+      "author": "Ben Newman",
+      "description": "TypeScript implementation of invariant(condition, message)",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/apollographql/invariant-packages/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/apollographql/invariant-packages.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/apollographql/invariant-packages",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "tslib",
+      "version": "2.5.0",
+      "bom-ref": "tslib@2.5.0#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
+      "author": "Microsoft Corp.",
+      "description": "Runtime library for TypeScript helper functions",
+      "licenses": [
+        {
+          "license": {
+            "id": "0BSD",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/Microsoft/TypeScript/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/Microsoft/tslib.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://www.typescriptlang.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "zen-observable-ts",
+      "version": "1.2.5",
+      "bom-ref": "zen-observable-ts@1.2.5#9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59",
+      "description": "Thin wrapper around zen-observable and @types/zen-observable, to support ESM exports as well as CommonJS exports",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/apollographql/zen-observable-ts/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/apollographql/zen-observable-ts.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/apollographql/zen-observable-ts#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
@@ -11105,70 +11105,70 @@ exports[`integration regression: issue#745 generated json file: dist/.bom/bom.js
   ],
   "dependencies": [
     {
-      "ref": "03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577",
+      "ref": "@apollo/client@3.7.10#28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06",
       "dependsOn": [
-        "a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71",
-        "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+        "@wry/context@0.7.0#1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e",
+        "@wry/equality@0.5.3#d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722",
+        "@wry/trie@0.3.2#6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3",
+        "graphql-tag@2.12.6#03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577",
+        "graphql@16.6.0#a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71",
+        "optimism@0.16.2#f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5",
+        "react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
+        "symbol-observable@4.0.0#706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479",
+        "ts-invariant@0.10.3#078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5",
+        "tslib@2.5.0#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
+        "zen-observable-ts@1.2.5#9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59"
       ]
     },
     {
-      "ref": "078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5",
+      "ref": "@cyclonedx-webpack-plugin-tests/regression-issue745@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+        "@apollo/client@3.7.10#28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06"
       ]
     },
     {
-      "ref": "1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e"
+      "ref": "@wry/context@0.7.0#1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e"
     },
     {
-      "ref": "28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06",
+      "ref": "@wry/equality@0.5.3#d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722"
+    },
+    {
+      "ref": "@wry/trie@0.3.2#6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3"
+    },
+    {
+      "ref": "graphql-tag@2.12.6#03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577",
       "dependsOn": [
-        "03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577",
-        "078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5",
-        "1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e",
-        "6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3",
-        "706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479",
-        "9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59",
-        "a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71",
-        "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
-        "d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722",
-        "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
-        "f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5"
+        "graphql@16.6.0#a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71",
+        "tslib@2.5.0#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
       ]
     },
     {
-      "ref": "6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3"
+      "ref": "graphql@16.6.0#a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71"
     },
     {
-      "ref": "706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479"
-    },
-    {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "optimism@0.16.2#f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5",
       "dependsOn": [
-        "28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06"
+        "@wry/context@0.7.0#1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e",
+        "@wry/trie@0.3.2#6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3"
       ]
     },
     {
-      "ref": "9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59"
+      "ref": "react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
     },
     {
-      "ref": "a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71"
+      "ref": "symbol-observable@4.0.0#706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479"
     },
     {
-      "ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
-    },
-    {
-      "ref": "d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722"
-    },
-    {
-      "ref": "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
-    },
-    {
-      "ref": "f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5",
+      "ref": "ts-invariant@0.10.3#078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5",
       "dependsOn": [
-        "1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e",
-        "6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3"
+        "tslib@2.5.0#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
       ]
+    },
+    {
+      "ref": "tslib@2.5.0#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+    },
+    {
+      "ref": "zen-observable-ts@1.2.5#9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59"
     }
   ]
 }"
@@ -11263,7 +11263,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
       "type": "application",
       "name": "regression-issue745",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/regression-issue745@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "author": "Jan Kowalleck",
       "description": "example setup for issue#745",
       "licenses": [
@@ -11297,112 +11297,10 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
   "components": [
     {
       "type": "library",
-      "name": "graphql-tag",
-      "version": "2.12.6",
-      "bom-ref": "03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577",
-      "description": "A JavaScript template literal tag that parses GraphQL queries",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/apollographql/graphql-tag/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/apollographql/graphql-tag.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/apollographql/graphql-tag#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "ts-invariant",
-      "version": "0.10.3",
-      "bom-ref": "078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5",
-      "author": "Ben Newman",
-      "description": "TypeScript implementation of invariant(condition, message)",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/apollographql/invariant-packages/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/apollographql/invariant-packages.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/apollographql/invariant-packages",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "context",
-      "group": "@wry",
-      "version": "0.7.0",
-      "bom-ref": "1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e",
-      "author": "Ben Newman",
-      "description": "Manage contextual information needed by (a)synchronous tasks without explicitly passing objects around",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/benjamn/wryware/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/benjamn/wryware.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/benjamn/wryware",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "client",
       "group": "@apollo",
       "version": "3.7.10",
-      "bom-ref": "28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06",
+      "bom-ref": "@apollo/client@3.7.10#28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06",
       "author": "packages@apollographql.com",
       "description": "A fully-featured caching GraphQL client.",
       "licenses": [
@@ -11434,12 +11332,12 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
     },
     {
       "type": "library",
-      "name": "trie",
+      "name": "context",
       "group": "@wry",
-      "version": "0.3.2",
-      "bom-ref": "6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3",
+      "version": "0.7.0",
+      "bom-ref": "@wry/context@0.7.0#1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e",
       "author": "Ben Newman",
-      "description": "https://en.wikipedia.org/wiki/Trie",
+      "description": "Manage contextual information needed by (a)synchronous tasks without explicitly passing objects around",
       "licenses": [
         {
           "license": {
@@ -11448,7 +11346,7 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           }
         }
       ],
-      "purl": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
+      "purl": "pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
       "externalReferences": [
         {
           "url": "https://github.com/benjamn/wryware/issues",
@@ -11469,144 +11367,10 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
     },
     {
       "type": "library",
-      "name": "symbol-observable",
-      "version": "4.0.0",
-      "bom-ref": "706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479",
-      "author": "Ben Lesh",
-      "description": "Symbol.observable ponyfill",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/blesh/symbol-observable/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/blesh/symbol-observable.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/blesh/symbol-observable#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "zen-observable-ts",
-      "version": "1.2.5",
-      "bom-ref": "9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59",
-      "description": "Thin wrapper around zen-observable and @types/zen-observable, to support ESM exports as well as CommonJS exports",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/apollographql/zen-observable-ts/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/apollographql/zen-observable-ts.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/apollographql/zen-observable-ts#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "graphql",
-      "version": "16.6.0",
-      "bom-ref": "a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71",
-      "description": "A Query Language and Runtime which can target any service.",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/graphql/graphql-js/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/graphql/graphql-js.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/graphql/graphql-js",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "name": "tslib",
-      "version": "2.5.0",
-      "bom-ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
-      "author": "Microsoft Corp.",
-      "description": "Runtime library for TypeScript helper functions",
-      "licenses": [
-        {
-          "license": {
-            "id": "0BSD",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/Microsoft/TypeScript/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/Microsoft/tslib.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://www.typescriptlang.org/",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "equality",
       "group": "@wry",
       "version": "0.5.3",
-      "bom-ref": "d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722",
+      "bom-ref": "@wry/equality@0.5.3#d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722",
       "author": "Ben Newman",
       "description": "Structural equality checking for JavaScript values",
       "licenses": [
@@ -11638,9 +11402,144 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
     },
     {
       "type": "library",
+      "name": "trie",
+      "group": "@wry",
+      "version": "0.3.2",
+      "bom-ref": "@wry/trie@0.3.2#6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3",
+      "author": "Ben Newman",
+      "description": "https://en.wikipedia.org/wiki/Trie",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/benjamn/wryware/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/benjamn/wryware.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/benjamn/wryware",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "graphql-tag",
+      "version": "2.12.6",
+      "bom-ref": "graphql-tag@2.12.6#03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577",
+      "description": "A JavaScript template literal tag that parses GraphQL queries",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/apollographql/graphql-tag/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/apollographql/graphql-tag.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/apollographql/graphql-tag#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "graphql",
+      "version": "16.6.0",
+      "bom-ref": "graphql@16.6.0#a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71",
+      "description": "A Query Language and Runtime which can target any service.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/graphql/graphql-js/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/graphql/graphql-js.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/graphql/graphql-js",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "optimism",
+      "version": "0.16.2",
+      "bom-ref": "optimism@0.16.2#f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5",
+      "author": "Ben Newman",
+      "description": "Composable reactive caching with efficient invalidation.",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Foptimism.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/benjamn/optimism/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/benjamn/optimism.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/benjamn/optimism#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
       "name": "react",
       "version": "18.2.0",
-      "bom-ref": "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
+      "bom-ref": "react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
       "description": "React is a JavaScript library for building user interfaces.",
       "licenses": [
         {
@@ -11671,11 +11570,11 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
     },
     {
       "type": "library",
-      "name": "optimism",
-      "version": "0.16.2",
-      "bom-ref": "f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5",
-      "author": "Ben Newman",
-      "description": "Composable reactive caching with efficient invalidation.",
+      "name": "symbol-observable",
+      "version": "4.0.0",
+      "bom-ref": "symbol-observable@4.0.0#706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479",
+      "author": "Ben Lesh",
+      "description": "Symbol.observable ponyfill",
       "licenses": [
         {
           "license": {
@@ -11684,20 +11583,121 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
           }
         }
       ],
-      "purl": "pkg:npm/optimism@0.16.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Foptimism.git",
+      "purl": "pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git",
       "externalReferences": [
         {
-          "url": "https://github.com/benjamn/optimism/issues",
+          "url": "https://github.com/blesh/symbol-observable/issues",
           "type": "issue-tracker",
           "comment": "as detected from PackageJson property \\"bugs.url\\""
         },
         {
-          "url": "git+https://github.com/benjamn/optimism.git",
+          "url": "git+https://github.com/blesh/symbol-observable.git",
           "type": "vcs",
           "comment": "as detected from PackageJson property \\"repository.url\\""
         },
         {
-          "url": "https://github.com/benjamn/optimism#readme",
+          "url": "https://github.com/blesh/symbol-observable#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "ts-invariant",
+      "version": "0.10.3",
+      "bom-ref": "ts-invariant@0.10.3#078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5",
+      "author": "Ben Newman",
+      "description": "TypeScript implementation of invariant(condition, message)",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/apollographql/invariant-packages/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/apollographql/invariant-packages.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/apollographql/invariant-packages",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "tslib",
+      "version": "2.5.0",
+      "bom-ref": "tslib@2.5.0#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
+      "author": "Microsoft Corp.",
+      "description": "Runtime library for TypeScript helper functions",
+      "licenses": [
+        {
+          "license": {
+            "id": "0BSD",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/Microsoft/TypeScript/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/Microsoft/tslib.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://www.typescriptlang.org/",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "zen-observable-ts",
+      "version": "1.2.5",
+      "bom-ref": "zen-observable-ts@1.2.5#9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59",
+      "description": "Thin wrapper around zen-observable and @types/zen-observable, to support ESM exports as well as CommonJS exports",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/apollographql/zen-observable-ts/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/apollographql/zen-observable-ts.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/apollographql/zen-observable-ts#readme",
           "type": "website",
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
@@ -11706,70 +11706,70 @@ exports[`integration regression: issue#745 generated json file: dist/.well-known
   ],
   "dependencies": [
     {
-      "ref": "03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577",
+      "ref": "@apollo/client@3.7.10#28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06",
       "dependsOn": [
-        "a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71",
-        "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+        "@wry/context@0.7.0#1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e",
+        "@wry/equality@0.5.3#d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722",
+        "@wry/trie@0.3.2#6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3",
+        "graphql-tag@2.12.6#03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577",
+        "graphql@16.6.0#a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71",
+        "optimism@0.16.2#f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5",
+        "react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
+        "symbol-observable@4.0.0#706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479",
+        "ts-invariant@0.10.3#078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5",
+        "tslib@2.5.0#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
+        "zen-observable-ts@1.2.5#9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59"
       ]
     },
     {
-      "ref": "078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5",
+      "ref": "@cyclonedx-webpack-plugin-tests/regression-issue745@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+        "@apollo/client@3.7.10#28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06"
       ]
     },
     {
-      "ref": "1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e"
+      "ref": "@wry/context@0.7.0#1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e"
     },
     {
-      "ref": "28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06",
+      "ref": "@wry/equality@0.5.3#d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722"
+    },
+    {
+      "ref": "@wry/trie@0.3.2#6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3"
+    },
+    {
+      "ref": "graphql-tag@2.12.6#03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577",
       "dependsOn": [
-        "03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577",
-        "078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5",
-        "1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e",
-        "6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3",
-        "706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479",
-        "9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59",
-        "a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71",
-        "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc",
-        "d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722",
-        "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6",
-        "f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5"
+        "graphql@16.6.0#a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71",
+        "tslib@2.5.0#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
       ]
     },
     {
-      "ref": "6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3"
+      "ref": "graphql@16.6.0#a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71"
     },
     {
-      "ref": "706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479"
-    },
-    {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "optimism@0.16.2#f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5",
       "dependsOn": [
-        "28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06"
+        "@wry/context@0.7.0#1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e",
+        "@wry/trie@0.3.2#6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3"
       ]
     },
     {
-      "ref": "9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59"
+      "ref": "react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
     },
     {
-      "ref": "a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71"
+      "ref": "symbol-observable@4.0.0#706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479"
     },
     {
-      "ref": "cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
-    },
-    {
-      "ref": "d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722"
-    },
-    {
-      "ref": "de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"
-    },
-    {
-      "ref": "f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5",
+      "ref": "ts-invariant@0.10.3#078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5",
       "dependsOn": [
-        "1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e",
-        "6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3"
+        "tslib@2.5.0#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
       ]
+    },
+    {
+      "ref": "tslib@2.5.0#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"
+    },
+    {
+      "ref": "zen-observable-ts@1.2.5#9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59"
     }
   ]
 }"
@@ -11844,7 +11844,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </component>
       </components>
     </tools>
-    <component type="application" bom-ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+    <component type="application" bom-ref="@cyclonedx-webpack-plugin-tests/regression-issue745@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
       <author>Jan Kowalleck</author>
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>regression-issue745</name>
@@ -11872,85 +11872,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577">
-      <name>graphql-tag</name>
-      <version>2.12.6</version>
-      <description>A JavaScript template literal tag that parses GraphQL queries</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/apollographql/graphql-tag/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/apollographql/graphql-tag.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/apollographql/graphql-tag#readme</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5">
-      <author>Ben Newman</author>
-      <name>ts-invariant</name>
-      <version>0.10.3</version>
-      <description>TypeScript implementation of invariant(condition, message)</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/apollographql/invariant-packages/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/apollographql/invariant-packages.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/apollographql/invariant-packages</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e">
-      <author>Ben Newman</author>
-      <group>@wry</group>
-      <name>context</name>
-      <version>0.7.0</version>
-      <description>Manage contextual information needed by (a)synchronous tasks without explicitly passing objects around</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/benjamn/wryware/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/benjamn/wryware.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/benjamn/wryware</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06">
+    <component type="library" bom-ref="@apollo/client@3.7.10#28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06">
       <author>packages@apollographql.com</author>
       <group>@apollo</group>
       <name>client</name>
@@ -11977,18 +11899,18 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3">
+    <component type="library" bom-ref="@wry/context@0.7.0#1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e">
       <author>Ben Newman</author>
       <group>@wry</group>
-      <name>trie</name>
-      <version>0.3.2</version>
-      <description>https://en.wikipedia.org/wiki/Trie</description>
+      <name>context</name>
+      <version>0.7.0</version>
+      <description>Manage contextual information needed by (a)synchronous tasks without explicitly passing objects around</description>
       <licenses>
         <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git</purl>
+      <purl>pkg:npm/%40wry/context@0.7.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
           <url>https://github.com/benjamn/wryware/issues</url>
@@ -12004,109 +11926,7 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479">
-      <author>Ben Lesh</author>
-      <name>symbol-observable</name>
-      <version>4.0.0</version>
-      <description>Symbol.observable ponyfill</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/blesh/symbol-observable/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/blesh/symbol-observable.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/blesh/symbol-observable#readme</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59">
-      <name>zen-observable-ts</name>
-      <version>1.2.5</version>
-      <description>Thin wrapper around zen-observable and @types/zen-observable, to support ESM exports as well as CommonJS exports</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/apollographql/zen-observable-ts/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/apollographql/zen-observable-ts.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/apollographql/zen-observable-ts#readme</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71">
-      <name>graphql</name>
-      <version>16.6.0</version>
-      <description>A Query Language and Runtime which can target any service.</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/graphql/graphql-js/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/graphql/graphql-js.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/graphql/graphql-js</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc">
-      <author>Microsoft Corp.</author>
-      <name>tslib</name>
-      <version>2.5.0</version>
-      <description>Runtime library for TypeScript helper functions</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>0BSD</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/Microsoft/TypeScript/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/Microsoft/tslib.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://www.typescriptlang.org/</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722">
+    <component type="library" bom-ref="@wry/equality@0.5.3#d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722">
       <author>Ben Newman</author>
       <group>@wry</group>
       <name>equality</name>
@@ -12133,32 +11953,84 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6">
-      <name>react</name>
-      <version>18.2.0</version>
-      <description>React is a JavaScript library for building user interfaces.</description>
+    <component type="library" bom-ref="@wry/trie@0.3.2#6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3">
+      <author>Ben Newman</author>
+      <group>@wry</group>
+      <name>trie</name>
+      <version>0.3.2</version>
+      <description>https://en.wikipedia.org/wiki/Trie</description>
       <licenses>
         <license acknowledgement="declared">
           <id>MIT</id>
         </license>
       </licenses>
-      <purl>pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Freact</purl>
+      <purl>pkg:npm/%40wry/trie@0.3.2?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fbenjamn%2Fwryware.git</purl>
       <externalReferences>
         <reference type="issue-tracker">
-          <url>https://github.com/facebook/react/issues</url>
+          <url>https://github.com/benjamn/wryware/issues</url>
           <comment>as detected from PackageJson property "bugs.url"</comment>
         </reference>
         <reference type="vcs">
-          <url>git+https://github.com/facebook/react.git#packages/react</url>
-          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
+          <url>git+https://github.com/benjamn/wryware.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
         </reference>
         <reference type="website">
-          <url>https://reactjs.org/</url>
+          <url>https://github.com/benjamn/wryware</url>
           <comment>as detected from PackageJson property "homepage"</comment>
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5">
+    <component type="library" bom-ref="graphql-tag@2.12.6#03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577">
+      <name>graphql-tag</name>
+      <version>2.12.6</version>
+      <description>A JavaScript template literal tag that parses GraphQL queries</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/graphql-tag@2.12.6?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fgraphql-tag.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/apollographql/graphql-tag/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/apollographql/graphql-tag.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/apollographql/graphql-tag#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="graphql@16.6.0#a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71">
+      <name>graphql</name>
+      <version>16.6.0</version>
+      <description>A Query Language and Runtime which can target any service.</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/graphql@16.6.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphql%2Fgraphql-js.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/graphql/graphql-js/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/graphql/graphql-js.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/graphql/graphql-js</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="optimism@0.16.2#f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5">
       <author>Ben Newman</author>
       <name>optimism</name>
       <version>0.16.2</version>
@@ -12184,43 +12056,171 @@ exports[`integration regression: issue#745 generated xml file: dist/.bom/bom.xml
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6">
+      <name>react</name>
+      <version>18.2.0</version>
+      <description>React is a JavaScript library for building user interfaces.</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/react@18.2.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ffacebook%2Freact.git%23packages%2Freact</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/facebook/react/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/facebook/react.git#packages/react</url>
+          <comment>as detected from PackageJson property "repository.url" and "repository.directory"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://reactjs.org/</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="symbol-observable@4.0.0#706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479">
+      <author>Ben Lesh</author>
+      <name>symbol-observable</name>
+      <version>4.0.0</version>
+      <description>Symbol.observable ponyfill</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/symbol-observable@4.0.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fblesh%2Fsymbol-observable.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/blesh/symbol-observable/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/blesh/symbol-observable.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/blesh/symbol-observable#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="ts-invariant@0.10.3#078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5">
+      <author>Ben Newman</author>
+      <name>ts-invariant</name>
+      <version>0.10.3</version>
+      <description>TypeScript implementation of invariant(condition, message)</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/ts-invariant@0.10.3?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Finvariant-packages.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/apollographql/invariant-packages/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/apollographql/invariant-packages.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/apollographql/invariant-packages</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="tslib@2.5.0#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc">
+      <author>Microsoft Corp.</author>
+      <name>tslib</name>
+      <version>2.5.0</version>
+      <description>Runtime library for TypeScript helper functions</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>0BSD</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/tslib@2.5.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2FMicrosoft%2Ftslib.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/Microsoft/TypeScript/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/Microsoft/tslib.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://www.typescriptlang.org/</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="zen-observable-ts@1.2.5#9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59">
+      <name>zen-observable-ts</name>
+      <version>1.2.5</version>
+      <description>Thin wrapper around zen-observable and @types/zen-observable, to support ESM exports as well as CommonJS exports</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/zen-observable-ts@1.2.5?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fapollographql%2Fzen-observable-ts.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/apollographql/zen-observable-ts/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/apollographql/zen-observable-ts.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/apollographql/zen-observable-ts#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
   </components>
   <dependencies>
-    <dependency ref="03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577">
-      <dependency ref="a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71"/>
-      <dependency ref="cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
+    <dependency ref="@apollo/client@3.7.10#28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06">
+      <dependency ref="@wry/context@0.7.0#1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e"/>
+      <dependency ref="@wry/equality@0.5.3#d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722"/>
+      <dependency ref="@wry/trie@0.3.2#6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3"/>
+      <dependency ref="graphql-tag@2.12.6#03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577"/>
+      <dependency ref="graphql@16.6.0#a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71"/>
+      <dependency ref="optimism@0.16.2#f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5"/>
+      <dependency ref="react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"/>
+      <dependency ref="symbol-observable@4.0.0#706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479"/>
+      <dependency ref="ts-invariant@0.10.3#078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5"/>
+      <dependency ref="tslib@2.5.0#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
+      <dependency ref="zen-observable-ts@1.2.5#9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59"/>
     </dependency>
-    <dependency ref="078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5">
-      <dependency ref="cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
+    <dependency ref="@cyclonedx-webpack-plugin-tests/regression-issue745@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+      <dependency ref="@apollo/client@3.7.10#28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06"/>
     </dependency>
-    <dependency ref="1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e"/>
-    <dependency ref="28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06">
-      <dependency ref="03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577"/>
-      <dependency ref="078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5"/>
-      <dependency ref="1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e"/>
-      <dependency ref="6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3"/>
-      <dependency ref="706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479"/>
-      <dependency ref="9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59"/>
-      <dependency ref="a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71"/>
-      <dependency ref="cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
-      <dependency ref="d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722"/>
-      <dependency ref="de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"/>
-      <dependency ref="f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5"/>
+    <dependency ref="@wry/context@0.7.0#1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e"/>
+    <dependency ref="@wry/equality@0.5.3#d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722"/>
+    <dependency ref="@wry/trie@0.3.2#6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3"/>
+    <dependency ref="graphql-tag@2.12.6#03a5e8ce2535169a8f9bca8a80155a6189ec26be010ab889fa73f8e03d3dc577">
+      <dependency ref="graphql@16.6.0#a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71"/>
+      <dependency ref="tslib@2.5.0#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
     </dependency>
-    <dependency ref="6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3"/>
-    <dependency ref="706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479"/>
-    <dependency ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
-      <dependency ref="28ca1f6f5d1a6abb32b880a400ded431d20e3c680685c303f9fff729ac68fa06"/>
+    <dependency ref="graphql@16.6.0#a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71"/>
+    <dependency ref="optimism@0.16.2#f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5">
+      <dependency ref="@wry/context@0.7.0#1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e"/>
+      <dependency ref="@wry/trie@0.3.2#6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3"/>
     </dependency>
-    <dependency ref="9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59"/>
-    <dependency ref="a624681f45b1e71377daa795a75cb5703318b683741136001effe81966fefa71"/>
-    <dependency ref="cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
-    <dependency ref="d6d7948094d25092b90ef4f884da695c12aa691c034bde2115304bf443ce1722"/>
-    <dependency ref="de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"/>
-    <dependency ref="f47ab405028332dab8e9a8eace764bd4ee9e233fef98e3c36eaf2eab2fac73a5">
-      <dependency ref="1e2da816b9731f4087623f04fc76b1890821c8aeb41ab512078e29821906c28e"/>
-      <dependency ref="6a1d11947c5693acf3614253e409e429ab7e17302c082c77aab434da7482a0f3"/>
+    <dependency ref="react@18.2.0#de5f9516e3ab25d34db207368c3e93d42308a55dffacbb8b5bdcf0f9f14c10f6"/>
+    <dependency ref="symbol-observable@4.0.0#706e7e89d43ff6b25f3bf08faccb5c35ef7136907d6a26fa6895e98f2baeb479"/>
+    <dependency ref="ts-invariant@0.10.3#078ee7f021d5703284917f4a1a10a3f6c33c37597afa66c71c5435f27efed0a5">
+      <dependency ref="tslib@2.5.0#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
     </dependency>
+    <dependency ref="tslib@2.5.0#cbbb7e65d13628dfd263aa44e9fa95aa00fa9bb6e58379b9fbe1cebc28c627fc"/>
+    <dependency ref="zen-observable-ts@1.2.5#9eb7388b487bd130524999e4e678eede126f5a6a37a4b6e3555e2a5e42407a59"/>
   </dependencies>
 </bom>"
 `;
@@ -12314,7 +12314,7 @@ exports[`integration regression: verify enhanced package.json finder generated j
       "type": "application",
       "name": "regression-issue1284",
       "group": "@cyclonedx-weboack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-weboack-plugin-tests/regression-issue1284@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "example to verify issue1284",
       "purl": "pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue1284"
     }
@@ -12322,43 +12322,9 @@ exports[`integration regression: verify enhanced package.json finder generated j
   "components": [
     {
       "type": "library",
-      "name": "luxon",
-      "version": "3.4.4",
-      "bom-ref": "53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1",
-      "author": "Isaac Cambron",
-      "description": "Immutable date wrapper",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/moment/luxon/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/moment/luxon.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/moment/luxon#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "libphonenumber-js",
       "version": "1.11.3",
-      "bom-ref": "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725",
+      "bom-ref": "libphonenumber-js@1.11.3#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725",
       "author": "catamphetamine",
       "description": "A simpler (and smaller) rewrite of Google Android's libphonenumber library in javascript",
       "licenses": [
@@ -12387,21 +12353,55 @@ exports[`integration regression: verify enhanced package.json finder generated j
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
       ]
+    },
+    {
+      "type": "library",
+      "name": "luxon",
+      "version": "3.4.4",
+      "bom-ref": "luxon@3.4.4#53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1",
+      "author": "Isaac Cambron",
+      "description": "Immutable date wrapper",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/moment/luxon/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/moment/luxon.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/moment/luxon#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
     }
   ],
   "dependencies": [
     {
-      "ref": "53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1"
-    },
-    {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@cyclonedx-weboack-plugin-tests/regression-issue1284@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1",
-        "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
+        "libphonenumber-js@1.11.3#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725",
+        "luxon@3.4.4#53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1"
       ]
     },
     {
-      "ref": "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
+      "ref": "libphonenumber-js@1.11.3#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
+    },
+    {
+      "ref": "luxon@3.4.4#53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1"
     }
   ]
 }"
@@ -12496,7 +12496,7 @@ exports[`integration regression: verify enhanced package.json finder generated j
       "type": "application",
       "name": "regression-issue1284",
       "group": "@cyclonedx-weboack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-weboack-plugin-tests/regression-issue1284@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "example to verify issue1284",
       "purl": "pkg:npm/%40cyclonedx-weboack-plugin-tests/regression-issue1284"
     }
@@ -12504,43 +12504,9 @@ exports[`integration regression: verify enhanced package.json finder generated j
   "components": [
     {
       "type": "library",
-      "name": "luxon",
-      "version": "3.4.4",
-      "bom-ref": "53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1",
-      "author": "Isaac Cambron",
-      "description": "Immutable date wrapper",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/moment/luxon/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/moment/luxon.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/moment/luxon#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "libphonenumber-js",
       "version": "1.11.3",
-      "bom-ref": "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725",
+      "bom-ref": "libphonenumber-js@1.11.3#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725",
       "author": "catamphetamine",
       "description": "A simpler (and smaller) rewrite of Google Android's libphonenumber library in javascript",
       "licenses": [
@@ -12569,21 +12535,55 @@ exports[`integration regression: verify enhanced package.json finder generated j
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
       ]
+    },
+    {
+      "type": "library",
+      "name": "luxon",
+      "version": "3.4.4",
+      "bom-ref": "luxon@3.4.4#53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1",
+      "author": "Isaac Cambron",
+      "description": "Immutable date wrapper",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/moment/luxon/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/moment/luxon.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/moment/luxon#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
     }
   ],
   "dependencies": [
     {
-      "ref": "53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1"
-    },
-    {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@cyclonedx-weboack-plugin-tests/regression-issue1284@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1",
-        "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
+        "libphonenumber-js@1.11.3#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725",
+        "luxon@3.4.4#53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1"
       ]
     },
     {
-      "ref": "c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
+      "ref": "libphonenumber-js@1.11.3#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"
+    },
+    {
+      "ref": "luxon@3.4.4#53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1"
     }
   ]
 }"
@@ -12658,7 +12658,7 @@ exports[`integration regression: verify enhanced package.json finder generated x
         </component>
       </components>
     </tools>
-    <component type="application" bom-ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+    <component type="application" bom-ref="@cyclonedx-weboack-plugin-tests/regression-issue1284@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
       <group>@cyclonedx-weboack-plugin-tests</group>
       <name>regression-issue1284</name>
       <description>example to verify issue1284</description>
@@ -12666,33 +12666,7 @@ exports[`integration regression: verify enhanced package.json finder generated x
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1">
-      <author>Isaac Cambron</author>
-      <name>luxon</name>
-      <version>3.4.4</version>
-      <description>Immutable date wrapper</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/moment/luxon/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/moment/luxon.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/moment/luxon#readme</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725">
+    <component type="library" bom-ref="libphonenumber-js@1.11.3#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725">
       <author>catamphetamine</author>
       <name>libphonenumber-js</name>
       <version>1.11.3</version>
@@ -12718,14 +12692,40 @@ exports[`integration regression: verify enhanced package.json finder generated x
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="luxon@3.4.4#53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1">
+      <author>Isaac Cambron</author>
+      <name>luxon</name>
+      <version>3.4.4</version>
+      <description>Immutable date wrapper</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/moment/luxon/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/moment/luxon.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/moment/luxon#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
   </components>
   <dependencies>
-    <dependency ref="53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1"/>
-    <dependency ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
-      <dependency ref="53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1"/>
-      <dependency ref="c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"/>
+    <dependency ref="@cyclonedx-weboack-plugin-tests/regression-issue1284@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+      <dependency ref="libphonenumber-js@1.11.3#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"/>
+      <dependency ref="luxon@3.4.4#53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1"/>
     </dependency>
-    <dependency ref="c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"/>
+    <dependency ref="libphonenumber-js@1.11.3#c72c569a87c47c93fb3b9ea9e17640212a94a8fe49c718f954f9f13848a89725"/>
+    <dependency ref="luxon@3.4.4#53b5723e5bb6e890569f67351e71e936a43c9e0d2058485ae98d76e611f021f1"/>
   </dependencies>
 </bom>"
 `;
@@ -12819,7 +12819,7 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
       "type": "application",
       "name": "regression-issue1284-yarn",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/regression-issue1284-yarn@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "example to verify issue1284 with yarn",
       "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1284-yarn"
     }
@@ -12827,43 +12827,9 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
   "components": [
     {
       "type": "library",
-      "name": "luxon",
-      "version": "3.4.4",
-      "bom-ref": "01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595",
-      "author": "Isaac Cambron",
-      "description": "Immutable date wrapper",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/moment/luxon/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/moment/luxon.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/moment/luxon#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "libphonenumber-js",
       "version": "1.11.3",
-      "bom-ref": "3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff",
+      "bom-ref": "libphonenumber-js@1.11.3#3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff",
       "author": "catamphetamine",
       "description": "A simpler (and smaller) rewrite of Google Android's libphonenumber library in javascript",
       "licenses": [
@@ -12892,21 +12858,55 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
       ]
+    },
+    {
+      "type": "library",
+      "name": "luxon",
+      "version": "3.4.4",
+      "bom-ref": "luxon@3.4.4#01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595",
+      "author": "Isaac Cambron",
+      "description": "Immutable date wrapper",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/moment/luxon/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/moment/luxon.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/moment/luxon#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
     }
   ],
   "dependencies": [
     {
-      "ref": "01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595"
-    },
-    {
-      "ref": "3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff"
-    },
-    {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@cyclonedx-webpack-plugin-tests/regression-issue1284-yarn@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595",
-        "3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff"
+        "libphonenumber-js@1.11.3#3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff",
+        "luxon@3.4.4#01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595"
       ]
+    },
+    {
+      "ref": "libphonenumber-js@1.11.3#3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff"
+    },
+    {
+      "ref": "luxon@3.4.4#01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595"
     }
   ]
 }"
@@ -13001,7 +13001,7 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
       "type": "application",
       "name": "regression-issue1284-yarn",
       "group": "@cyclonedx-webpack-plugin-tests",
-      "bom-ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "bom-ref": "@cyclonedx-webpack-plugin-tests/regression-issue1284-yarn@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "description": "example to verify issue1284 with yarn",
       "purl": "pkg:npm/%40cyclonedx-webpack-plugin-tests/regression-issue1284-yarn"
     }
@@ -13009,43 +13009,9 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
   "components": [
     {
       "type": "library",
-      "name": "luxon",
-      "version": "3.4.4",
-      "bom-ref": "01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595",
-      "author": "Isaac Cambron",
-      "description": "Immutable date wrapper",
-      "licenses": [
-        {
-          "license": {
-            "id": "MIT",
-            "acknowledgement": "declared"
-          }
-        }
-      ],
-      "purl": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git",
-      "externalReferences": [
-        {
-          "url": "https://github.com/moment/luxon/issues",
-          "type": "issue-tracker",
-          "comment": "as detected from PackageJson property \\"bugs.url\\""
-        },
-        {
-          "url": "git+https://github.com/moment/luxon.git",
-          "type": "vcs",
-          "comment": "as detected from PackageJson property \\"repository.url\\""
-        },
-        {
-          "url": "https://github.com/moment/luxon#readme",
-          "type": "website",
-          "comment": "as detected from PackageJson property \\"homepage\\""
-        }
-      ]
-    },
-    {
-      "type": "library",
       "name": "libphonenumber-js",
       "version": "1.11.3",
-      "bom-ref": "3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff",
+      "bom-ref": "libphonenumber-js@1.11.3#3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff",
       "author": "catamphetamine",
       "description": "A simpler (and smaller) rewrite of Google Android's libphonenumber library in javascript",
       "licenses": [
@@ -13074,21 +13040,55 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
           "comment": "as detected from PackageJson property \\"homepage\\""
         }
       ]
+    },
+    {
+      "type": "library",
+      "name": "luxon",
+      "version": "3.4.4",
+      "bom-ref": "luxon@3.4.4#01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595",
+      "author": "Isaac Cambron",
+      "description": "Immutable date wrapper",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "acknowledgement": "declared"
+          }
+        }
+      ],
+      "purl": "pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git",
+      "externalReferences": [
+        {
+          "url": "https://github.com/moment/luxon/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \\"bugs.url\\""
+        },
+        {
+          "url": "git+https://github.com/moment/luxon.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \\"repository.url\\""
+        },
+        {
+          "url": "https://github.com/moment/luxon#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \\"homepage\\""
+        }
+      ]
     }
   ],
   "dependencies": [
     {
-      "ref": "01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595"
-    },
-    {
-      "ref": "3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff"
-    },
-    {
-      "ref": "7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
+      "ref": "@cyclonedx-webpack-plugin-tests/regression-issue1284-yarn@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519",
       "dependsOn": [
-        "01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595",
-        "3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff"
+        "libphonenumber-js@1.11.3#3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff",
+        "luxon@3.4.4#01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595"
       ]
+    },
+    {
+      "ref": "libphonenumber-js@1.11.3#3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff"
+    },
+    {
+      "ref": "luxon@3.4.4#01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595"
     }
   ]
 }"
@@ -13163,7 +13163,7 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
         </component>
       </components>
     </tools>
-    <component type="application" bom-ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+    <component type="application" bom-ref="@cyclonedx-webpack-plugin-tests/regression-issue1284-yarn@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
       <group>@cyclonedx-webpack-plugin-tests</group>
       <name>regression-issue1284-yarn</name>
       <description>example to verify issue1284 with yarn</description>
@@ -13171,33 +13171,7 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595">
-      <author>Isaac Cambron</author>
-      <name>luxon</name>
-      <version>3.4.4</version>
-      <description>Immutable date wrapper</description>
-      <licenses>
-        <license acknowledgement="declared">
-          <id>MIT</id>
-        </license>
-      </licenses>
-      <purl>pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git</purl>
-      <externalReferences>
-        <reference type="issue-tracker">
-          <url>https://github.com/moment/luxon/issues</url>
-          <comment>as detected from PackageJson property "bugs.url"</comment>
-        </reference>
-        <reference type="vcs">
-          <url>git+https://github.com/moment/luxon.git</url>
-          <comment>as detected from PackageJson property "repository.url"</comment>
-        </reference>
-        <reference type="website">
-          <url>https://github.com/moment/luxon#readme</url>
-          <comment>as detected from PackageJson property "homepage"</comment>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff">
+    <component type="library" bom-ref="libphonenumber-js@1.11.3#3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff">
       <author>catamphetamine</author>
       <name>libphonenumber-js</name>
       <version>1.11.3</version>
@@ -13223,14 +13197,40 @@ exports[`integration regression: verify enhanced package.json finder with yarn p
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="luxon@3.4.4#01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595">
+      <author>Isaac Cambron</author>
+      <name>luxon</name>
+      <version>3.4.4</version>
+      <description>Immutable date wrapper</description>
+      <licenses>
+        <license acknowledgement="declared">
+          <id>MIT</id>
+        </license>
+      </licenses>
+      <purl>pkg:npm/luxon@3.4.4?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fmoment%2Fluxon.git</purl>
+      <externalReferences>
+        <reference type="issue-tracker">
+          <url>https://github.com/moment/luxon/issues</url>
+          <comment>as detected from PackageJson property "bugs.url"</comment>
+        </reference>
+        <reference type="vcs">
+          <url>git+https://github.com/moment/luxon.git</url>
+          <comment>as detected from PackageJson property "repository.url"</comment>
+        </reference>
+        <reference type="website">
+          <url>https://github.com/moment/luxon#readme</url>
+          <comment>as detected from PackageJson property "homepage"</comment>
+        </reference>
+      </externalReferences>
+    </component>
   </components>
   <dependencies>
-    <dependency ref="01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595"/>
-    <dependency ref="3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff"/>
-    <dependency ref="7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
-      <dependency ref="01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595"/>
-      <dependency ref="3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff"/>
+    <dependency ref="@cyclonedx-webpack-plugin-tests/regression-issue1284-yarn@#7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">
+      <dependency ref="libphonenumber-js@1.11.3#3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff"/>
+      <dependency ref="luxon@3.4.4#01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595"/>
     </dependency>
+    <dependency ref="libphonenumber-js@1.11.3#3bef3dad74b8d08fe3f560915209acbca287b530a703c36da25a003cab1ae7ff"/>
+    <dependency ref="luxon@3.4.4#01acd051f538b8bd94120e6bde7088b327bacf0878b10cf330cf700aac90d595"/>
   </dependencies>
 </bom>"
 `;


### PR DESCRIPTION


### Description

Reproducible `bom-ref`s might have had almost constant values over multiple builds of different projects.
This is not an issue, since `bom-ref` values are technically allowed to be the same in various SBOMs, but this might have lead to conflicts in downstream use cases.

new: reproducible `bom-refs` are component-based and still are reproducible for unique value parts.  

at the point of adding those hashes, the `bom-ref` are already set to `<package-name>@<version>>`

similar to https://github.com/CycloneDX/cyclonedx-esbuild/issues/185

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX/cyclonedx-webpack-plugin/blob/main/CONTRIBUTING.md) guidelines
